### PR TITLE
scrum-67/tests: codecov 48% : unit tests for the `core` module.

### DIFF
--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "haystack-ai>=2.17.1",
     "langfuse-haystack>=2.3.0",
     "python-dotenv>=1.1.1",
+    "pytest-asyncio>=1.2.0",
 ]
 
 [project.urls]

--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "haystack-ai>=2.17.1",
     "langfuse-haystack>=2.3.0",
     "python-dotenv>=1.1.1",
-    "pytest-asyncio>=1.2.0",
 ]
 
 [project.urls]
@@ -63,6 +62,7 @@ dev = [
     "pytest>=8.3.3,<9",
     "pytest-cov>=5.0.0,<7",
     "types-PyYAML>=6.0.12.20240808,<7",
+    "pytest-asyncio>=1.2.0",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/libs/idun_agent_engine/pytest.ini
+++ b/libs/idun_agent_engine/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
-addopts = -ra -q --strict-markers --disable-warnings
-testpaths = tests
+addopts = -ra -q --strict-markers --disable-warnings --ignore src/idun_agent_engine_ui/tests
+testpaths = tests:w
+
+
 pythonpath = src
 # pytest has no native support for async.
 markers =

--- a/libs/idun_agent_engine/pytest.ini
+++ b/libs/idun_agent_engine/pytest.ini
@@ -2,3 +2,6 @@
 addopts = -ra -q --strict-markers --disable-warnings
 testpaths = tests
 pythonpath = src
+# pytest has no native support for async.
+markers =
+asyncio_mode = auto

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -365,8 +365,15 @@ class LanggraphAgent(agent_base.BaseAgent):
                                     tool_call_id=current_tool_call_id,
                                 )
 
-                            current_tool_call_id = str(tc["id"]) if tc.get("id") is not None else None
-                            tool_call_name = str(tc["function"]["name"]) if tc.get("function") and tc["function"].get("name") is not None else None
+                            current_tool_call_id = (
+                                str(tc["id"]) if tc.get("id") is not None else None
+                            )
+                            tool_call_name = (
+                                str(tc["function"]["name"])
+                                if tc.get("function")
+                                and tc["function"].get("name") is not None
+                                else None
+                            )
                             yield ag_events.ToolCallStartEvent(
                                 type=ag_events.EventType.TOOL_CALL_START,
                                 tool_call_id=current_tool_call_id or "",
@@ -394,8 +401,8 @@ class LanggraphAgent(agent_base.BaseAgent):
                 # Tool end event from langgraph has the tool output, but ag-ui model doesn't have a place for it in ToolCallEndEvent
                 if current_tool_call_id:
                     yield ag_events.ToolCallEndEvent(
-                                type=ag_events.EventType.TOOL_CALL_END,
-                                tool_call_id=current_tool_call_id or "",
+                        type=ag_events.EventType.TOOL_CALL_END,
+                        tool_call_id=current_tool_call_id or "",
                     )
                     current_tool_call_id = None
 
@@ -412,7 +419,8 @@ class LanggraphAgent(agent_base.BaseAgent):
 
         if current_message_id:
             yield ag_events.TextMessageEndEvent(
-                type=ag_events.EventType.TEXT_MESSAGE_END, message_id=current_message_id or ""
+                type=ag_events.EventType.TEXT_MESSAGE_END,
+                message_id=current_message_id or "",
             )
 
         yield ag_events.RunFinishedEvent(

--- a/libs/idun_agent_engine/src/idun_agent_engine/core/engine_config.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/core/engine_config.py
@@ -4,7 +4,7 @@ This module contains the core configuration models for the entire Engine engine.
 These models define the overall structure and validation for the complete system.
 """
 
-from typing import Literal, Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/__init__.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/__init__.py
@@ -1,5 +1,5 @@
 """Server package for FastAPI app components and configuration."""
 
-from . import server_config, dependencies, lifespan
+from . import dependencies, lifespan, server_config
 
 __all__ = ["server_config", "dependencies", "lifespan"]

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
@@ -24,6 +24,8 @@ class ChatRequest(BaseModel):
 
     session_id: str
     query: str
+
+
 class ChatResponse(BaseModel):
     """Chat response payload containing session and response text."""
 

--- a/libs/idun_agent_engine/tests/test_agent.py
+++ b/libs/idun_agent_engine/tests/test_agent.py
@@ -1,0 +1,64 @@
+import json
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from idun_agent_engine.server.routers.agent import agent_router
+
+
+def test_invoke_with_payload():
+    app = FastAPI()
+    app.include_router(agent_router)
+
+    mock_agent = AsyncMock()
+    mock_agent.invoke = AsyncMock(return_value="Processed complex query")
+    app.state.agent = mock_agent
+
+    client = TestClient(app)
+
+    complex_query = {
+        "session_id": "complex-123",
+        "query": "Analyze this data: "
+        + json.dumps({"key": "value", "nested": {"data": [1, 2, 3]}}),
+    }
+
+    response = client.post("/invoke", json=complex_query)
+
+    assert response.status_code == 200
+    assert response.json()["session_id"] == "complex-123"
+    mock_agent.invoke.assert_called_once()
+
+    called_message = mock_agent.invoke.call_args[0][0]
+    assert "Analyze this data" in called_message["query"]
+    assert called_message["session_id"] == "complex-123"
+
+
+def test_stream_returns_event_stream_format():
+    app = FastAPI()
+    app.include_router(agent_router)
+
+    async def mock_stream(message):
+        class Event:
+            def model_dump_json(self):
+                return json.dumps({"event": "chunk", "data": "test"})
+
+        for i in range(3):
+            yield Event()
+
+    mock_agent = AsyncMock()
+    mock_agent.stream = mock_stream
+    app.state.agent = mock_agent
+
+    client = TestClient(app)
+
+    response = client.post(
+        "/stream", json={"session_id": "stream-test", "query": "Stream this"}
+    )
+
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+
+    content = response.text
+    assert "data: {" in content
+    assert content.count("data: ") >= 3

--- a/libs/idun_agent_engine/tests/test_app_factory.py
+++ b/libs/idun_agent_engine/tests/test_app_factory.py
@@ -1,0 +1,99 @@
+import yaml
+from fastapi.testclient import TestClient
+
+from idun_agent_engine.core.app_factory import create_app
+from idun_agent_engine.core.engine_config import EngineConfig
+
+
+def test_create_app_with_yaml_config(tmp_path):
+    config_data = {
+        "server": {"api": {"port": 8888}},
+        "agent": {
+            "type": "langgraph",
+            "config": {
+                "name": "YAML Test Agent",
+                "graph_definition": "./test/graph.py:app",
+                "observability": {"provider": "langfuse", "enabled": False},
+            },
+        },
+    }
+
+    config_file = tmp_path / "test_config.yaml"
+    config_file.write_text(yaml.dump(config_data))
+
+    app = create_app(config_path=str(config_file))
+    client = TestClient(app)
+
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+
+    assert app.state.engine_config.server.api.port == 8888
+    assert app.state.engine_config.agent.config["name"] == "YAML Test Agent"
+
+
+def test_create_app_config_priority_order(tmp_path):
+    file_config = {
+        "server": {"api": {"port": 7777}},
+        "agent": {
+            "type": "langgraph",
+            "config": {"name": "File Agent", "graph_definition": "file.py:graph"},
+        },
+    }
+
+    dict_config = {
+        "server": {"api": {"port": 8888}},
+        "agent": {
+            "type": "langgraph",
+            "config": {"name": "Dict Agent", "graph_definition": "dict.py:graph"},
+        },
+    }
+
+    engine_config = EngineConfig.model_validate(
+        {
+            "server": {"api": {"port": 9999}},
+            "agent": {
+                "type": "langgraph",
+                "config": {
+                    "name": "Engine Agent",
+                    "graph_definition": "engine.py:graph",
+                },
+            },
+        }
+    )
+
+    config_file = tmp_path / "priority.yaml"
+    config_file.write_text(yaml.dump(file_config))
+
+    app = create_app(
+        config_path=str(config_file),
+        config_dict=dict_config,
+        engine_config=engine_config,
+    )
+
+    assert app.state.engine_config.server.api.port == 9999
+    assert app.state.engine_config.agent.config["name"] == "Engine Agent"
+
+
+def test_create_app_with_checkpointer_config(tmp_path):
+    config_with_checkpointer = {
+        "server": {"api": {"port": 8000}},
+        "agent": {
+            "type": "langgraph",
+            "config": {
+                "name": "Persistent Agent",
+                "graph_definition": "./agent.py:graph",
+                "checkpointer": {
+                    "type": "sqlite",
+                    "db_url": "sqlite:///test_checkpoint.db",
+                },
+            },
+        },
+    }
+
+    app = create_app(config_dict=config_with_checkpointer)
+
+    agent_config = app.state.engine_config.agent.config
+
+    assert agent_config["checkpointer"]["type"] == "sqlite"
+    assert "test_checkpoint.db" in agent_config["checkpointer"]["db_url"]

--- a/libs/idun_agent_engine/tests/test_engine_config_with_default.py
+++ b/libs/idun_agent_engine/tests/test_engine_config_with_default.py
@@ -1,0 +1,51 @@
+from idun_agent_engine.agent.langgraph.langgraph_model import LangGraphAgentConfig
+from idun_agent_engine.core.engine_config import AgentConfig, EngineConfig
+from idun_agent_engine.server.server_config import ServerConfig
+
+
+def test_engine_config_with_defaults():
+    config = EngineConfig(
+        agent=AgentConfig(
+            type="langgraph",
+            config=LangGraphAgentConfig(
+                name="TestAgent", graph_definition="test.py:graph"
+            ),
+        )
+    )
+
+    assert config.server.api.port == 8000
+    assert config.agent.type == "langgraph"
+
+
+def test_agent_config_default_type():
+    config = AgentConfig(config={"name": "Test", "graph_definition": "test.py:graph"})
+
+    assert config.type == "langgraph"
+
+
+def test_engine_config_from_dict():
+    config_dict = {
+        "server": {"api": {"port": 9000}},
+        "agent": {"type": "haystack", "config": {"name": "HaystackAgent"}},
+    }
+
+    config = EngineConfig.model_validate(config_dict)
+
+    assert config.server.api.port == 9000
+    assert config.agent.type == "haystack"
+
+
+def test_engine_config_model_dump():
+    config = EngineConfig(
+        server=ServerConfig(),
+        agent=AgentConfig(
+            type="langgraph",
+            config={"name": "Test", "graph_definition": "test.py:graph"},
+        ),
+    )
+
+    dumped = config.model_dump()
+
+    assert isinstance(dumped, dict)
+    assert dumped["server"]["api"]["port"] == 8000
+    assert dumped["agent"]["type"] == "langgraph"

--- a/libs/idun_agent_engine/tests/test_lifespan.py
+++ b/libs/idun_agent_engine/tests/test_lifespan.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from idun_agent_engine.core.engine_config import EngineConfig
+from idun_agent_engine.server.lifespan import lifespan
+
+
+async def test_lifespan_with_yaml_config(tmp_path):
+    config_data = {
+        "server": {"api": {"port": 8000}},
+        "agent": {
+            "type": "langgraph",
+            "config": {
+                "name": "Lifecycle Agent",
+                "graph_definition": "./agent.py:graph",
+                "observability": {
+                    "provider": "langfuse",
+                    "enabled": True,
+                    "options": {"run_name": "test-lifecycle"},
+                },
+            },
+        },
+    }
+
+    engine_config = EngineConfig.model_validate(config_data)
+
+    app = MagicMock()
+    app.state.engine_config = engine_config
+
+    mock_agent = AsyncMock()
+    mock_agent.name = "Lifecycle Agent"
+
+    with patch(
+        "idun_agent_engine.core.config_builder.ConfigBuilder.initialize_agent_from_config"
+    ) as mock_init:
+        mock_init.return_value = mock_agent
+
+        async with lifespan(app):
+            assert app.state.agent == mock_agent
+            assert app.state.config == engine_config
+            mock_init.assert_called_once_with(engine_config)
+
+        mock_agent.close.assert_called_once()

--- a/libs/idun_agent_engine/tests/test_server_config.py
+++ b/libs/idun_agent_engine/tests/test_server_config.py
@@ -1,0 +1,33 @@
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from idun_agent_engine.server.server_config import ServerAPIConfig, ServerConfig
+
+
+def test_server_config_from_yaml_string():
+    yaml_content = """
+    api:
+      port: 5555
+    """
+
+    config_dict = yaml.safe_load(yaml_content)
+    config = ServerConfig.model_validate(config_dict)
+
+    assert config.api.port == 5555
+
+
+def test_server_config_validation_with_invalid_port():
+    with pytest.raises(ValidationError):
+        ServerAPIConfig(port="nan")  # type: ignore
+
+
+def test_server_config_nested_validation():
+    complex_config = {"api": {"port": 6666}}
+
+    config = ServerConfig.model_validate(complex_config)
+    assert config.api.port == 6666
+
+    dumped = config.model_dump()
+    reloaded = ServerConfig.model_validate(dumped)
+    assert reloaded.api.port == config.api.port

--- a/libs/idun_agent_engine/tests/test_server_runner.py
+++ b/libs/idun_agent_engine/tests/test_server_runner.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from idun_agent_engine.core.config_builder import ConfigBuilder
+from idun_agent_engine.core.server_runner import (
+    run_server_from_builder,
+    run_server_from_config,
+)
+
+
+@patch("uvicorn.run")
+@patch("idun_agent_engine.core.app_factory.create_app")
+def test_run_server_from_config_uses_yaml_port(mock_create_app, mock_uvicorn, tmp_path):
+    config_data = {
+        "server": {"api": {"port": 3333}},
+        "agent": {
+            "type": "langgraph",
+            "config": {
+                "name": "Port Test Agent",
+                "graph_definition": "./agent.py:graph",
+            },
+        },
+    }
+
+    config_file = tmp_path / "port_test.yaml"
+    config_file.write_text(yaml.dump(config_data))
+
+    mock_app = MagicMock()
+    mock_create_app.return_value = mock_app
+
+    run_server_from_config(str(config_file))
+
+    mock_uvicorn.assert_called_once()
+    call_kwargs = mock_uvicorn.call_args[1]
+    assert call_kwargs["port"] == 3333
+
+
+@patch("uvicorn.run")
+@patch("idun_agent_engine.core.app_factory.create_app")
+def test_run_server_from_builder_with_observability(mock_create_app, mock_uvicorn):
+    mock_app = MagicMock()
+    mock_create_app.return_value = mock_app
+
+    builder = (
+        ConfigBuilder()
+        .with_api_port(4444)
+        .with_langgraph_agent(
+            name="Observable Agent",
+            graph_definition="./agent.py:graph",
+            observability={
+                "provider": "phoenix",
+                "enabled": True,
+                "options": {"project_name": "test-project", "run_name": "test-run"},
+            },
+        )
+    )
+
+    run_server_from_builder(builder)
+
+    created_config = mock_create_app.call_args[1]["engine_config"]
+    assert created_config.server.api.port == 4444
+    assert created_config.agent.config.observability.provider == "phoenix"
+    assert created_config.agent.config.observability.enabled is True
+
+    mock_uvicorn.assert_called_once()
+    call_kwargs = mock_uvicorn.call_args[1]
+    assert call_kwargs["port"] == 4444

--- a/libs/idun_agent_engine/uv.lock
+++ b/libs/idun_agent_engine/uv.lock
@@ -1145,6 +1145,7 @@ dependencies = [
     { name = "langgraph-checkpoint-sqlite" },
     { name = "openinference-instrumentation-langchain" },
     { name = "pydantic" },
+    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "streamlit" },
     { name = "uvicorn" },
@@ -1180,6 +1181,7 @@ requires-dist = [
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0.11,<3.0.0" },
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.13,<1.0.0" },
     { name = "pydantic", specifier = ">=2.11.7,<3.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "streamlit", specifier = ">=1.47.1,<2.0.0" },
     { name = "uvicorn", specifier = ">=0.35.0,<0.36.0" },
@@ -2284,6 +2286,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095 },
 ]
 
 [[package]]


### PR DESCRIPTION
added 6 tests and fixed 2 tests that were not working(observability):
test_agent.py
test_app_factory.py
test_engine_config_with_default.py
test_lifespan.py
test_server_config.py
test_server_runner.py

codecov report:

<img width="1031" height="659" alt="image" src="https://github.com/user-attachments/assets/6a128511-a16d-4772-9234-a0b58acc30e2" />
