### PR TITLE
feat(haystack): make observability enabled/disabled based on config

### DIFF
--- a/libs/idun_agent_engine/examples/04_haystack_example/config.yaml
+++ b/libs/idun_agent_engine/examples/04_haystack_example/config.yaml
@@ -7,7 +7,12 @@ agent:
   type: "haystack"
   config:
     name: "haystack test agent"
-    # component_type: "pipeline"
-    # component_definition: "./examples/04_haystack_example/pipe.py:pipe"
-    component_type: "agent"
-    component_definition: "./examples/04_haystack_example/agent.py:agent"
+    component_type: "pipeline"
+    component_definition: "./examples/04_haystack_example/pipe.py:pipe"
+    # component_type: "agent"
+    # component_definition: "./examples/04_haystack_example/agent.py:agent"
+    observability:
+      enabled: true
+
+
+

--- a/libs/idun_agent_engine/examples/04_haystack_example/pipe.py
+++ b/libs/idun_agent_engine/examples/04_haystack_example/pipe.py
@@ -12,9 +12,9 @@ load_dotenv()
 template = "Answer the next message (return the answer to the last user query in normal text and not json, based on the conversation history), given the prior json holding the conversation: {{query}}"
 
 
-from haystack_integrations.components.connectors.langfuse import (
-    LangfuseConnector,
-)
+# from haystack_integrations.components.connectors.langfuse import (
+#     LangfuseConnector,
+# )
 
 def get_pipe():
     prompt_builder = PromptBuilder(template=template)
@@ -24,7 +24,7 @@ def get_pipe():
         api_base_url="https://api.groq.com/openai/v1"
     )
     pipeline = Pipeline()
-    pipeline.add_component("own tracer", LangfuseConnector("own tracer"))
+    # pipeline.add_component("own tracer", LangfuseConnector("own tracer"))
     pipeline.add_component("prompt_builder", prompt_builder)
     pipeline.add_component("generator", generator)
     pipeline.connect("prompt_builder", "generator")


### PR DESCRIPTION
Haystack observability is handled through its components. Before this pr, the user had no possibility of choosing to not have observability, even when setting observability enabled=false (which will raise issues for langfuse keys).
This just checks the config for enabled == True or False, and loads the component accordingly.