### PR TITLE
feat: add idun-agent-schema to project dependencies and update uv.loc…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ package = false
 [tool.uv.sources]
 idun-agent-engine = { path = "libs/idun_agent_engine", editable = true }
 idun-agent-manager = { path = "services/idun_agent_manager", editable = true }
+idun-agent-schema = { path = "libs/idun_agent_schema", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -1619,7 +1619,7 @@ dev = [
 requires-dist = [
     { name = "idun-agent-engine", editable = "libs/idun_agent_engine" },
     { name = "idun-agent-manager", editable = "services/idun_agent_manager" },
-    { name = "idun-agent-schema" },
+    { name = "idun-agent-schema", editable = "libs/idun_agent_schema" },
 ]
 
 [package.metadata.requires-dev]
@@ -1646,14 +1646,16 @@ dev = [
 [[package]]
 name = "idun-agent-schema"
 version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "libs/idun_agent_schema" }
 dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/a7/446b1202b3a605ed311eb1025beff32087cbca55ee280bddb8e4735fab1b/idun_agent_schema-0.1.0.tar.gz", hash = "sha256:62243f0935ca9bfdc36d59e1eb5fb84c24189e9430f0c4174f0d431f9965d3e2", size = 9275, upload-time = "2025-09-28T18:58:45.344Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/dc/ac3077caf223fd2556c691a79ec63927eadfa627f9c9707a8ecc44b33201/idun_agent_schema-0.1.0-py3-none-any.whl", hash = "sha256:af942ab09cf305be47a8690872f23ddce487ca7a9e0eb81173de4f836a797c48", size = 13236, upload-time = "2025-09-28T18:58:44.335Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.11.7,<3.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.7.0,<3.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
…k metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `idun-agent-schema` to a local editable dependency and updates `uv.lock` metadata accordingly.
> 
> - **Dependency management**:
>   - Add local editable source for `idun-agent-schema` in `pyproject.toml` under `[tool.uv.sources]` (`libs/idun_agent_schema`).
>   - Update `uv.lock` to reference editable `idun-agent-schema` (remove PyPI source/wheels; add versioned `requires-dist` for `pydantic` and `pydantic-settings`).
>   - Adjust `idun-agent-platform` `requires-dist` entry to editable `libs/idun_agent_schema` path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b975f8743bb0bbdc72a58f57f85a1bda519eaeb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->