### PR TITLE
Add Ag UI langgraph

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,18 +25,25 @@
       "type": "debugpy",
       "request": "launch",
       "console": "integratedTerminal",
-      "module": "uvicorn",
+      "module": "idun_platform_cli.main",
+      // "args": [
+      //   "main:app",
+      //   "--host",
+      //   "0.0.0.0",
+      //   "--port",
+      //   "8100",
+      //   "--reload"
+      // ],
       "args": [
-        "main:app",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        "8100",
-        "--reload"
+        "agent", "serve",
+        "--source",
+        "file",
+        "--path",
+        "${workspaceFolder}/libs/idun_agent_engine/examples/01_basic_config_file/config.yaml",
       ],
-      "cwd": "${workspaceFolder}/libs/idun_agent_engine/examples/01_basic_config_file",
+      "cwd": "${workspaceFolder}/libs/idun_agent_engine",
       "justMyCode": false,
-      "envFile": "${workspaceFolder}/libs/idun_agent_engine/examples/01_basic_config_file/.env"
+      "envFile": "${workspaceFolder}/libs/idun_agent_engine/.env"
     },
   ],
   "compounds": [

--- a/bruno/idun_agent_engine/Copilotkit stream.bru
+++ b/bruno/idun_agent_engine/Copilotkit stream.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Copilotkit stream
+  type: http
+  seq: 4
+}
+
+post {
+  url: http://0.0.0.0:8001/agent/copilotkit/stream
+  body: json
+  auth: none
+}
+
+headers {
+  content-type: application/json
+}
+
+body:json {
+  {"threadId":"thread-001","runId":"run-001","state":{},"messages":[{"id":"msg-001","role":"user","content":"Hello! boss"}],"tools":[],"context":[],"forwardedProps":{}}
+}

--- a/libs/idun_agent_engine/examples/01_basic_config_file/Dockerfile
+++ b/libs/idun_agent_engine/examples/01_basic_config_file/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && pip install uv
 #     --extra-index-url https://pypi.org/simple idun-agent-engine==0.2.1.dev20251118083707 \
 #     --index-strategy unsafe-best-match --prerelease=allow
 
-RUN uv pip install idun-agent-schema==0.2.6 --system
-RUN uv pip install idun-agent-engine==0.2.6 --system
+RUN uv pip install idun-agent-schema==0.2.7 --system
+RUN uv pip install idun-agent-engine==0.2.7 --system
 
 COPY requirements.txt .
 COPY config.yaml .

--- a/libs/idun_agent_engine/examples/01_basic_config_file/config.yaml
+++ b/libs/idun_agent_engine/examples/01_basic_config_file/config.yaml
@@ -4,7 +4,7 @@
 # Server Configuration - Controls the server and platform behavior
 server:
   api:
-    port: 8000 # Port where the server will run
+    port: 8001 # Port where the server will run
 
 # Agent Configuration - Defines which agent to load and how
 agent:
@@ -12,7 +12,7 @@ agent:
   # Agent-specific configuration (passed to the LangGraph adapter)
   config:
     name: "My Example LangGraph Agent"
-    graph_definition: "agent/example_agent.py:app" # Path to your graph definition
+    graph_definition: "./examples/01_basic_config_file/example_agent.py:app" # Path to your graph definition
     # Observability (provider-agnostic). Example with Langfuse or Phoenix
     observability:
       provider: langfuse #langfuse # or phoenix

--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-agent-engine"
-version = "0.2.6"
+version = "0.2.7"
 description = "Python SDK and runtime to serve AI agents with FastAPI, LangGraph, and observability."
 authors = [{ name = "Geoffrey HARRAZI", email = "geoffreyharrazi@gmail.com" }]
 requires-python = ">=3.12,<3.14"
@@ -26,7 +26,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "fastapi>=0.116.1,<0.117.0",
+    "fastapi>=0.115.0,<0.116.0",
     "uvicorn>=0.35.0,<0.36.0",
     "langgraph>=0.6.3,<0.7.0",
     "langgraph-checkpoint-sqlite>=2.0.11,<3.0.0",
@@ -44,12 +44,14 @@ dependencies = [
     "langchain>=0.3.27,<0.4",
     # Pin <12: 12.x currently depends on placeholder jmespath==99.99.99 and fails in Docker
     "arize-phoenix>=11.22.0,<12.0.0",
-    "idun-agent-schema>=0.2.6,<0.3.0",
+    "idun-agent-schema>=0.2.7,<0.3.0",
     "langfuse-haystack>=2.3.0",
     "python-dotenv>=1.1.1",
     "click>=8.2.1",
     # Pin SQLAlchemy for Python 3.13 compatibility (required by Phoenix)
     "sqlalchemy>=2.0.36,<3.0.0",
+    "ag-ui-langgraph>=0.0.20,<0.1.0",
+    "copilotkit>=0.1.72,<0.2.0",
 ]
 
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/_version.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/_version.py
@@ -1,3 +1,3 @@
 """Version information for Idun Agent Engine."""
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/base.py
@@ -40,6 +40,15 @@ class BaseAgent[ConfigType: BaseAgentConfig](ABC):
         pass
 
     @property
+    @abstractmethod
+    def copilotkit_agent_instance(self) -> Any:
+        """Get the CopilotKit agent instance.
+
+        This might be set after initialization.
+        """
+        pass
+
+    @property
     def configuration(self) -> ConfigType:
         """Return current configuration settings for the agent.
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/haystack/haystack.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/haystack/haystack.py
@@ -71,6 +71,15 @@ class HaystackAgent(BaseAgent):
         return self._agent_instance
 
     @property
+    def copilotkit_agent_instance(self) -> Any:
+        """Return the CopilotKit agent instance.
+
+        Raises:
+            RuntimeError: If the CopilotKit agent is not yet initialized.
+        """
+        raise NotImplementedError("CopilotKit agent instance not supported yet for Haystack agent.")
+
+    @property
     def configuration(self) -> HaystackAgentConfig:
         """Return validated configuration.
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -17,6 +17,7 @@ from langgraph.graph import StateGraph
 
 from idun_agent_engine import observability
 from idun_agent_engine.agent import base as agent_base
+from copilotkit import LangGraphAGUIAgent
 
 
 class LanggraphAgent(agent_base.BaseAgent):
@@ -29,6 +30,7 @@ class LanggraphAgent(agent_base.BaseAgent):
         self._input_schema: Any = None
         self._output_schema: Any = None
         self._agent_instance: Any = None
+        self._copilotkit_agent_instance: LangGraphAGUIAgent | None = None
         self._checkpointer: Any = None
         self._store: Any = None
         self._connection: Any = None
@@ -78,6 +80,17 @@ class LanggraphAgent(agent_base.BaseAgent):
         if self._agent_instance is None:
             raise RuntimeError("Agent not initialized. Call initialize() first.")
         return self._agent_instance
+
+    @property
+    def copilotkit_agent_instance(self) -> LangGraphAGUIAgent:
+        """Return the CopilotKit agent instance.
+
+        Raises:
+            RuntimeError: If the CopilotKit agent is not yet initialized.
+        """
+        if self._copilotkit_agent_instance is None:
+            raise RuntimeError("CopilotKit agent not initialized. Call initialize() first.")
+        return self._copilotkit_agent_instance
 
     @property
     def configuration(self) -> LangGraphAgentConfig:
@@ -156,6 +169,12 @@ class LanggraphAgent(agent_base.BaseAgent):
 
         self._agent_instance = graph_builder.compile(
             checkpointer=self._checkpointer, store=self._store
+        )
+
+        self._copilotkit_agent_instance = LangGraphAGUIAgent(
+            name=self._name,
+            description="Agent description", # TODO: add agent description
+            graph=self._agent_instance,
         )
 
         if self._agent_instance:

--- a/libs/idun_agent_engine/src/idun_agent_engine/core/app_factory.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/core/app_factory.py
@@ -14,6 +14,7 @@ from ..server.routers.agent import agent_router
 from ..server.routers.base import base_router
 from .config_builder import ConfigBuilder
 from .engine_config import EngineConfig
+from .._version import __version__
 
 
 def create_app(
@@ -48,7 +49,7 @@ def create_app(
         lifespan=lifespan,
         title="Idun Agent Engine Server",
         description="A production-ready server for conversational AI agents",
-        version="0.1.0",
+        version=__version__,
         docs_url="/docs",
         redoc_url="/redoc",
     )

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/dependencies.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/dependencies.py
@@ -21,3 +21,20 @@ async def get_agent(request: Request):
         app_config = ConfigBuilder.load_from_file()
         agent = await ConfigBuilder.initialize_agent_from_config(app_config)
         return agent
+
+async def get_copilotkit_agent(request: Request):
+    """Return the pre-initialized agent instance from the app state.
+
+    Falls back to loading from the default config if not present (e.g., tests).
+    """
+    if hasattr(request.app.state, "copilotkit_agent"):
+        return request.app.state.copilotkit_agent
+    else:
+        # This is a fallback for cases where the lifespan event did not run,
+        # like in some testing scenarios.
+        # Consider logging a warning here.
+        print("⚠️  CopilotKit agent not found in app state, initializing fallback agent...")
+
+        app_config = ConfigBuilder.load_from_file()
+        copilotkit_agent = await ConfigBuilder.initialize_agent_from_config(app_config)
+        return copilotkit_agent

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
@@ -8,7 +8,11 @@ from fastapi.responses import StreamingResponse
 from idun_agent_schema.engine.api import ChatRequest, ChatResponse
 
 from idun_agent_engine.agent.base import BaseAgent
-from idun_agent_engine.server.dependencies import get_agent
+from idun_agent_engine.server.dependencies import get_agent, get_copilotkit_agent
+
+from ag_ui.core.types import RunAgentInput
+from ag_ui.encoder import EventEncoder
+from copilotkit import LangGraphAGUIAgent
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
@@ -57,12 +61,36 @@ async def stream(
 ):
     """Process a message with the agent, streaming ag-ui events."""
     try:
-
         async def event_stream():
             message = {"query": request.query, "session_id": request.session_id}
             async for event in agent.stream(message):
                 yield f"data: {event.model_dump_json()}\n\n"
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+@agent_router.post("/copilotkit/stream")
+async def copilotkit_stream(
+    input_data: RunAgentInput,
+    request: Request,
+    copilotkit_agent: Annotated[LangGraphAGUIAgent, Depends(get_copilotkit_agent)],
+):
+    """Process a message with the agent, streaming ag-ui events."""
+    try:
+        # Get the accept header from the request
+        accept_header = request.headers.get("accept")
+
+        # Create an event encoder to properly format SSE events
+        encoder = EventEncoder(accept=accept_header or "") # type: ignore[arg-type]
+
+        async def event_generator():
+            async for event in copilotkit_agent.run(input_data):
+                yield encoder.encode(event)
+
+        return StreamingResponse(
+            event_generator(),  # type: ignore[arg-type]
+            media_type=encoder.get_content_type()
+        )
     except Exception as e:  # noqa: BLE001
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/libs/idun_agent_engine/src/idun_platform_cli/groups/agent/package.py
+++ b/libs/idun_agent_engine/src/idun_platform_cli/groups/agent/package.py
@@ -39,8 +39,8 @@ def generate_dockerfile(dependency: Dependency) -> str:
         requirements_dockerfile = f"""FROM python:3.13-slim
 RUN apt-get update && pip install uv
 
-RUN uv pip install idun-agent-schema==0.2.6 --system
-RUN uv pip install idun-agent-engine==0.2.6 --system
+RUN uv pip install idun-agent-schema==0.2.7 --system
+RUN uv pip install idun-agent-engine==0.2.7 --system
 
 COPY . .
 RUN uv pip install -r requirements.txt --system

--- a/libs/idun_agent_schema/pyproject.toml
+++ b/libs/idun_agent_schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-agent-schema"
-version = "0.2.6"
+version = "0.2.7"
 description = "Centralized Pydantic schema library for Idun Agent Engine and Manager"
 authors = [{ name = "Idun Group", email = "contact@idun-group.com" }]
 readme = "README.md"

--- a/libs/idun_agent_schema/src/idun_agent_schema/__init__.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/__init__.py
@@ -6,4 +6,4 @@ Public namespaces:
 - idun_agent_schema.shared: Shared cross-cutting schemas
 """
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.13,<3.14"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "click>=8.2.1",
     "idun-agent-engine",
     "idun-agent-manager",
     "idun-agent-schema",

--- a/services/idun_agent_manager/Dockerfile
+++ b/services/idun_agent_manager/Dockerfile
@@ -47,7 +47,7 @@ FROM python:3.13-slim AS runtime
 # Metadata
 LABEL maintainer="Idun Group <contact@idun-group.com>" \
       description="Idun Agent Manager - FastAPI service for managing AI agents" \
-      version="0.2.6"
+      version="0.2.7"
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/services/idun_agent_manager/pyproject.toml
+++ b/services/idun_agent_manager/pyproject.toml
@@ -1,7 +1,7 @@
 ## Project metadata and dependencies (PEP 621)
 [project]
 name = "idun-agent-manager"
-version = "0.2.6"
+version = "0.2.7"
 description = "Modern FastAPI backend for managing AI agents with PostgreSQL, SQLAlchemy, and observability"
 readme = "README.md"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ requires-python = ">=3.13,<3.14"
 
 dependencies = [
   # Core web framework
-  "fastapi>=0.116.1,<0.117.0",
+  "fastapi>=0.115.0,<0.116.0",
   "uvicorn[standard]>=0.35.0,<0.36.0",
   "gunicorn>=23.0.0,<24.0.0",
 

--- a/services/idun_agent_manager/src/app/main.py
+++ b/services/idun_agent_manager/src/app/main.py
@@ -73,7 +73,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="Idun Agent Manager API",
         description="Idun service for managing AI agents",
-        version="0.1.0",
+        version="0.1.0", # TODO: add dinamic auto version from pyproject.toml
         docs_url="/docs",
         redoc_url="/redoc",
         lifespan=lifespan,

--- a/services/idun_agent_manager/uv.lock
+++ b/services/idun_agent_manager/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -427,6 +427,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
 ]
 
@@ -532,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "idun-agent-manager"
-version = "0.2.1"
+version = "0.2.6"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -16,15 +16,35 @@ wheels = [
 ]
 
 [[package]]
+name = "ag-ui-langgraph"
+version = "0.0.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ag-ui-protocol" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/3b/cda443661521e4a414c28eb8b54f8467600b3cdd51b5281f6f26d8352d87/ag_ui_langgraph-0.0.21.tar.gz", hash = "sha256:0c6096604c18c836bb736bc028222887d5f39413f9024b266fc199ffbf0dacb3", size = 12670, upload-time = "2025-11-13T13:00:44.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/99/293cb7cf86df1eef9f7f2df2f4afd41eec31ff1c27c5f5413101b0bb8876/ag_ui_langgraph-0.0.21-py3-none-any.whl", hash = "sha256:589f52bb20a6c0fded89decacaa42265c57d984d20d8fbfb5e53d9f23cbe1060", size = 14410, upload-time = "2025-11-13T13:00:43.349Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
+[[package]]
 name = "ag-ui-protocol"
-version = "0.1.9"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/d7/a8f8789b3b8b5f7263a902361468e8dfefd85ec63d1d5398579b9175d76d/ag_ui_protocol-0.1.9.tar.gz", hash = "sha256:94d75e3919ff75e0b608a7eed445062ea0e6f11cd33b3386a7649047e0c7abd3", size = 4988, upload-time = "2025-09-19T13:36:26.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/bb/5a5ec893eea5805fb9a3db76a9888c3429710dfb6f24bbb37568f2cf7320/ag_ui_protocol-0.1.10.tar.gz", hash = "sha256:3213991c6b2eb24bb1a8c362ee270c16705a07a4c5962267a083d0959ed894f4", size = 6945, upload-time = "2025-11-06T15:17:17.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/50/2bb71a2a9135f4d88706293773320d185789b592987c09f79e9bf2f4875f/ag_ui_protocol-0.1.9-py3-none-any.whl", hash = "sha256:44c1238b0576a3915b3a16e1b3855724e08e92ebc96b1ff29379fbd3bfbd400b", size = 7070, upload-time = "2025-09-19T13:36:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/78/eb55fabaab41abc53f52c0918a9a8c0f747807e5306273f51120fd695957/ag_ui_protocol-0.1.10-py3-none-any.whl", hash = "sha256:c81e6981f30aabdf97a7ee312bfd4df0cd38e718d9fc10019c7d438128b93ab5", size = 7889, upload-time = "2025-11-06T15:17:15.325Z" },
 ]
 
 [[package]]
@@ -502,6 +522,23 @@ wheels = [
 ]
 
 [[package]]
+name = "copilotkit"
+version = "0.1.72"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ag-ui-langgraph", extra = ["fastapi"] },
+    { name = "fastapi" },
+    { name = "langchain" },
+    { name = "langgraph" },
+    { name = "partialjson" },
+    { name = "toml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/ba/9e68086a51e7ca7adc7f6c1349367580d1cadae5f71de7d9402e9136e297/copilotkit-0.1.72.tar.gz", hash = "sha256:738718f28fccfd3f5ecf55ffb545da7f1f3b12f15ac5ca8f12d70583cb9b5008", size = 35611, upload-time = "2025-11-13T14:43:34.366Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/d3/16b7941c6dc32d42e912356cc66cec2a1d95cda5f39336e6090f8dae5c05/copilotkit-0.1.72-py3-none-any.whl", hash = "sha256:6b502cffa3d2ee17daf61673c3ed6b20d10f01b3696d7de7a67a3f2772143aa2", size = 44633, upload-time = "2025-11-13T14:43:32.463Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.10.7"
 source = { registry = "https://pypi.org/simple" }
@@ -640,16 +677,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.116.2"
+version = "0.115.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/64/1296f46d6b9e3b23fb22e5d01af3f104ef411425531376212f1eefa2794d/fastapi-0.116.2.tar.gz", hash = "sha256:231a6af2fe21cfa2c32730170ad8514985fc250bec16c9b242d3b94c835ef529", size = 298595, upload-time = "2025-09-16T18:29:23.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/53/8c38a874844a8b0fa10dd8adf3836ac154082cf88d3f22b544e9ceea0a15/fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739", size = 296263, upload-time = "2025-06-26T15:29:08.21Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/e4/c543271a8018874b7f682bf6156863c416e1334b8ed3e51a69495c5d4360/fastapi-0.116.2-py3-none-any.whl", hash = "sha256:c3a7a8fb830b05f7e087d920e0d786ca1fc9892eb4e9a84b227be4c1bc7569db", size = 95670, upload-time = "2025-09-16T18:29:21.329Z" },
+    { url = "https://files.pythonhosted.org/packages/53/50/b1222562c6d270fea83e9c9075b8e8600b8479150a18e4516a6138b980d1/fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca", size = 95514, upload-time = "2025-06-26T15:29:06.49Z" },
 ]
 
 [[package]]
@@ -1363,14 +1400,16 @@ wheels = [
 
 [[package]]
 name = "idun-agent-engine"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "libs/idun_agent_engine" }
 dependencies = [
+    { name = "ag-ui-langgraph" },
     { name = "ag-ui-protocol" },
     { name = "aiosqlite" },
     { name = "arize-phoenix" },
     { name = "arize-phoenix-otel" },
     { name = "click" },
+    { name = "copilotkit" },
     { name = "fastapi" },
     { name = "google-adk" },
     { name = "httpx" },
@@ -1392,15 +1431,17 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ag-ui-langgraph", specifier = ">=0.0.20,<0.1.0" },
     { name = "ag-ui-protocol", specifier = ">=0.1.8,<0.2.0" },
     { name = "aiosqlite", specifier = ">=0.21.0,<0.22.0" },
     { name = "arize-phoenix", specifier = ">=11.22.0,<12.0.0" },
     { name = "arize-phoenix-otel", specifier = ">=0.2.0,<1.0.0" },
     { name = "click", specifier = ">=8.2.1" },
-    { name = "fastapi", specifier = ">=0.116.1,<0.117.0" },
+    { name = "copilotkit", specifier = ">=0.1.72,<0.2.0" },
+    { name = "fastapi", specifier = ">=0.115.0,<0.116.0" },
     { name = "google-adk", specifier = ">=1.9.0,<2.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
-    { name = "idun-agent-schema", specifier = ">=0.2.6,<0.3.0" },
+    { name = "idun-agent-schema", specifier = ">=0.2.7,<0.3.0" },
     { name = "langchain", specifier = ">=0.3.27,<0.4" },
     { name = "langchain-core", specifier = ">=0.3.72,<0.4.0" },
     { name = "langchain-google-vertexai", specifier = ">=2.0.27,<3.0.0" },
@@ -1430,7 +1471,7 @@ dev = [
 
 [[package]]
 name = "idun-agent-manager"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "services/idun_agent_manager" }
 dependencies = [
     { name = "alembic" },
@@ -1463,7 +1504,7 @@ dependencies = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.14.0,<2.0.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<0.31.0" },
-    { name = "fastapi", specifier = ">=0.116.1,<0.117.0" },
+    { name = "fastapi", specifier = ">=0.115.0,<0.116.0" },
     { name = "gunicorn", specifier = ">=23.0.0,<24.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "idun-agent-schema", specifier = ">=0.2.0,<0.3.0" },
@@ -1507,7 +1548,6 @@ name = "idun-agent-platform"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "click" },
     { name = "idun-agent-engine" },
     { name = "idun-agent-manager" },
     { name = "idun-agent-schema" },
@@ -1536,7 +1576,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.2.1" },
     { name = "idun-agent-engine", editable = "libs/idun_agent_engine" },
     { name = "idun-agent-manager", editable = "services/idun_agent_manager" },
     { name = "idun-agent-schema", editable = "libs/idun_agent_schema" },
@@ -1565,7 +1604,7 @@ dev = [
 
 [[package]]
 name = "idun-agent-schema"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "libs/idun_agent_schema" }
 dependencies = [
     { name = "pydantic" },
@@ -2667,6 +2706,15 @@ wheels = [
 ]
 
 [[package]]
+name = "partialjson"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/b2/59669fdc3ecbc724a077c598c1c9b4068549af0cd8c3b5add9337bd4d93a/partialjson-0.0.8.tar.gz", hash = "sha256:91217e19a15049332df534477f56420065ad1729cedee7d8c7433e1d2acc7dca", size = 4142, upload-time = "2024-08-03T18:03:15.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/fb/453af21468774dbd0954853735a4fc7841544c3022ff86e5d93252d7ea72/partialjson-0.0.8-py3-none-any.whl", hash = "sha256:22c6c60944137f931a7033fa0eeee2d74b49114f3d45c25a560b07a6ebf22b76", size = 4549, upload-time = "2024-08-03T18:03:14.447Z" },
+]
+
+[[package]]
 name = "passlib"
 version = "1.7.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3485,14 +3533,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.48.0"
+version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds CopilotKit + ag-ui integration for LangGraph with a new streaming endpoint, and bumps engine/schema/manager to 0.2.7 with related dependency and config updates.
> 
> - **Engine/API**:
>   - **CopilotKit Streaming**: New `POST /agent/copilotkit/stream` using `LangGraphAGUIAgent` and SSE encoding; new `get_copilotkit_agent` dependency.
>   - **Agent Abstractions**: `BaseAgent` adds `copilotkit_agent_instance`; `LanggraphAgent` initializes/exposes `LangGraphAGUIAgent`; Haystack raises `NotImplementedError` for CopilotKit.
>   - **App Versioning**: FastAPI app now uses engine `__version__`.
> - **Config & Tooling**:
>   - VS Code launch runs `idun_platform_cli.main` with `idun agent serve --source file` pointing to example config.
>   - Example config: API port `8001`; `graph_definition` path updated.
>   - Docker: example and packaging Dockerfiles pin engine/schema `0.2.7`; Manager image label to `0.2.7`.
>   - Compose: adds `web` service on port `3000`.
>   - Bruno: adds request for CopilotKit stream.
> - **Dependencies/Versions**:
>   - Bump `idun-agent-engine`, `idun-agent-schema`, `idun-agent-manager` to `0.2.7`.
>   - Add `copilotkit` and `ag-ui-langgraph`; bump `ag-ui-protocol`; pin `fastapi <0.116` (and matching `starlette`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dd8d4bfccbf00eaca71821dc2f96e0548d30216. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->