### PR TITLE
Update Discord links across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="docs/images/banner.png" alt="Idun Agent Platform Banner"/>
 
-  [![License: MIT](https://img.shields.io/badge/License-MIT-purple.svg)](https://opensource.org/licenses/MIT) [![Python 3.12](https://img.shields.io/badge/python-3.12-purple.svg)](https://www.python.org/downloads/) [![PyPI](https://img.shields.io/pypi/v/idun-agent-engine?color=purple)](https://pypi.org/project/idun-agent-engine/) [![Documentation](https://img.shields.io/badge/docs-mkdocs-purple.svg)](https://idun-group.github.io/idun-agent-platform/) [![GitHub Stars](https://img.shields.io/github/stars/Idun-Group/idun-agent-platform?style=social&label=Star)](https://github.com/Idun-Group/idun-agent-platform) [![Discord](https://img.shields.io/badge/Discord-Join%20Us-purple?logo=discord&logoColor=white)](https://discord.gg/tcwH4z7R)
+  [![License: MIT](https://img.shields.io/badge/License-MIT-purple.svg)](https://opensource.org/licenses/MIT) [![Python 3.12](https://img.shields.io/badge/python-3.12-purple.svg)](https://www.python.org/downloads/) [![PyPI](https://img.shields.io/pypi/v/idun-agent-engine?color=purple)](https://pypi.org/project/idun-agent-engine/) [![Documentation](https://img.shields.io/badge/docs-mkdocs-purple.svg)](https://idun-group.github.io/idun-agent-platform/) [![GitHub Stars](https://img.shields.io/github/stars/Idun-Group/idun-agent-platform?style=social&label=Star)](https://github.com/Idun-Group/idun-agent-platform) [![Discord](https://img.shields.io/badge/Discord-Join%20Us-purple?logo=discord&logoColor=white)](https://discord.gg/KCZ6nW2jQe)
 
 </div>
 
@@ -362,7 +362,7 @@ services/
 
 ## Community and support
 
-- Questions and help, [join the Discord](https://discord.gg/tcwH4z7R)
+- Questions and help, [join the Discord](https://discord.gg/KCZ6nW2jQe)
 - Proposals and ideas, [GitHub Discussions](https://github.com/Idun-Group/idun-agent-platform/discussions)
 - Bugs and feature requests, [GitHub Issues](https://github.com/Idun-Group/idun-agent-platform/issues)
 

--- a/docs/a2a/overview.md
+++ b/docs/a2a/overview.md
@@ -6,7 +6,7 @@ Agent-to-Agent (A2A) communication enables agents to interact with each other, c
 
 !!! warning
     The guide for this feature is coming soon.
-    If you are interested by this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+    If you are interested by this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).
 
 
 ## Features

--- a/docs/deployment/aws-self-hosted.md
+++ b/docs/deployment/aws-self-hosted.md
@@ -3,4 +3,4 @@
 !!! warning "Coming Soon"
     The documentation for AWS self-hosted deployment is currently under development.
 
-We have Terraform modules available for deploying the Idun Agent Platform on AWS. If you are interested in early access or need assistance, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+We have Terraform modules available for deploying the Idun Agent Platform on AWS. If you are interested in early access or need assistance, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).

--- a/docs/deployment/azure-self-hosted.md
+++ b/docs/deployment/azure-self-hosted.md
@@ -3,4 +3,4 @@
 !!! warning "Coming Soon"
     The documentation for Azure self-hosted deployment is currently under development.
 
-We have Terraform modules available for deploying the Idun Agent Platform on Azure. If you are interested in early access or need assistance, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+We have Terraform modules available for deploying the Idun Agent Platform on Azure. If you are interested in early access or need assistance, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).

--- a/docs/deployment/gcp-self-hosted.md
+++ b/docs/deployment/gcp-self-hosted.md
@@ -29,4 +29,4 @@ Agents continue to be deployed using your standard CI/CD pipelines (e.g., GitHub
 We offer **Terraform modules** to automate this entire deployment process, ensuring a production-ready setup with best practices (IAM, networking, security).
 
 !!! info "Get Terraform Code"
-    The Terraform code is available upon request. If you are interested in automating your GCP deployment, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+    The Terraform code is available upon request. If you are interested in automating your GCP deployment, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).

--- a/docs/deployment/idun-cloud.md
+++ b/docs/deployment/idun-cloud.md
@@ -4,11 +4,11 @@
 
 !!! warning
     The guide for this feature is coming soon.
-    If you are interested by this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+    If you are interested by this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).
 
 !!! warning
     The guide for this feature is coming soon.
-    If you are interested by this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+    If you are interested by this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).
 
 Idun Cloud is a fully managed platform for deploying and operating AI agents with zero infrastructure management.
 
@@ -25,6 +25,6 @@ Idun Cloud is a fully managed platform for deploying and operating AI agents wit
 
 ## Get Notified
 
-Interested in Idun Cloud? Follow our [GitHub repository](https://github.com/Idun-Group/idun-agent-platform) for updates, reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+Interested in Idun Cloud? Follow our [GitHub repository](https://github.com/Idun-Group/idun-agent-platform) for updates, reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).
 
 [Deployment overview →](overview.md)

--- a/docs/deployment/k8s-self-hosted.md
+++ b/docs/deployment/k8s-self-hosted.md
@@ -3,4 +3,4 @@
 !!! warning "Coming Soon"
     The documentation for Kubernetes deployment via Helm is currently under development.
 
-We have Helm charts available for deploying the Idun Agent Platform on Kubernetes clusters. If you are interested in early access or need assistance, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+We have Helm charts available for deploying the Idun Agent Platform on Kubernetes clusters. If you are interested in early access or need assistance, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@
   </p>
   <p style="margin: 0.6em 0 1.2em 0;">
     <a href="https://idun-group.github.io/idun-agent-platform/getting-started/quickstart/" class="md-button md-button--primary">Quickstart in 5 minutes</a>
-    <a href="https://discord.gg/tcwH4z7R" class="md-button">Join the Discord</a>
+    <a href="https://discord.gg/KCZ6nW2jQe" class="md-button">Join the Discord</a>
   </p>
 </div>
 
@@ -238,7 +238,7 @@ See the detailed **[Roadmap](roadmap/roadmap.md)** for up-to-date status.
 
 ## Community and support
 
-- Questions and help: **[Discord](https://discord.gg/tcwH4z7R)**
+- Questions and help: **[Discord](https://discord.gg/KCZ6nW2jQe)**
 - Proposals and ideas: **[GitHub Discussions](https://github.com/Idun-Group/idun-agent-platform/discussions)**
 - Bugs and feature requests: **[GitHub Issues](https://github.com/Idun-Group/idun-agent-platform/issues)**
 

--- a/docs/more/faq.md
+++ b/docs/more/faq.md
@@ -12,4 +12,4 @@ No. For many use cases you can run the **Idun Agent Engine** standalone from a l
 ## I found a bug or missing doc—where should I report it?
 
 - Bugs / feature requests: [GitHub Issues](https://github.com/Idun-Group/idun-agent-platform/issues)
-- Questions: [Discord](https://discord.gg/tcwH4z7R)
+- Questions: [Discord](https://discord.gg/KCZ6nW2jQe)

--- a/docs/observability/langfuse.md
+++ b/docs/observability/langfuse.md
@@ -90,7 +90,7 @@ You'll see detailed traces showing:
 
 !!! warning
     ADK does not currently support simultaneous tracing with both Langfuse and GCP tracing.
-    If you are interested by this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+    If you are interested by this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).
 
 ### Observability not working?
 

--- a/docs/sso-rbac/overview.md
+++ b/docs/sso-rbac/overview.md
@@ -25,4 +25,4 @@ These capabilities help organizations maintain security, streamline user experie
 
 !!! warning
     The guide for this feature is coming soon.
-    If you are interested in this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/tcwH4z7R).
+    If you are interested in this feature, please reach out via [GitHub issues](https://github.com/Idun-Group/idun-agent-platform/issues) or join our [Discord Server](https://discord.gg/KCZ6nW2jQe).


### PR DESCRIPTION
Replaced outdated Discord server links with the new invite link in README.md, index.md, and various documentation files to ensure users have access to the correct community support channel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates community links to point to the new Discord invite.
> 
> - Replaces old Discord URL with `https://discord.gg/KCZ6nW2jQe` in `README.md`, `docs/index.md`, and several docs (`docs/a2a/overview.md`, deployment guides, `docs/more/faq.md`, `docs/observability/langfuse.md`, `docs/sso-rbac/overview.md`).
> 
> Minimal, docs-only change; no code or behavior modifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b44497766e9f2bc2a7ffe48405155c47a3f6a7de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->