### PR TITLE
Fix premature session expiry with sliding-window refresh

### DIFF
--- a/services/idun_agent_manager/src/app/api/v1/routers/auth.py
+++ b/services/idun_agent_manager/src/app/api/v1/routers/auth.py
@@ -108,9 +108,15 @@ def _read_session_cookie(request: Request) -> dict[str, Any] | None:
         payload: dict[str, Any] = _get_serializer().loads(
             token, max_age=settings.auth.session_ttl_seconds
         )
-        return payload
     except (BadSignature, SignatureExpired):
         return None
+
+    created_at = payload.get("created_at")
+    if created_at is not None:
+        if (time.time() - created_at) > settings.auth.session_max_lifetime_seconds:
+            return None
+
+    return payload
 
 
 def encrypt_payload(payload: str) -> bytes:
@@ -274,7 +280,7 @@ async def callback(
             "roles": ["admin"] if not workspace_ids else ["admin"],
             "workspace_ids": workspace_ids,
         },
-        "expires_at": int(time.time()) + settings.auth.session_ttl_seconds,
+        "created_at": int(time.time()),
     }
 
     redirect_url = f"{settings.auth.frontend_url}/agents"
@@ -387,7 +393,7 @@ async def basic_signup(
             "roles": ["admin"],
             "workspace_ids": [str(workspace.id)],
         },
-        "expires_at": int(time.time()) + settings.auth.session_ttl_seconds,
+        "created_at": int(time.time()),
     }
     _set_session_cookie(response, session_payload)
 
@@ -459,7 +465,7 @@ async def basic_login(
             "roles": ["admin"],
             "workspace_ids": workspace_ids,
         },
-        "expires_at": int(time.time()) + settings.auth.session_ttl_seconds,
+        "created_at": int(time.time()),
     }
     _set_session_cookie(response, session_payload)
 

--- a/services/idun_agent_manager/src/app/core/middleware.py
+++ b/services/idun_agent_manager/src/app/core/middleware.py
@@ -1,0 +1,77 @@
+"""Session refresh middleware — sliding window session expiry."""
+
+import logging
+import time
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.core.settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class SessionRefreshMiddleware(BaseHTTPMiddleware):
+    """Re-sign the session cookie on authenticated requests to implement
+    a sliding-window session expiry.
+
+    The cookie is only refreshed when the token age exceeds a configurable
+    threshold (default: half the session TTL).
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        response = await call_next(request)
+
+        token = request.cookies.get("sid")
+        if not token:
+            return response
+
+        try:
+            self._maybe_refresh(token, response)
+        except Exception:
+            logger.debug("Session refresh skipped due to error", exc_info=True)
+
+        return response
+
+    @staticmethod
+    def _maybe_refresh(token: str, response: Response) -> None:
+        from app.api.v1.routers.auth import (
+            _get_serializer,
+            _set_session_cookie,
+        )
+
+        settings = get_settings()
+        serializer = _get_serializer()
+
+        try:
+            payload: dict[str, Any]
+            payload, signing_dt = serializer.loads(
+                token, max_age=None, return_timestamp=True
+            )
+        except Exception:
+            return
+
+        now = time.time()
+        token_age = now - signing_dt.timestamp()
+
+        ttl = settings.auth.session_ttl_seconds
+        threshold = settings.auth.session_refresh_threshold_seconds
+        if threshold is None:
+            threshold = ttl // 2
+
+        if token_age < threshold:
+            return
+
+        if "created_at" not in payload:
+            payload["created_at"] = int(now)
+
+        _set_session_cookie(response, payload, max_age=ttl)
+        logger.debug(
+            "Refreshed session cookie (age=%ds, threshold=%ds)",
+            int(token_age),
+            threshold,
+        )

--- a/services/idun_agent_manager/src/app/infrastructure/db/models/settings.py
+++ b/services/idun_agent_manager/src/app/infrastructure/db/models/settings.py
@@ -59,6 +59,8 @@ class AuthSettings(BaseSettings):
         default="change-me-to-a-random-secret-at-least-32-chars!"
     )
     session_ttl_seconds: int = Field(default=86400)
+    session_max_lifetime_seconds: int = Field(default=604800)  # 7 days
+    session_refresh_threshold_seconds: int | None = Field(default=None)
     cookie_secure: bool = Field(default=False)
 
     google: GoogleProviderSettings = Field(default_factory=GoogleProviderSettings)

--- a/services/idun_agent_manager/src/app/main.py
+++ b/services/idun_agent_manager/src/app/main.py
@@ -94,7 +94,10 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
-    # Starlette SessionMiddleware – required by authlib for OIDC state storage
+    from app.core.middleware import SessionRefreshMiddleware
+
+    app.add_middleware(SessionRefreshMiddleware)
+
     app.add_middleware(
         SessionMiddleware,
         secret_key=settings.auth.session_secret,

--- a/services/idun_agent_manager/tests/unit/test_session_refresh.py
+++ b/services/idun_agent_manager/tests/unit/test_session_refresh.py
@@ -1,0 +1,178 @@
+"""Unit tests for session refresh middleware."""
+
+import time
+
+import pytest
+
+from app.api.v1.routers.auth import _get_serializer
+
+pytestmark = pytest.mark.asyncio
+
+
+def _decode_cookie(token: str) -> dict:
+    return _get_serializer().loads(token)
+
+
+def _forge_cookie(payload: dict) -> str:
+    return _get_serializer().dumps(payload)
+
+
+def _get_set_cookie_headers(response, name: str = "sid") -> list[str]:
+    return [
+        v
+        for k, v in response.headers.multi_items()
+        if k.lower() == "set-cookie" and v.startswith(f"{name}=")
+    ]
+
+
+async def _signup(client, email: str) -> str:
+    resp = await client.post(
+        "/api/v1/auth/basic/signup",
+        json={"email": email, "password": "password123", "name": "Test"},
+    )
+    assert resp.status_code == 200
+    return resp.cookies["sid"]
+
+
+class TestSessionPayload:
+    async def test_signup_sets_created_at(self, client):
+        token = await _signup(client, "payload-signup@example.com")
+        payload = _decode_cookie(token)
+        assert "created_at" in payload
+        assert isinstance(payload["created_at"], int)
+        assert abs(payload["created_at"] - int(time.time())) < 5
+
+    async def test_signup_no_expires_at(self, client):
+        token = await _signup(client, "payload-no-exp-signup@example.com")
+        payload = _decode_cookie(token)
+        assert "expires_at" not in payload
+
+    async def test_login_sets_created_at(self, client):
+        await _signup(client, "payload-login@example.com")
+        resp = await client.post(
+            "/api/v1/auth/basic/login",
+            json={"email": "payload-login@example.com", "password": "password123"},
+        )
+        assert resp.status_code == 200
+        payload = _decode_cookie(resp.cookies["sid"])
+        assert "created_at" in payload
+        assert "expires_at" not in payload
+
+
+class TestNoRefreshOnFreshCookie:
+    async def test_fresh_cookie_not_refreshed(self, client):
+        await _signup(client, "fresh@example.com")
+        response = await client.get("/api/v1/auth/me")
+        assert response.status_code == 200
+        sid_headers = _get_set_cookie_headers(response)
+        assert len(sid_headers) == 0
+
+
+class TestRefreshOnOldCookie:
+    async def test_old_cookie_is_refreshed(self, client):
+        token = await _signup(client, "old-cookie@example.com")
+        original_payload = _decode_cookie(token)
+
+        original_payload["created_at"] = int(time.time()) - 3600
+        old_token = _forge_cookie(original_payload)
+        client.cookies.clear()
+        client.cookies.set("sid", old_token)
+
+        from app.core.settings import get_settings
+
+        settings = get_settings()
+        original_threshold = settings.auth.session_refresh_threshold_seconds
+        settings.auth.session_refresh_threshold_seconds = 0
+
+        try:
+            response = await client.get("/api/v1/auth/me")
+            assert response.status_code == 200
+            sid_headers = _get_set_cookie_headers(response)
+            assert len(sid_headers) > 0
+
+            new_token = response.cookies["sid"]
+            new_payload = _decode_cookie(new_token)
+            assert new_payload["principal"] == original_payload["principal"]
+            assert new_payload["provider"] == original_payload["provider"]
+        finally:
+            settings.auth.session_refresh_threshold_seconds = original_threshold
+
+    async def test_refresh_preserves_created_at(self, client):
+        token = await _signup(client, "preserve-ts@example.com")
+        payload = _decode_cookie(token)
+        original_created_at = payload["created_at"]
+
+        from app.core.settings import get_settings
+
+        settings = get_settings()
+        original_threshold = settings.auth.session_refresh_threshold_seconds
+        settings.auth.session_refresh_threshold_seconds = 0
+
+        try:
+            response = await client.get("/api/v1/auth/me")
+            assert response.status_code == 200
+            sid_headers = _get_set_cookie_headers(response)
+            assert len(sid_headers) > 0
+            new_payload = _decode_cookie(response.cookies["sid"])
+            assert new_payload["created_at"] == original_created_at
+        finally:
+            settings.auth.session_refresh_threshold_seconds = original_threshold
+
+
+class TestAbsoluteMaxLifetime:
+    async def test_session_past_max_lifetime_is_rejected(self, client):
+        token = await _signup(client, "max-life@example.com")
+        payload = _decode_cookie(token)
+
+        payload["created_at"] = int(time.time()) - (8 * 86400)
+        old_token = _forge_cookie(payload)
+        client.cookies.clear()
+        client.cookies.set("sid", old_token)
+
+        response = await client.get("/api/v1/auth/me")
+        assert response.status_code == 401
+
+
+class TestBackwardCompat:
+    async def test_old_cookie_without_created_at_gets_backfilled(self, client):
+        token = await _signup(client, "backfill@example.com")
+        payload = _decode_cookie(token)
+        payload.pop("created_at", None)
+        old_token = _forge_cookie(payload)
+        client.cookies.clear()
+        client.cookies.set("sid", old_token)
+
+        from app.core.settings import get_settings
+
+        settings = get_settings()
+        original_threshold = settings.auth.session_refresh_threshold_seconds
+        settings.auth.session_refresh_threshold_seconds = 0
+
+        try:
+            response = await client.get("/api/v1/auth/me")
+            assert response.status_code == 200
+            sid_headers = _get_set_cookie_headers(response)
+            assert len(sid_headers) > 0
+            new_payload = _decode_cookie(response.cookies["sid"])
+            assert "created_at" in new_payload
+            assert abs(new_payload["created_at"] - int(time.time())) < 5
+        finally:
+            settings.auth.session_refresh_threshold_seconds = original_threshold
+
+
+class TestMiddlewareNoOp:
+    async def test_no_cookie_no_effect(self, client):
+        response = await client.get("/api/v1/healthz")
+        assert response.status_code == 200
+        sid_headers = _get_set_cookie_headers(response)
+        assert len(sid_headers) == 0
+
+    async def test_garbage_cookie_no_crash(self, client):
+        client.cookies.set("sid", "garbage-not-a-real-token")
+        response = await client.get("/api/v1/healthz")
+        assert response.status_code == 200
+
+    async def test_malformed_cookie_does_not_break_auth(self, client):
+        client.cookies.set("sid", "totally-broken")
+        response = await client.get("/api/v1/auth/me")
+        assert response.status_code == 401

--- a/services/idun_agent_web/src/utils/auth.ts
+++ b/services/idun_agent_web/src/utils/auth.ts
@@ -14,7 +14,6 @@ export interface SessionPrincipal {
 export interface Session {
     provider?: string;
     principal?: SessionPrincipal;
-    expires_at?: number;
 }
 
 export async function loginBasic(params: { email: string; password: string }): Promise<void> {


### PR DESCRIPTION
fixes issue #328: 
Session cookies were fixed-lifetime from login with no renewal, causing users to be logged out after 30 (or whatever is set by the env var) minutes regardless of activity. Added SessionRefreshMiddleware that re-signs the cookie when token age exceeds a configurable threshold, plus an absolute max session lifetime (7 days) via created_at in the payload.


