### PR TITLE
Fix CI failures: syntax error, stale imports, duplicate JSON keys

### DIFF
--- a/services/idun_agent_manager/src/app/api/v1/routers/agents.py
+++ b/services/idun_agent_manager/src/app/api/v1/routers/agents.py
@@ -49,12 +49,12 @@ from app.infrastructure.db.models.agent_prompt_assignment import (
     AgentPromptAssignmentModel,
 )
 from app.infrastructure.db.models.managed_agent import ManagedAgentModel
+from app.infrastructure.db.models.managed_prompt import ManagedPromptModel
 from app.services.engine_config import (
     extract_resource_ids,
     recompute_engine_config,
     sync_resources,
 )
-from app.infrastructure.db.models.managed_prompt import ManagedPromptModel
 
 router = APIRouter()
 
@@ -132,12 +132,6 @@ async def create_agent(
 
     # Extract resources before Pydantic validation
     resources_data = body.pop("resources", None)
-
-    # Backward compat: convert guardrails in old-format engine_config
-    if "engine_config" in body and "guardrails" in body["engine_config"]:
-        body["engine_config"]["guardrails"] = convert_guardrail(
-            body["engine_config"]["guardrails"]
-        )
 
     request = ManagedAgentCreate(**body)
     now = datetime.now(UTC)
@@ -385,12 +379,6 @@ async def patch_agent(
 
     # Extract resources before Pydantic validation
     resources_data = body.pop("resources", None)
-
-    # Backward compat: convert guardrails in old-format engine_config
-    if "engine_config" in body and "guardrails" in body["engine_config"]:
-        body["engine_config"]["guardrails"] = convert_guardrail(
-            body["engine_config"]["guardrails"]
-        )
 
     request = ManagedAgentPatch(**body)
 

--- a/services/idun_agent_manager/src/app/services/engine_config.py
+++ b/services/idun_agent_manager/src/app/services/engine_config.py
@@ -11,7 +11,6 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from idun_agent_schema.engine import EngineConfig
-from idun_agent_schema.manager.guardrail_configs import convert_guardrail
 from idun_agent_schema.manager.managed_agent import AgentResourceIds
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -71,8 +70,7 @@ def assemble_engine_config(model: ManagedAgentModel) -> dict[str, Any]:
                 output_guards.append(guard_data)
 
     if input_guards or output_guards:
-        raw_guardrails = {"input": input_guards, "output": output_guards}
-        base["guardrails"] = convert_guardrail(raw_guardrails)
+        base["guardrails"] = {"input": input_guards, "output": output_guards}
     else:
         base.pop("guardrails", None)
 

--- a/services/idun_agent_manager/tests/conftest.py
+++ b/services/idun_agent_manager/tests/conftest.py
@@ -22,6 +22,7 @@ from app.infrastructure.db.models.agent_mcp_server import (
 )
 from app.infrastructure.db.models.agent_observability import (
     AgentObservabilityModel,  # noqa: F401
+)
 from app.infrastructure.db.models.agent_prompt_assignment import (
     AgentPromptAssignmentModel,  # noqa: F401
 )

--- a/services/idun_agent_web/src/App.tsx
+++ b/services/idun_agent_web/src/App.tsx
@@ -143,7 +143,7 @@ function App() {
                                 </ContentLayout>
                             </AppLayout>
                         }
-                    /> 
+                    />
                     <Route
                         path="/observability"
                         element={

--- a/services/idun_agent_web/src/i18n/locales/de.json
+++ b/services/idun_agent_web/src/i18n/locales/de.json
@@ -1010,17 +1010,6 @@
         "comingSoon": "Demnächst",
         "whatsapp": "WhatsApp"
     },
-    "integrations": {
-        "title": "Integrationen",
-        "subtitle": "Verbinden Sie externe Messaging-Plattformen mit Ihren Agenten",
-        "search": "Integrationen suchen...",
-        "add": "Integration hinzufügen",
-        "addCard": "Integration hinzufügen",
-        "loading": "Integrationen werden geladen…",
-        "active": "Aktive Integrationen",
-        "comingSoon": "Demnächst",
-        "whatsapp": "WhatsApp"
-    },
     "theme": {
         "toggleToLight": "In den hellen Modus wechseln",
         "toggleToDark": "In den dunklen Modus wechseln",

--- a/services/idun_agent_web/src/i18n/locales/en.json
+++ b/services/idun_agent_web/src/i18n/locales/en.json
@@ -1046,18 +1046,6 @@
         "whatsapp": "WhatsApp",
         "discord": "Discord"
     },
-    "integrations": {
-        "title": "Integrations",
-        "subtitle": "Connect external messaging platforms to your agents",
-        "search": "Search integrations...",
-        "add": "Add integration",
-        "addCard": "Add integration",
-        "loading": "Loading integrations…",
-        "active": "Active Integrations",
-        "comingSoon": "Coming Soon",
-        "whatsapp": "WhatsApp",
-        "discord": "Discord"
-    },
     "theme": {
         "toggleToLight": "Switch to light mode",
         "toggleToDark": "Switch to dark mode",

--- a/services/idun_agent_web/src/i18n/locales/es.json
+++ b/services/idun_agent_web/src/i18n/locales/es.json
@@ -1003,17 +1003,6 @@
         "comingSoon": "Próximamente",
         "whatsapp": "WhatsApp"
     },
-    "integrations": {
-        "title": "Integraciones",
-        "subtitle": "Conecte plataformas de mensajería externas a sus agentes",
-        "search": "Buscar integraciones...",
-        "add": "Añadir integración",
-        "addCard": "Añadir integración",
-        "loading": "Cargando integraciones…",
-        "active": "Integraciones activas",
-        "comingSoon": "Próximamente",
-        "whatsapp": "WhatsApp"
-    },
     "theme": {
         "toggleToLight": "Cambiar a modo claro",
         "toggleToDark": "Cambiar a modo oscuro",

--- a/services/idun_agent_web/src/i18n/locales/fr.json
+++ b/services/idun_agent_web/src/i18n/locales/fr.json
@@ -1052,17 +1052,6 @@
         "comingSoon": "Bientôt disponible",
         "whatsapp": "WhatsApp"
     },
-    "integrations": {
-        "title": "Intégrations",
-        "subtitle": "Connectez des plateformes de messagerie externes à vos agents",
-        "search": "Rechercher des intégrations...",
-        "add": "Ajouter une intégration",
-        "addCard": "Ajouter une intégration",
-        "loading": "Chargement des intégrations…",
-        "active": "Intégrations actives",
-        "comingSoon": "Bientôt disponible",
-        "whatsapp": "WhatsApp"
-    },
     "theme": {
         "toggleToLight": "Passer en mode clair",
         "toggleToDark": "Passer en mode sombre",


### PR DESCRIPTION
## Summary
- Fix missing closing parenthesis in `conftest.py` `AgentObservabilityModel` import (caused `SyntaxError` failing both CI jobs)
- Remove broken `convert_guardrail` import/usage from `engine_config.py` and `agents.py` (function was removed in earlier PR)
- Deduplicate `"integrations"` keys in en/de/es/fr locale JSON files (invalid JSON)
- Fix trailing whitespace in `App.tsx`

## Test plan
- [ ] CI / Lint, type-check, and secrets scan passes
- [ ] CI / Test manager (Py3.12) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)