### PR TITLE
Fix CI: agents.ts EOF newline and guardrail test assertion

### DIFF
--- a/services/idun_agent_manager/tests/unit/test_engine_config.py
+++ b/services/idun_agent_manager/tests/unit/test_engine_config.py
@@ -241,8 +241,8 @@ class TestAssembleEngineConfig:
         input_guards = result["guardrails"]["input"]
         assert len(input_guards) == 2
         # g1 (sort_order=0) should be first
-        assert input_guards[0]["guard_params"]["banned_words"] == ["first"]
-        assert input_guards[1]["guard_params"]["banned_words"] == ["second"]
+        assert input_guards[0]["banned_words"] == ["first"]
+        assert input_guards[1]["banned_words"] == ["second"]
 
     def test_no_guardrails_removes_key(self):
         import copy

--- a/services/idun_agent_web/src/services/agents.ts
+++ b/services/idun_agent_web/src/services/agents.ts
@@ -277,4 +277,3 @@ export async function getAgentApiKey(agentId: string): Promise<string> {
     const result = await getJson<ApiKeyResponse>(`/api/v1/agents/key?agent_id=${encodeURIComponent(agentId)}`);
     return result.api_key;
 }
-


### PR DESCRIPTION
## Summary
- Fix extra trailing newline in `agents.ts` that failed the `end-of-file-fixer` pre-commit hook
- Fix `test_guardrails_sorted_by_sort_order` — test referenced `guard_params["banned_words"]` but guardrail configs are now flattened (banned_words is a top-level key after Pydantic validation)

Fixes the two remaining CI failures on PR #372:
- `CI / Lint, type-check, and secrets scan`
- `CI / Test manager (Py3.12)`

## Test plan
- [x] `test_guardrails_sorted_by_sort_order` passes locally
- [ ] CI / Lint, type-check, and secrets scan passes
- [ ] CI / Test manager (Py3.12) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)