### PR TITLE
fix cloud access to localhost agents

### DIFF
--- a/libs/idun_agent_engine/CLAUDE.md
+++ b/libs/idun_agent_engine/CLAUDE.md
@@ -95,6 +95,13 @@ Config resolution priority in `ConfigBuilder.resolve_config()`:
 
 Fields inside `agent.config` change depending on `agent.type`:
 
+### Server API Settings
+
+`server.api` currently exposes only `port`. Browser access behavior is built into the engine app factory:
+
+- CORS remains wildcard (`allow_origins=["*"]`)
+- Qualifying CORS preflights receive `Access-Control-Allow-Private-Network: true` so the hosted UI can reach a localhost agent from the browser
+
 **LangGraph:**
 ```yaml
 server:
@@ -223,6 +230,8 @@ All adapters implement `discover_capabilities()` (returns `AgentCapabilities`) a
 | `/agent/config` | GET | Get current agent config |
 | `/integrations/whatsapp/webhook` | GET/POST | WhatsApp webhook (GET: Meta verify, POST: receive messages) |
 | `/integrations/discord/webhook` | POST | Discord Interactions Endpoint (Ed25519 verified, handles PING + slash commands) |
+
+`/reload` is not currently protected by the SSO dependency used on `/agent/*` routes. Because engine CORS remains wildcard, any browser origin that can reach the agent can call `/reload` cross-origin as well.
 
 ## Guardrails
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/core/app_factory.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/core/app_factory.py
@@ -5,10 +5,13 @@ application with their agent integrated. It handles all the complexity of
 setting up routes, dependencies, and lifecycle management behind the scenes.
 """
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
 
 from .._version import __version__
 from ..server.lifespan import lifespan
@@ -61,10 +64,9 @@ def create_app(
         redoc_url="/redoc",
     )
 
-    # TODO: Add CORS configuration feature. Default allowed origins should be:
-    #   - https://cloud.idunplatform.com (production SaaS)
-    #   - http://localhost:3000 (local frontend dev)
-    # For now, allow all origins to avoid blocking local agent connections.
+    # TODO: Add a proper CORS configuration feature. We currently keep wildcard
+    # CORS behavior and layer Private Network Access support on top so the
+    # hosted UI can reach localhost agents from the browser.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
@@ -72,6 +74,20 @@ def create_app(
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    @app.middleware("http")
+    async def allow_private_network_access(
+        request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        response = await call_next(request)
+
+        if request.headers.get("access-control-request-private-network") != "true":
+            return response
+
+        if "access-control-allow-origin" in response.headers:
+            response.headers["Access-Control-Allow-Private-Network"] = "true"
+
+        return response
 
     # Store configuration in app state for lifespan to use
     app.state.engine_config = validated_config

--- a/libs/idun_agent_engine/tests/unit/core/test_app_factory.py
+++ b/libs/idun_agent_engine/tests/unit/core/test_app_factory.py
@@ -106,7 +106,6 @@ class TestAppFactoryConfigSources:
         assert agent_config.checkpointer.type == "sqlite"
         assert "test_checkpoint.db" in agent_config.checkpointer.db_url
 
-
 @pytest.mark.unit
 class TestAppFactoryRoutes:
     """Test basic routes on the created app."""
@@ -134,3 +133,74 @@ class TestAppFactoryRoutes:
         resp = client.get("/")
         assert resp.status_code == 200
         assert "agent_endpoints" in resp.json()
+
+
+@pytest.mark.unit
+class TestAppFactoryCors:
+    """Test CORS and Private Network Access behavior on the created app."""
+
+    def test_preflight_allows_any_origin_and_private_network(self, tmp_path) -> None:
+        """Wildcard CORS should still return the private-network allow header."""
+        app = create_app(
+            config_dict={
+                "server": {"api": {"port": 0}},
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {
+                        "name": "Test Agent",
+                        "graph_definition": str(tmp_path / "agent.py:graph"),
+                    },
+                },
+            }
+        )
+        client = TestClient(app)
+
+        response = client.options(
+            "/reload",
+            headers={
+                "Origin": "https://cloud.idunplatform.com",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Private-Network": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        assert (
+            response.headers.get("access-control-allow-origin")
+            == "https://cloud.idunplatform.com"
+        )
+        assert response.headers.get("access-control-allow-private-network") == "true"
+
+    def test_preflight_allows_arbitrary_origin_with_wildcard_cors(
+        self, tmp_path
+    ) -> None:
+        """Private-network support should apply even for non-cloud origins."""
+        app = create_app(
+            config_dict={
+                "server": {"api": {"port": 0}},
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {
+                        "name": "Test Agent",
+                        "graph_definition": str(tmp_path / "agent.py:graph"),
+                    },
+                },
+            }
+        )
+        client = TestClient(app)
+
+        response = client.options(
+            "/agent/capabilities",
+            headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Private-Network": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        assert (
+            response.headers.get("access-control-allow-origin")
+            == "https://evil.example.com"
+        )
+        assert response.headers.get("access-control-allow-private-network") == "true"

--- a/services/idun_agent_web/src/services/agents.test.ts
+++ b/services/idun_agent_web/src/services/agents.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function setHostname(hostname: string): void {
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: {
+            location: { hostname },
+            __RUNTIME_CONFIG__: {},
+        },
+    });
+}
+
+describe('fetchEngineHealth', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        vi.resetModules();
+        fetchMock.mockReset();
+        fetchMock.mockResolvedValue(
+            new Response(JSON.stringify({ status: 'ok', version: '0.4.9' }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+        setHostname('cloud.idunplatform.com');
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('routes localhost health checks through agentFetch address-space handling', async () => {
+        const { fetchEngineHealth } = await import('./agents');
+
+        const result = await fetchEngineHealth('http://localhost:8817');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'http://localhost:8817/health',
+            expect.objectContaining({
+                signal: expect.any(AbortSignal),
+                targetAddressSpace: 'loopback',
+            }),
+        );
+        expect(result).toEqual({ status: 'ok', engineVersion: '0.4.9' });
+    });
+});

--- a/services/idun_agent_web/src/services/agents.ts
+++ b/services/idun_agent_web/src/services/agents.ts
@@ -244,7 +244,7 @@ export async function fetchEngineHealth(baseUrl: string): Promise<EngineHealth |
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
     try {
-        const res = await fetch(url, { signal: controller.signal });
+        const res = await agentFetch(url, { signal: controller.signal });
         clearTimeout(timer);
         if (!res.ok) return null;
         const data = await res.json();

--- a/services/idun_agent_web/src/utils/agent-fetch.test.ts
+++ b/services/idun_agent_web/src/utils/agent-fetch.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { agentFetch } from './agent-fetch';
+
+function setHostname(hostname: string): void {
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: {
+            location: { hostname },
+            __RUNTIME_CONFIG__: {},
+        },
+    });
+}
+
+describe('agentFetch', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+        fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('uses loopback targetAddressSpace for localhost from a public origin', async () => {
+        setHostname('cloud.idunplatform.com');
+
+        await agentFetch('http://localhost:8817/health');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'http://localhost:8817/health',
+            expect.objectContaining({ targetAddressSpace: 'loopback' }),
+        );
+    });
+
+    it('uses local targetAddressSpace for private network hosts from a public origin', async () => {
+        setHostname('cloud.idunplatform.com');
+
+        await agentFetch('http://192.168.1.20:8817/health');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'http://192.168.1.20:8817/health',
+            expect.objectContaining({ targetAddressSpace: 'local' }),
+        );
+    });
+
+    it('does not annotate requests when the frontend itself runs on loopback', async () => {
+        setHostname('localhost');
+
+        await agentFetch('http://localhost:8817/health');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'http://localhost:8817/health',
+            expect.not.objectContaining({ targetAddressSpace: expect.anything() }),
+        );
+    });
+});

--- a/services/idun_agent_web/src/utils/agent-fetch.ts
+++ b/services/idun_agent_web/src/utils/agent-fetch.ts
@@ -3,9 +3,9 @@
  *
  * Handles two concerns:
  * 1. URL normalization — eliminates the repeated `endsWith('/')` pattern
- * 2. Local network access — when the cloud frontend calls a localhost agent,
- *    adds `targetAddressSpace: "local"` to signal that the request targets the
- *    local network (Chrome Local Network Access requirement).
+ * 2. Local network access — when the cloud frontend calls a loopback or
+ *    private-network agent, annotate the request with the matching Chrome
+ *    address space (`loopback` or `local`).
  *    Skipped in local dev (both sides are localhost, no PNA rules apply).
  */
 
@@ -17,9 +17,26 @@ function isLoopbackHost(hostname: string): boolean {
     return hostname.startsWith('127.');
 }
 
+function isPrivateIpv4Host(hostname: string): boolean {
+    return (
+        hostname.startsWith('10.') ||
+        hostname.startsWith('192.168.') ||
+        /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname) ||
+        hostname.startsWith('169.254.')
+    );
+}
+
 function isLoopbackUrl(url: string): boolean {
     try {
         return isLoopbackHost(new URL(url).hostname);
+    } catch {
+        return false;
+    }
+}
+
+function isLocalNetworkUrl(url: string): boolean {
+    try {
+        return isPrivateIpv4Host(new URL(url).hostname);
     } catch {
         return false;
     }
@@ -40,16 +57,23 @@ export function buildAgentUrl(baseUrl: string, path: string): string {
 
 /**
  * Fetch wrapper for agent endpoints. When the frontend runs on a public
- * domain (e.g. cloud.idunplatform.com) and the agent is on localhost,
- * adds `targetAddressSpace: "local"` to signal local-network intent for
- * Chrome Local Network Access checks.
+ * domain (e.g. cloud.idunplatform.com) and the agent is on loopback or the
+ * local network, adds the matching `targetAddressSpace` for Chrome Local
+ * Network Access checks.
  */
 export function agentFetch(url: string, init?: RequestInit): Promise<Response> {
     const options: RequestInit = { ...init };
 
-    if (!isLoopbackOrigin() && isLoopbackUrl(url)) {
-        (options as RequestInit & { targetAddressSpace?: 'local' }).targetAddressSpace =
-            'local';
+    if (!isLoopbackOrigin()) {
+        const requestOptions = options as RequestInit & {
+            targetAddressSpace?: 'local' | 'loopback';
+        };
+
+        if (isLoopbackUrl(url)) {
+            requestOptions.targetAddressSpace = 'loopback';
+        } else if (isLocalNetworkUrl(url)) {
+            requestOptions.targetAddressSpace = 'local';
+        }
     }
 
     return fetch(url, options);

--- a/services/idun_agent_web/vitest.unit.config.ts
+++ b/services/idun_agent_web/vitest.unit.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    },
+});


### PR DESCRIPTION
## Summary
- add engine-side Private Network Access response handling so browser preflights to localhost agents can succeed from the hosted UI
- fix web localhost request tagging by using `loopback` for `localhost`/`127.*` and `local` for private-network hosts
- route engine health checks through the shared agent fetch wrapper and add focused regression tests for the new browser access behavior

## Test plan
- [x] `uv run pytest libs/idun_agent_engine/tests/unit/core/test_app_factory.py -q`
- [x] `uv run ruff check libs/idun_agent_engine/src/idun_agent_engine/core/app_factory.py libs/idun_agent_schema/src/idun_agent_schema/engine/server.py libs/idun_agent_engine/tests/unit/core/test_app_factory.py`
- [x] `npm exec -- vitest run --config vitest.unit.config.ts src/utils/agent-fetch.test.ts src/services/agents.test.ts`
- [x] `npm exec -- eslint src/utils/agent-fetch.ts src/services/agents.ts src/utils/agent-fetch.test.ts src/services/agents.test.ts vitest.unit.config.ts`
- [ ] verify from `https://cloud.idunplatform.com` against a real local agent in Chrome


Made with [Cursor](https://cursor.com)