### PR TITLE
fix(388): use typed body params in agent endpoints

### DIFF
--- a/services/idun_agent_manager/src/app/api/v1/routers/agents.py
+++ b/services/idun_agent_manager/src/app/api/v1/routers/agents.py
@@ -23,7 +23,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 from idun_agent_schema.engine import EngineConfig
 from idun_agent_schema.manager import (
     AgentResourceIds,
@@ -122,18 +122,12 @@ def _model_to_schema(model: ManagedAgentModel) -> ManagedAgentRead:
     description="Create a new managed agent with an EngineConfig. The agent is created in DRAFT status.",
 )
 async def create_agent(
-    raw_request: Request,
+    request: ManagedAgentCreate,
     session: AsyncSession = Depends(get_session),
     user: CurrentUser = Depends(get_current_user),
     workspace_id: UUID = Depends(require_workspace),
 ) -> ManagedAgentRead:
     """Create a new managed agent."""
-    body = await raw_request.json()
-
-    # Extract resources before Pydantic validation
-    resources_data = body.pop("resources", None)
-
-    request = ManagedAgentCreate(**body)
     now = datetime.now(UTC)
 
     engine_config = EngineConfig(**request.engine_config.model_dump())
@@ -154,7 +148,7 @@ async def create_agent(
     await session.flush()
 
     # Sync resource associations and recompute materialized config
-    resources = AgentResourceIds(**(resources_data or {}))
+    resources = request.resources or AgentResourceIds()
     await sync_resources(session, model, resources)
     await session.flush()
     await recompute_engine_config(session, model.id)
@@ -367,20 +361,13 @@ async def delete_agent(
 )
 async def patch_agent(
     id: str,
-    raw_request: Request,
+    request: ManagedAgentPatch,
     session: AsyncSession = Depends(get_session),
     user: CurrentUser = Depends(get_current_user),
     workspace_id: UUID = Depends(require_workspace),
 ) -> ManagedAgentRead:
     """Partially update an agent's configuration."""
     model = await _get_agent(id, session, workspace_id)
-
-    body = await raw_request.json()
-
-    # Extract resources before Pydantic validation
-    resources_data = body.pop("resources", None)
-
-    request = ManagedAgentPatch(**body)
 
     model.name = request.name
     model.base_url = request.base_url
@@ -389,7 +376,7 @@ async def patch_agent(
     model.updated_at = datetime.now(UTC)
 
     # Sync resource associations and recompute materialized config
-    resources = AgentResourceIds(**(resources_data or {}))
+    resources = request.resources or AgentResourceIds()
     await sync_resources(session, model, resources)
     await session.flush()
     await recompute_engine_config(session, model.id)

--- a/services/idun_agent_web/schema/manager-openapi.json
+++ b/services/idun_agent_web/schema/manager-openapi.json
@@ -1,3354 +1,7582 @@
 {
-    "openapi": "3.1.0",
-    "info": {
-        "title": "Idun Agent Manager API",
-        "description": "Idun service for managing AI agents",
-        "version": "0.2.7"
-    },
-    "paths": {
-        "/api/v1/agents/": {
-            "post": {
-                "tags": ["Agents"],
-                "summary": "Create managed agent",
-                "description": "Create a new managed agent with an EngineConfig. The agent is created in DRAFT status.",
-                "operationId": "create_agent_api_v1_agents__post",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedAgentCreate-Input"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedAgentCreate-Output"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "tags": ["Agents"],
-                "summary": "List managed agents",
-                "description": "List all managed agents with pagination.",
-                "operationId": "list_agents_api_v1_agents__get",
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 100,
-                            "title": "Limit"
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "title": "Offset"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ManagedAgentRead"
-                                    },
-                                    "title": "Response List Agents Api V1 Agents  Get"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Idun Agent Manager API",
+    "description": "Idun service for managing AI agents",
+    "version": "0.5.0"
+  },
+  "paths": {
+    "/api/v1/auth/login": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Redirect to Google OIDC login",
+        "description": "Initiates the Google OIDC authorization code flow.",
+        "operationId": "login_api_v1_auth_login_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
             }
-        },
-        "/api/v1/agents/key": {
-            "get": {
-                "tags": ["Agents"],
-                "summary": "Generate agent API key",
-                "description": "Generate a unique API key (hash) for an agent to authenticate API requests.",
-                "operationId": "generate_key_api_v1_agents_key_get",
-                "parameters": [
-                    {
-                        "name": "agent_id",
-                        "in": "query",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Agent Id" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ApiKeyResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/agents/config": {
-            "get": {
-                "tags": ["Agents"],
-                "summary": "Get agent config by API key",
-                "description": "Retrieve agent configuration using API key authentication (Bearer token).",
-                "operationId": "config_api_v1_agents_config_get",
-                "parameters": [
-                    {
-                        "name": "auth",
-                        "in": "header",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Auth" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": { "application/json": { "schema": {} } }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/agents/{id}": {
-            "get": {
-                "tags": ["Agents"],
-                "summary": "Get managed agent by ID",
-                "description": "Retrieve a specific managed agent by its UUID with complete configuration details.",
-                "operationId": "get_agent_api_v1_agents__id__get",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedAgentRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["Agents"],
-                "summary": "Delete managed agent",
-                "description": "Permanently delete a managed agent and all its configuration data.",
-                "operationId": "delete_agent_api_v1_agents__id__delete",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "204": { "description": "Successful Response" },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "tags": ["Agents"],
-                "summary": "Partially update agent (PATCH)",
-                "description": "Partially update an agent's configuration. Only the name andengine_config field can be updated if provided.",
-                "operationId": "patch_agent_api_v1_agents__id__patch",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedAgentPatch"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedAgentRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/healthz": {
-            "get": {
-                "tags": ["Health"],
-                "summary": "Health Check",
-                "description": "Basic health check.",
-                "operationId": "health_check_api_v1_healthz_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object",
-                                    "title": "Response Health Check Api V1 Healthz Get"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/readyz": {
-            "get": {
-                "tags": ["Health"],
-                "summary": "Readiness Check",
-                "description": "Readiness check including database connectivity.",
-                "operationId": "readiness_check_api_v1_readyz_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object",
-                                    "title": "Response Readiness Check Api V1 Readyz Get"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/version": {
-            "get": {
-                "tags": ["Health"],
-                "summary": "Version",
-                "description": "Get application version and name from FastAPI app metadata.",
-                "operationId": "version_api_v1_version_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object",
-                                    "title": "Response Version Api V1 Version Get"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/mcp-servers/": {
-            "post": {
-                "tags": ["MCP Servers"],
-                "summary": "Create managed MCP server",
-                "description": "Create a new managed MCP server configuration.",
-                "operationId": "create_mcp_server_api_v1_mcp_servers__post",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedMCPServerCreate"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedMCPServerRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "tags": ["MCP Servers"],
-                "summary": "List managed MCP servers",
-                "description": "List managed MCP server configurations with pagination.",
-                "operationId": "list_mcp_servers_api_v1_mcp_servers__get",
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 100,
-                            "title": "Limit"
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "title": "Offset"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ManagedMCPServerRead"
-                                    },
-                                    "title": "Response List Mcp Servers Api V1 Mcp Servers  Get"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/mcp-servers/{id}": {
-            "get": {
-                "tags": ["MCP Servers"],
-                "summary": "Get managed MCP server by ID",
-                "description": "Get a managed MCP server configuration by ID.",
-                "operationId": "get_mcp_server_api_v1_mcp_servers__id__get",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedMCPServerRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["MCP Servers"],
-                "summary": "Delete managed MCP server",
-                "description": "Delete a managed MCP server configuration permanently.",
-                "operationId": "delete_mcp_server_api_v1_mcp_servers__id__delete",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "204": { "description": "Successful Response" },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "tags": ["MCP Servers"],
-                "summary": "Update managed MCP server",
-                "description": "Update an MCP server configuration.",
-                "operationId": "patch_mcp_server_api_v1_mcp_servers__id__patch",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedMCPServerPatch"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedMCPServerRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/observability/": {
-            "post": {
-                "tags": ["Observability"],
-                "summary": "Create managed observability config",
-                "description": "Create a new managed observability configuration.",
-                "operationId": "create_observability_api_v1_observability__post",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedObservabilityCreate"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedObservabilityRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "tags": ["Observability"],
-                "summary": "List managed observability configs",
-                "description": "List managed observability configurations with pagination.",
-                "operationId": "list_observabilities_api_v1_observability__get",
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 100,
-                            "title": "Limit"
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "title": "Offset"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ManagedObservabilityRead"
-                                    },
-                                    "title": "Response List Observabilities Api V1 Observability  Get"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/observability/{id}": {
-            "get": {
-                "tags": ["Observability"],
-                "summary": "Get managed observability config by ID",
-                "description": "Get a managed observability configuration by ID.",
-                "operationId": "get_observability_api_v1_observability__id__get",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedObservabilityRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["Observability"],
-                "summary": "Delete managed observability config",
-                "description": "Delete a managed observability configuration permanently.",
-                "operationId": "delete_observability_api_v1_observability__id__delete",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "204": { "description": "Successful Response" },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "tags": ["Observability"],
-                "summary": "Update managed observability config",
-                "description": "Update an observability configuration.",
-                "operationId": "patch_observability_api_v1_observability__id__patch",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedObservabilityPatch"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedObservabilityRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/memory/": {
-            "post": {
-                "tags": ["Memory"],
-                "summary": "Create managed memory config",
-                "description": "Create a new managed memory configuration.",
-                "operationId": "create_memory_api_v1_memory__post",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedMemoryCreate"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedMemoryRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "tags": ["Memory"],
-                "summary": "List managed memory configs",
-                "description": "List managed memory configurations with pagination.",
-                "operationId": "list_memories_api_v1_memory__get",
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 100,
-                            "title": "Limit"
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "title": "Offset"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ManagedMemoryRead"
-                                    },
-                                    "title": "Response List Memories Api V1 Memory  Get"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/memory/{id}": {
-            "get": {
-                "tags": ["Memory"],
-                "summary": "Get managed memory config by ID",
-                "description": "Get a managed memory configuration by ID.",
-                "operationId": "get_memory_api_v1_memory__id__get",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedMemoryRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["Memory"],
-                "summary": "Delete managed memory config",
-                "description": "Delete a managed memory configuration permanently.",
-                "operationId": "delete_memory_api_v1_memory__id__delete",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "204": { "description": "Successful Response" },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "tags": ["Memory"],
-                "summary": "Update managed memory config",
-                "description": "Update a memory configuration.",
-                "operationId": "patch_memory_api_v1_memory__id__patch",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedMemoryPatch"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedMemoryRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/agent-frameworks/": {
-            "get": {
-                "tags": ["Agent Frameworks"],
-                "summary": "List available agent frameworks",
-                "description": "Retrieve the list of supported agent frameworks in the platform.",
-                "operationId": "list_agent_frameworks_api_v1_agent_frameworks__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "items": { "type": "string" },
-                                    "type": "array",
-                                    "title": "Response List Agent Frameworks Api V1 Agent Frameworks  Get"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/guardrails/": {
-            "post": {
-                "tags": ["Guardrails"],
-                "summary": "Create managed guardrail config",
-                "description": "Create a new managed guardrail configuration.",
-                "operationId": "create_guardrail_api_v1_guardrails__post",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedGuardrailCreate"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedGuardrailRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "tags": ["Guardrails"],
-                "summary": "List managed guardrail configs",
-                "description": "List managed guardrail configurations with pagination.",
-                "operationId": "list_guardrails_api_v1_guardrails__get",
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 100,
-                            "title": "Limit"
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "title": "Offset"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/ManagedGuardrailRead"
-                                    },
-                                    "title": "Response List Guardrails Api V1 Guardrails  Get"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/guardrails/{id}": {
-            "get": {
-                "tags": ["Guardrails"],
-                "summary": "Get managed guardrail config by ID",
-                "description": "Get a managed guardrail configuration by ID.",
-                "operationId": "get_guardrail_api_v1_guardrails__id__get",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedGuardrailRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["Guardrails"],
-                "summary": "Delete managed guardrail config",
-                "description": "Delete a managed guardrail configuration permanently.",
-                "operationId": "delete_guardrail_api_v1_guardrails__id__delete",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "responses": {
-                    "204": { "description": "Successful Response" },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "tags": ["Guardrails"],
-                "summary": "Update managed guardrail config",
-                "description": "Update a guardrail configuration.",
-                "operationId": "patch_guardrail_api_v1_guardrails__id__patch",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "title": "Id" }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ManagedGuardrailPatch"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ManagedGuardrailRead"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/": {
-            "get": {
-                "summary": "Root",
-                "description": "Root endpoint.",
-                "operationId": "root__get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "type": "object",
-                                    "title": "Response Root  Get"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+          }
         }
+      }
     },
-    "components": {
-        "schemas": {
-            "AdkAgentConfig": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "input_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Input Schema Definition"
-                    },
-                    "output_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Output Schema Definition"
-                    },
-                    "observability": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
-                            },
-                            { "type": "null" }
-                        ]
-                    },
-                    "agent": {
-                        "type": "string",
-                        "title": "Agent",
-                        "description": "Agent definition (e.g. module.path:agent_instance)"
-                    },
-                    "app_name": {
-                        "type": "string",
-                        "title": "App Name",
-                        "description": "Application name for the agent"
-                    },
-                    "session_service": {
-                        "anyOf": [
-                            {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/AdkInMemorySessionConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/AdkVertexAiSessionConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/AdkDatabaseSessionConfig"
-                                    }
-                                ],
-                                "discriminator": {
-                                    "propertyName": "type",
-                                    "mapping": {
-                                        "database": "#/components/schemas/AdkDatabaseSessionConfig",
-                                        "in_memory": "#/components/schemas/AdkInMemorySessionConfig",
-                                        "vertex_ai": "#/components/schemas/AdkVertexAiSessionConfig"
-                                    }
-                                }
-                            },
-                            { "type": "null" }
-                        ],
-                        "title": "Session Service",
-                        "description": "Session service configuration"
-                    },
-                    "memory_service": {
-                        "anyOf": [
-                            {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/AdkInMemoryMemoryConfig"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/AdkVertexAiMemoryConfig"
-                                    }
-                                ],
-                                "discriminator": {
-                                    "propertyName": "type",
-                                    "mapping": {
-                                        "in_memory": "#/components/schemas/AdkInMemoryMemoryConfig",
-                                        "vertex_ai": "#/components/schemas/AdkVertexAiMemoryConfig"
-                                    }
-                                }
-                            },
-                            { "type": "null" }
-                        ],
-                        "title": "Memory Service",
-                        "description": "Memory service configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "agent", "app_name"],
-                "title": "AdkAgentConfig",
-                "description": "Configuration model for ADK agents."
-            },
-            "AdkDatabaseSessionConfig": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "database",
-                        "title": "Type",
-                        "default": "database"
-                    },
-                    "db_url": {
-                        "type": "string",
-                        "title": "Db Url",
-                        "description": "Database URL (e.g. postgresql://...)"
-                    }
-                },
-                "type": "object",
-                "required": ["db_url"],
-                "title": "AdkDatabaseSessionConfig",
-                "description": "Configuration for Database Session Service."
-            },
-            "AdkInMemoryMemoryConfig": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "in_memory",
-                        "title": "Type",
-                        "default": "in_memory"
-                    }
-                },
-                "type": "object",
-                "title": "AdkInMemoryMemoryConfig",
-                "description": "Configuration for In-Memory Memory Service."
-            },
-            "AdkInMemorySessionConfig": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "in_memory",
-                        "title": "Type",
-                        "default": "in_memory"
-                    }
-                },
-                "type": "object",
-                "title": "AdkInMemorySessionConfig",
-                "description": "Configuration for In-Memory Session Service."
-            },
-            "AdkVertexAiMemoryConfig": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "vertex_ai",
-                        "title": "Type",
-                        "default": "vertex_ai"
-                    },
-                    "project_id": {
-                        "type": "string",
-                        "title": "Project Id",
-                        "description": "Google Cloud Project ID"
-                    },
-                    "location": {
-                        "type": "string",
-                        "title": "Location",
-                        "description": "Google Cloud Location"
-                    },
-                    "memory_bank_id": {
-                        "anyOf": [{ "type": "string" }, { "type": "null" }],
-                        "title": "Memory Bank Id",
-                        "description": "Vertex AI Memory Bank Resource ID"
-                    }
-                },
-                "type": "object",
-                "required": ["project_id", "location"],
-                "title": "AdkVertexAiMemoryConfig",
-                "description": "Configuration for Vertex AI Memory Service."
-            },
-            "AdkVertexAiSessionConfig": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "vertex_ai",
-                        "title": "Type",
-                        "default": "vertex_ai"
-                    },
-                    "project_id": {
-                        "type": "string",
-                        "title": "Project Id",
-                        "description": "Google Cloud Project ID"
-                    },
-                    "location": {
-                        "type": "string",
-                        "title": "Location",
-                        "description": "Google Cloud Location (e.g. us-central1)"
-                    },
-                    "reasoning_engine_app_name": {
-                        "type": "string",
-                        "title": "Reasoning Engine App Name",
-                        "description": "Reasoning Engine Application Name or ID"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "project_id",
-                    "location",
-                    "reasoning_engine_app_name"
-                ],
-                "title": "AdkVertexAiSessionConfig",
-                "description": "Configuration for Vertex AI Session Service."
-            },
-            "AgentConfig-Input": {
-                "properties": {
-                    "type": { "$ref": "#/components/schemas/AgentFramework" },
-                    "config": {
-                        "anyOf": [
-                            { "$ref": "#/components/schemas/BaseAgentConfig" },
-                            {
-                                "$ref": "#/components/schemas/LangGraphAgentConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/HaystackAgentConfig"
-                            },
-                            { "$ref": "#/components/schemas/AdkAgentConfig" },
-                            {
-                                "$ref": "#/components/schemas/TranslationAgentConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/CorrectionAgentConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/DeepResearchAgentConfig"
-                            }
-                        ],
-                        "title": "Config"
-                    }
-                },
-                "type": "object",
-                "required": ["type", "config"],
-                "title": "AgentConfig",
-                "description": "Configuration for agent specification and settings."
-            },
-            "AgentConfig-Output": {
-                "properties": {
-                    "type": { "$ref": "#/components/schemas/AgentFramework" },
-                    "config": {
-                        "anyOf": [
-                            { "$ref": "#/components/schemas/BaseAgentConfig" },
-                            {
-                                "$ref": "#/components/schemas/LangGraphAgentConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/HaystackAgentConfig"
-                            },
-                            { "$ref": "#/components/schemas/AdkAgentConfig" },
-                            {
-                                "$ref": "#/components/schemas/TranslationAgentConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/CorrectionAgentConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/DeepResearchAgentConfig"
-                            }
-                        ],
-                        "title": "Config"
-                    }
-                },
-                "type": "object",
-                "required": ["type", "config"],
-                "title": "AgentConfig",
-                "description": "Configuration for agent specification and settings."
-            },
-            "AgentFramework": {
-                "type": "string",
-                "enum": [
-                    "LANGGRAPH",
-                    "ADK",
-                    "CREWAI",
-                    "HAYSTACK",
-                    "CUSTOM",
-                    "TRANSLATION_AGENT",
-                    "CORRECTION_AGENT",
-                    "DEEP_RESEARCH_AGENT"
-                ],
-                "title": "AgentFramework",
-                "description": "Supported agent frameworks for engine."
-            },
-            "AgentStatus": {
-                "type": "string",
-                "enum": ["draft", "active", "inactive", "deprecated", "error"],
-                "title": "AgentStatus",
-                "description": "Agent status enumeration."
-            },
-            "ApiKeyResponse": {
-                "properties": {
-                    "api_key": { "type": "string", "title": "Api Key" }
-                },
-                "type": "object",
-                "required": ["api_key"],
-                "title": "ApiKeyResponse",
-                "description": "Response shape for a single agent resource."
-            },
-            "BanListConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "ban_list",
-                        "title": "Config Id",
-                        "default": "ban_list"
-                    },
-                    "banned_words": {
-                        "items": { "type": "string" },
-                        "type": "array",
-                        "title": "Banned Words",
-                        "description": "A list of strings (words or phrases) to block"
-                    }
-                },
-                "type": "object",
-                "required": ["banned_words"],
-                "title": "BanListConfig",
-                "description": "Ban List configuration."
-            },
-            "BaseAgentConfig": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "input_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Input Schema Definition"
-                    },
-                    "output_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Output Schema Definition"
-                    },
-                    "observability": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
-                            },
-                            { "type": "null" }
-                        ]
-                    }
-                },
-                "type": "object",
-                "required": ["name"],
-                "title": "BaseAgentConfig",
-                "description": "Base model for agent configurations. Extend for specific frameworks."
-            },
-            "BiasCheckConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "bias_check",
-                        "title": "Config Id",
-                        "default": "bias_check"
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "maximum": 1.0,
-                        "minimum": 0.0,
-                        "title": "Threshold",
-                        "description": "Sensitivity level for bias detection"
-                    }
-                },
-                "type": "object",
-                "required": ["threshold"],
-                "title": "BiasCheckConfig",
-                "description": "Bias Check configuration."
-            },
-            "CodeScannerConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "code_scanner",
-                        "title": "Config Id",
-                        "default": "code_scanner"
-                    },
-                    "allowed_languages": {
-                        "items": { "type": "string" },
-                        "type": "array",
-                        "title": "Allowed Languages",
-                        "description": "List of allowed programming languages"
-                    }
-                },
-                "type": "object",
-                "required": ["allowed_languages"],
-                "title": "CodeScannerConfig",
-                "description": "Code Scanner configuration."
-            },
-            "CompetitionCheckConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "competition_check",
-                        "title": "Config Id",
-                        "default": "competition_check"
-                    },
-                    "competitors": {
-                        "items": { "type": "string" },
-                        "type": "array",
-                        "title": "Competitors",
-                        "description": "Names of competitor companies or products"
-                    }
-                },
-                "type": "object",
-                "required": ["competitors"],
-                "title": "CompetitionCheckConfig",
-                "description": "Competition Check configuration."
-            },
-            "CorrectLanguageConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "correct_language",
-                        "title": "Config Id",
-                        "default": "correct_language"
-                    },
-                    "expected_languages": {
-                        "items": { "type": "string" },
-                        "type": "array",
-                        "title": "Expected Languages",
-                        "description": "Valid ISO language codes (e.g., en, fr, es)"
-                    }
-                },
-                "type": "object",
-                "required": ["expected_languages"],
-                "title": "CorrectLanguageConfig",
-                "description": "Correct Language configuration."
-            },
-            "CorrectionAgentConfig": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "input_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Input Schema Definition"
-                    },
-                    "output_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Output Schema Definition"
-                    },
-                    "observability": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
-                            },
-                            { "type": "null" }
-                        ]
-                    },
-                    "language": {
-                        "type": "string",
-                        "title": "Language",
-                        "description": "Language to correct text in",
-                        "default": "French"
-                    },
-                    "model_name": {
-                        "type": "string",
-                        "title": "Model Name",
-                        "description": "LLM model to use",
-                        "default": "gemini-2.5-flash"
-                    },
-                    "checkpointer": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/SqliteCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/PostgresCheckpointConfig"
-                            },
-                            { "type": "null" }
-                        ],
-                        "title": "Checkpointer"
-                    }
-                },
-                "type": "object",
-                "required": ["name"],
-                "title": "CorrectionAgentConfig",
-                "description": "Configuration model for the Correction Agent Template."
-            },
-            "CustomLLMConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "custom_llm",
-                        "title": "Config Id",
-                        "default": "custom_llm"
-                    },
-                    "name": {
-                        "type": "string",
-                        "title": "Name",
-                        "description": "Name of the custom LLM config"
-                    },
-                    "model": {
-                        "$ref": "#/components/schemas/CustomLLMModel",
-                        "description": "Specific underlying Large Language Model"
-                    },
-                    "prompt": {
-                        "type": "string",
-                        "title": "Prompt",
-                        "description": "System instruction prompt"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "model", "prompt"],
-                "title": "CustomLLMConfig",
-                "description": "Custom LLM configuration."
-            },
-            "CustomLLMModel": {
-                "type": "string",
-                "enum": [
-                    "Gemini 2.5 flash lite",
-                    "Gemini 2.5 flash",
-                    "Gemini 2.5 pro",
-                    "Gemini 3 pro",
-                    "OpenAi GPT-5.1",
-                    "OpenAi GPT-5 mini",
-                    "OpenAi GPT-5 nano"
-                ],
-                "title": "CustomLLMModel",
-                "description": "Supported models for Custom LLM guardrail."
-            },
-            "DeepResearchAgentConfig": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "input_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Input Schema Definition"
-                    },
-                    "output_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Output Schema Definition"
-                    },
-                    "observability": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
-                            },
-                            { "type": "null" }
-                        ]
-                    },
-                    "model_name": {
-                        "type": "string",
-                        "title": "Model Name",
-                        "description": "LLM model to use",
-                        "default": "gemini-2.5-flash"
-                    },
-                    "project": {
-                        "type": "string",
-                        "title": "Project",
-                        "description": "Project identifier"
-                    },
-                    "region": {
-                        "type": "string",
-                        "title": "Region",
-                        "description": "Region identifier"
-                    },
-                    "tavily_api_key": {
-                        "type": "string",
-                        "title": "Tavily Api Key",
-                        "description": "Tavily API key for web search"
-                    },
-                    "system_prompt": {
-                        "type": "string",
-                        "title": "System Prompt",
-                        "description": "System prompt for the agent",
-                        "default": "Conduct research and write a polished report."
-                    },
-                    "checkpointer": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/SqliteCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/PostgresCheckpointConfig"
-                            },
-                            { "type": "null" }
-                        ],
-                        "title": "Checkpointer"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "project", "region", "tavily_api_key"],
-                "title": "DeepResearchAgentConfig",
-                "description": "Configuration model for the Deep Research Agent Template."
-            },
-            "DetectJailbreakConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "detect_jailbreak",
-                        "title": "Config Id",
-                        "default": "detect_jailbreak"
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "maximum": 1.0,
-                        "minimum": 0.0,
-                        "title": "Threshold",
-                        "description": "Sensitivity level for jailbreak detection"
-                    }
-                },
-                "type": "object",
-                "required": ["threshold"],
-                "title": "DetectJailbreakConfig",
-                "description": "Detect Jailbreak configuration."
-            },
-            "DetectPIIConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "detect_pii",
-                        "title": "Config Id",
-                        "default": "detect_pii"
-                    },
-                    "pii_entities": {
-                        "items": { "$ref": "#/components/schemas/PIIEntity" },
-                        "type": "array",
-                        "title": "Pii Entities",
-                        "description": "List of PII entities to detect"
-                    }
-                },
-                "type": "object",
-                "required": ["pii_entities"],
-                "title": "DetectPIIConfig",
-                "description": "Detect PII configuration."
-            },
-            "EngineConfig-Input": {
-                "properties": {
-                    "server": { "$ref": "#/components/schemas/ServerConfig" },
-                    "agent": {
-                        "$ref": "#/components/schemas/AgentConfig-Input"
-                    },
-                    "mcp_servers": {
-                        "anyOf": [
-                            {
-                                "items": {
-                                    "$ref": "#/components/schemas/MCPServer"
-                                },
-                                "type": "array"
-                            },
-                            { "type": "null" }
-                        ],
-                        "title": "Mcp Servers"
-                    },
-                    "guardrails": {
-                        "anyOf": [
-                            { "$ref": "#/components/schemas/Guardrails-Input" },
-                            { "type": "null" }
-                        ]
-                    }
-                },
-                "type": "object",
-                "required": ["agent"],
-                "title": "EngineConfig",
-                "description": "Main engine configuration model for the entire Idun Agent Engine."
-            },
-            "EngineConfig-Output": {
-                "properties": {
-                    "server": { "$ref": "#/components/schemas/ServerConfig" },
-                    "agent": {
-                        "$ref": "#/components/schemas/AgentConfig-Output"
-                    },
-                    "mcp_servers": {
-                        "anyOf": [
-                            {
-                                "items": {
-                                    "$ref": "#/components/schemas/MCPServer"
-                                },
-                                "type": "array"
-                            },
-                            { "type": "null" }
-                        ],
-                        "title": "Mcp Servers"
-                    },
-                    "guardrails": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/Guardrails-Output"
-                            },
-                            { "type": "null" }
-                        ]
-                    }
-                },
-                "type": "object",
-                "required": ["agent"],
-                "title": "EngineConfig",
-                "description": "Main engine configuration model for the entire Idun Agent Engine."
-            },
-            "GCPLoggingConfig": {
-                "properties": {
-                    "project_id": {
-                        "type": "string",
-                        "title": "Project Id",
-                        "description": "The project identifier where logs and traces will be sent.",
-                        "default": ""
-                    },
-                    "region": {
-                        "type": "string",
-                        "title": "Region",
-                        "description": "(Optional) The specific region/zone associated with the resource (e.g., us-central1).",
-                        "default": ""
-                    },
-                    "log_name": {
-                        "type": "string",
-                        "title": "Log Name",
-                        "description": "The identifier for the log stream (e.g., application-log).",
-                        "default": ""
-                    },
-                    "resource_type": {
-                        "type": "string",
-                        "title": "Resource Type",
-                        "description": "The resource type label (e.g., global, gce_instance, cloud_run_revision).",
-                        "default": ""
-                    },
-                    "severity": {
-                        "type": "string",
-                        "title": "Severity",
-                        "description": "Minimum level to record (e.g., INFO, WARNING, ERROR, CRITICAL).",
-                        "default": "INFO"
-                    },
-                    "transport": {
-                        "type": "string",
-                        "title": "Transport",
-                        "description": "Selection for delivery method (e.g., BackgroundThread vs Synchronous).",
-                        "default": "BackgroundThread"
-                    }
-                },
-                "type": "object",
-                "title": "GCPLoggingConfig",
-                "description": "GCP Logging configuration."
-            },
-            "GCPTraceConfig": {
-                "properties": {
-                    "project_id": {
-                        "type": "string",
-                        "title": "Project Id",
-                        "description": "The project identifier where logs and traces will be sent.",
-                        "default": ""
-                    },
-                    "region": {
-                        "type": "string",
-                        "title": "Region",
-                        "description": "(Optional) The specific region/zone associated with the resource (e.g., us-central1).",
-                        "default": ""
-                    },
-                    "trace_name": {
-                        "type": "string",
-                        "title": "Trace Name",
-                        "description": "The name for the trace or tracing session.",
-                        "default": ""
-                    },
-                    "sampling_rate": {
-                        "type": "number",
-                        "maximum": 1.0,
-                        "minimum": 0.0,
-                        "title": "Sampling Rate",
-                        "description": "A number between 0.0 and 1.0 indicating the probability of a request being traced (e.g., 1.0 for 100%, 0.1 for 10%).",
-                        "default": 1.0
-                    },
-                    "flush_interval": {
-                        "type": "integer",
-                        "minimum": 0.0,
-                        "title": "Flush Interval",
-                        "description": "Time in seconds to wait before sending buffered traces to the cloud.",
-                        "default": 5
-                    },
-                    "ignore_urls": {
-                        "type": "string",
-                        "title": "Ignore Urls",
-                        "description": "A list or comma-separated string of URL paths to exclude from tracing (e.g., /health, /metrics).",
-                        "default": ""
-                    }
-                },
-                "type": "object",
-                "title": "GCPTraceConfig",
-                "description": "GCP Trace configuration."
-            },
-            "GibberishTextConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "gibberish_text",
-                        "title": "Config Id",
-                        "default": "gibberish_text"
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "maximum": 1.0,
-                        "minimum": 0.0,
-                        "title": "Threshold",
-                        "description": "Sensitivity level for gibberish detection"
-                    }
-                },
-                "type": "object",
-                "required": ["threshold"],
-                "title": "GibberishTextConfig",
-                "description": "Gibberish Text configuration."
-            },
-            "Guardrail": {
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/GuardrailType",
-                        "description": "Type of guardrail to use"
-                    },
-                    "config": {
-                        "additionalProperties": true,
-                        "type": "object",
-                        "title": "Config",
-                        "description": "Configuration for the specific guardrail type"
-                    }
-                },
-                "type": "object",
-                "required": ["type", "config"],
-                "title": "Guardrail",
-                "description": "Base class for defining guardrails."
-            },
-            "GuardrailType": {
-                "type": "string",
-                "enum": ["CUSTOM_LLM", "GUARDRAILS_HUB"],
-                "title": "GuardrailType",
-                "description": "Enum for different guardrails."
-            },
-            "Guardrails-Input": {
-                "properties": {
-                    "enabled": {
-                        "type": "boolean",
-                        "title": "Enabled",
-                        "description": "enable/disable guardrails"
-                    },
-                    "input": {
-                        "items": { "$ref": "#/components/schemas/Guardrail" },
-                        "type": "array",
-                        "title": "Input",
-                        "description": "List of guardrails to apply to input messages"
-                    },
-                    "output": {
-                        "items": { "$ref": "#/components/schemas/Guardrail" },
-                        "type": "array",
-                        "title": "Output",
-                        "description": "List of guardrails to apply to output messages"
-                    }
-                },
-                "type": "object",
-                "required": ["enabled"],
-                "title": "Guardrails",
-                "description": "Class for specifying the engine's Guardrails configuration."
-            },
-            "Guardrails-Output": {
-                "properties": {
-                    "enabled": {
-                        "type": "boolean",
-                        "title": "Enabled",
-                        "description": "enable/disable guardrails"
-                    },
-                    "input": {
-                        "items": { "$ref": "#/components/schemas/Guardrail" },
-                        "type": "array",
-                        "title": "Input",
-                        "description": "List of guardrails to apply to input messages"
-                    },
-                    "output": {
-                        "items": { "$ref": "#/components/schemas/Guardrail" },
-                        "type": "array",
-                        "title": "Output",
-                        "description": "List of guardrails to apply to output messages"
-                    }
-                },
-                "type": "object",
-                "required": ["enabled"],
-                "title": "Guardrails",
-                "description": "Class for specifying the engine's Guardrails configuration."
-            },
-            "GuardrailsV2-Input": {
-                "properties": {
-                    "input": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/ModelArmorConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CustomLLMConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/BanListConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/BiasCheckConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CompetitionCheckConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CorrectLanguageConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/DetectPIIConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/GibberishTextConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/NSFWTextConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/DetectJailbreakConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/PromptInjectionConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/RagHallucinationConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/RestrictToTopicConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/ToxicLanguageConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CodeScannerConfig"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Input",
-                        "description": "List of input guardrails"
-                    },
-                    "output": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/ModelArmorConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CustomLLMConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/BanListConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/BiasCheckConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CompetitionCheckConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CorrectLanguageConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/DetectPIIConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/GibberishTextConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/NSFWTextConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/DetectJailbreakConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/PromptInjectionConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/RagHallucinationConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/RestrictToTopicConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/ToxicLanguageConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CodeScannerConfig"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Output",
-                        "description": "List of output guardrails"
-                    }
-                },
-                "type": "object",
-                "title": "GuardrailsV2",
-                "description": "Guardrails V2 configuration."
-            },
-            "GuardrailsV2-Output": {
-                "properties": {
-                    "input": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/ModelArmorConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CustomLLMConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/BanListConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/BiasCheckConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CompetitionCheckConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CorrectLanguageConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/DetectPIIConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/GibberishTextConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/NSFWTextConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/DetectJailbreakConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/PromptInjectionConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/RagHallucinationConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/RestrictToTopicConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/ToxicLanguageConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CodeScannerConfig"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Input",
-                        "description": "List of input guardrails"
-                    },
-                    "output": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/ModelArmorConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CustomLLMConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/BanListConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/BiasCheckConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CompetitionCheckConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CorrectLanguageConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/DetectPIIConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/GibberishTextConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/NSFWTextConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/DetectJailbreakConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/PromptInjectionConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/RagHallucinationConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/RestrictToTopicConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/ToxicLanguageConfig"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/CodeScannerConfig"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Output",
-                        "description": "List of output guardrails"
-                    }
-                },
-                "type": "object",
-                "title": "GuardrailsV2",
-                "description": "Guardrails V2 configuration."
-            },
-            "HTTPValidationError": {
-                "properties": {
-                    "detail": {
-                        "items": {
-                            "$ref": "#/components/schemas/ValidationError"
-                        },
-                        "type": "array",
-                        "title": "Detail"
-                    }
-                },
-                "type": "object",
-                "title": "HTTPValidationError"
-            },
-            "HaystackAgentConfig": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "input_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Input Schema Definition"
-                    },
-                    "output_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Output Schema Definition"
-                    },
-                    "observability": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
-                            },
-                            { "type": "null" }
-                        ]
-                    },
-                    "type": {
-                        "type": "string",
-                        "const": "haystack",
-                        "title": "Type",
-                        "default": "haystack"
-                    },
-                    "component_type": {
-                        "type": "string",
-                        "enum": ["pipeline", "agent"],
-                        "title": "Component Type"
-                    },
-                    "component_definition": {
-                        "type": "string",
-                        "title": "Component Definition"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "component_type", "component_definition"],
-                "title": "HaystackAgentConfig",
-                "description": "Configuration model for Haystack Agents."
-            },
-            "InMemoryCheckpointConfig": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "memory",
-                        "title": "Type"
-                    }
-                },
-                "type": "object",
-                "required": ["type"],
-                "title": "InMemoryCheckpointConfig",
-                "description": "Configuration for In-Memory checkpointer."
-            },
-            "LangGraphAgentConfig": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "input_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Input Schema Definition"
-                    },
-                    "output_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Output Schema Definition"
-                    },
-                    "observability": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
-                            },
-                            { "type": "null" }
-                        ]
-                    },
-                    "graph_definition": {
-                        "type": "string",
-                        "title": "Graph Definition"
-                    },
-                    "checkpointer": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/SqliteCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/PostgresCheckpointConfig"
-                            },
-                            { "type": "null" }
-                        ],
-                        "title": "Checkpointer"
-                    },
-                    "store": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Store"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "graph_definition"],
-                "title": "LangGraphAgentConfig",
-                "description": "Configuration model for LangGraph agents."
-            },
-            "LangfuseConfig": {
-                "properties": {
-                    "host": {
-                        "type": "string",
-                        "title": "Host",
-                        "default": "https://cloud.langfuse.com"
-                    },
-                    "public_key": {
-                        "type": "string",
-                        "title": "Public Key",
-                        "default": ""
-                    },
-                    "secret_key": {
-                        "type": "string",
-                        "title": "Secret Key",
-                        "default": ""
-                    },
-                    "run_name": {
-                        "type": "string",
-                        "title": "Run Name",
-                        "default": ""
-                    }
-                },
-                "type": "object",
-                "title": "LangfuseConfig",
-                "description": "Langfuse configuration."
-            },
-            "LangsmithConfig": {
-                "properties": {
-                    "api_key": {
-                        "type": "string",
-                        "title": "Api Key",
-                        "description": "The unique authentication key from the LangSmith settings page.",
-                        "default": ""
-                    },
-                    "project_name": {
-                        "type": "string",
-                        "title": "Project Name",
-                        "description": "The name of the project in LangSmith to bucket these traces under (e.g., prod-chatbot-v1).",
-                        "default": ""
-                    },
-                    "endpoint": {
-                        "type": "string",
-                        "title": "Endpoint",
-                        "description": "The URL endpoint, used primarily if you are self-hosting LangSmith or using a specific enterprise instance. (e.g., https://api.smith.langchain.com)",
-                        "default": ""
-                    }
-                },
-                "type": "object",
-                "title": "LangsmithConfig",
-                "description": "Langsmith configuration."
-            },
-            "MCPServer": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "title": "Name",
-                        "description": "Unique identifier for this MCP server."
-                    },
-                    "transport": {
-                        "type": "string",
-                        "enum": [
-                            "stdio",
-                            "sse",
-                            "streamable_http",
-                            "websocket"
-                        ],
-                        "title": "Transport",
-                        "description": "Transport type used to reach the MCP server.",
-                        "default": "streamable_http"
-                    },
-                    "url": {
-                        "anyOf": [{ "type": "string" }, { "type": "null" }],
-                        "title": "Url",
-                        "description": "Endpoint URL for HTTP/S based transports (SSE, streamable_http, websocket)."
-                    },
-                    "command": {
-                        "anyOf": [{ "type": "string" }, { "type": "null" }],
-                        "title": "Command",
-                        "description": "Executable to run when using stdio transport."
-                    },
-                    "args": {
-                        "items": { "type": "string" },
-                        "type": "array",
-                        "title": "Args",
-                        "description": "Arguments to pass to the command for stdio transport."
-                    },
-                    "headers": {
-                        "additionalProperties": { "type": "string" },
-                        "type": "object",
-                        "title": "Headers",
-                        "description": "Optional headers for HTTP/S transports."
-                    },
-                    "env": {
-                        "additionalProperties": { "type": "string" },
-                        "type": "object",
-                        "title": "Env",
-                        "description": "Environment variables to set when spawning stdio servers."
-                    },
-                    "cwd": {
-                        "anyOf": [{ "type": "string" }, { "type": "null" }],
-                        "title": "Cwd",
-                        "description": "Working directory for stdio transports."
-                    },
-                    "encoding": {
-                        "anyOf": [{ "type": "string" }, { "type": "null" }],
-                        "title": "Encoding",
-                        "description": "Encoding used for stdio transport."
-                    },
-                    "encoding_error_handler": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "enum": ["strict", "ignore", "replace"]
-                            },
-                            { "type": "null" }
-                        ],
-                        "title": "Encoding Error Handler",
-                        "description": "Encoding error handler for stdio transport."
-                    },
-                    "timeout_seconds": {
-                        "anyOf": [{ "type": "number" }, { "type": "null" }],
-                        "title": "Timeout Seconds",
-                        "description": "Timeout in seconds for HTTP/S transports (maps to `timeout`)."
-                    },
-                    "sse_read_timeout_seconds": {
-                        "anyOf": [{ "type": "number" }, { "type": "null" }],
-                        "title": "Sse Read Timeout Seconds",
-                        "description": "Timeout in seconds waiting for SSE events (maps to `sse_read_timeout`)."
-                    },
-                    "terminate_on_close": {
-                        "anyOf": [{ "type": "boolean" }, { "type": "null" }],
-                        "title": "Terminate On Close",
-                        "description": "Whether to terminate Streamable HTTP sessions on close."
-                    },
-                    "session_kwargs": {
-                        "additionalProperties": true,
-                        "type": "object",
-                        "title": "Session Kwargs",
-                        "description": "Extra keyword arguments forwarded to MCP ClientSession."
-                    }
-                },
-                "type": "object",
-                "required": ["name"],
-                "title": "MCPServer",
-                "description": "Configuration for a single MCP server connection."
-            },
-            "ManagedAgentCreate-Input": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "version": {
-                        "anyOf": [{ "type": "string" }, { "type": "null" }],
-                        "title": "Version",
-                        "description": "Agent version"
-                    },
-                    "engine_config": {
-                        "$ref": "#/components/schemas/EngineConfig-Input",
-                        "description": "Idun Agent Engine configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "engine_config"],
-                "title": "ManagedAgentCreate",
-                "description": "Create managed agent model for requests."
-            },
-            "ManagedAgentCreate-Output": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "version": {
-                        "anyOf": [{ "type": "string" }, { "type": "null" }],
-                        "title": "Version",
-                        "description": "Agent version"
-                    },
-                    "engine_config": {
-                        "$ref": "#/components/schemas/EngineConfig-Output",
-                        "description": "Idun Agent Engine configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "engine_config"],
-                "title": "ManagedAgentCreate",
-                "description": "Create managed agent model for requests."
-            },
-            "ManagedAgentPatch": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "engine_config": {
-                        "$ref": "#/components/schemas/EngineConfig-Input",
-                        "description": "Idun Agent Engine configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "engine_config"],
-                "title": "ManagedAgentPatch",
-                "description": "Full replacement schema for PUT of a managed agent."
-            },
-            "ManagedAgentRead": {
-                "properties": {
-                    "id": { "type": "string", "format": "uuid", "title": "Id" },
-                    "name": { "type": "string", "title": "Name" },
-                    "status": {
-                        "$ref": "#/components/schemas/AgentStatus",
-                        "description": "Agent status",
-                        "default": "draft"
-                    },
-                    "version": {
-                        "anyOf": [{ "type": "string" }, { "type": "null" }],
-                        "title": "Version",
-                        "description": "Agent version"
-                    },
-                    "engine_config": {
-                        "$ref": "#/components/schemas/EngineConfig-Output",
-                        "description": "Idun Agent Engine configuration"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Created At",
-                        "description": "Creation timestamp"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Updated At",
-                        "description": "Last update timestamp"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "name",
-                    "engine_config",
-                    "created_at",
-                    "updated_at"
-                ],
-                "title": "ManagedAgentRead",
-                "description": "Complete managed agent model for responses."
-            },
-            "ManagedGuardrailCreate": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "guardrail": {
-                        "$ref": "#/components/schemas/GuardrailsV2-Input",
-                        "description": "Guardrail configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "guardrail"],
-                "title": "ManagedGuardrailCreate",
-                "description": "Create managed guardrail model for requests."
-            },
-            "ManagedGuardrailPatch": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "guardrail": {
-                        "$ref": "#/components/schemas/GuardrailsV2-Input",
-                        "description": "Guardrail configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "guardrail"],
-                "title": "ManagedGuardrailPatch",
-                "description": "Full replacement schema for PUT of a managed guardrail."
-            },
-            "ManagedGuardrailRead": {
-                "properties": {
-                    "id": { "type": "string", "format": "uuid", "title": "Id" },
-                    "name": { "type": "string", "title": "Name" },
-                    "guardrail": {
-                        "$ref": "#/components/schemas/GuardrailsV2-Output",
-                        "description": "Guardrail configuration"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Created At",
-                        "description": "Creation timestamp"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Updated At",
-                        "description": "Last update timestamp"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "name",
-                    "guardrail",
-                    "created_at",
-                    "updated_at"
-                ],
-                "title": "ManagedGuardrailRead",
-                "description": "Complete managed guardrail model for responses."
-            },
-            "ManagedMCPServerCreate": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "mcp_server": {
-                        "$ref": "#/components/schemas/MCPServer",
-                        "description": "MCP server configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "mcp_server"],
-                "title": "ManagedMCPServerCreate",
-                "description": "Create managed MCP server model for requests."
-            },
-            "ManagedMCPServerPatch": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "mcp_server": {
-                        "$ref": "#/components/schemas/MCPServer",
-                        "description": "MCP server configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "mcp_server"],
-                "title": "ManagedMCPServerPatch",
-                "description": "Full replacement schema for PUT of a managed MCP server."
-            },
-            "ManagedMCPServerRead": {
-                "properties": {
-                    "id": { "type": "string", "format": "uuid", "title": "Id" },
-                    "name": { "type": "string", "title": "Name" },
-                    "mcp_server": {
-                        "$ref": "#/components/schemas/MCPServer",
-                        "description": "MCP server configuration"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Created At",
-                        "description": "Creation timestamp"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Updated At",
-                        "description": "Last update timestamp"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "name",
-                    "mcp_server",
-                    "created_at",
-                    "updated_at"
-                ],
-                "title": "ManagedMCPServerRead",
-                "description": "Complete managed MCP server model for responses."
-            },
-            "ManagedMemoryCreate": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "agent_framework": {
-                        "$ref": "#/components/schemas/AgentFramework",
-                        "description": "Agent framework"
-                    },
-                    "memory": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/SqliteCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/PostgresCheckpointConfig"
-                            }
-                        ],
-                        "title": "Memory",
-                        "description": "Memory (checkpoint) configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "agent_framework", "memory"],
-                "title": "ManagedMemoryCreate",
-                "description": "Create managed memory model for requests."
-            },
-            "ManagedMemoryPatch": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "agent_framework": {
-                        "$ref": "#/components/schemas/AgentFramework",
-                        "description": "Agent framework"
-                    },
-                    "memory": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/SqliteCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/PostgresCheckpointConfig"
-                            }
-                        ],
-                        "title": "Memory",
-                        "description": "Memory (checkpoint) configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "agent_framework", "memory"],
-                "title": "ManagedMemoryPatch",
-                "description": "Full replacement schema for PUT of a managed memory."
-            },
-            "ManagedMemoryRead": {
-                "properties": {
-                    "id": { "type": "string", "format": "uuid", "title": "Id" },
-                    "name": { "type": "string", "title": "Name" },
-                    "agent_framework": {
-                        "$ref": "#/components/schemas/AgentFramework",
-                        "description": "Agent framework"
-                    },
-                    "memory": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/SqliteCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/PostgresCheckpointConfig"
-                            }
-                        ],
-                        "title": "Memory",
-                        "description": "Memory (checkpoint) configuration"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Created At",
-                        "description": "Creation timestamp"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Updated At",
-                        "description": "Last update timestamp"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "name",
-                    "agent_framework",
-                    "memory",
-                    "created_at",
-                    "updated_at"
-                ],
-                "title": "ManagedMemoryRead",
-                "description": "Complete managed memory model for responses."
-            },
-            "ManagedObservabilityCreate": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "observability": {
-                        "$ref": "#/components/schemas/idun_agent_schema__engine__observability_v2__ObservabilityConfig",
-                        "description": "Observability configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "observability"],
-                "title": "ManagedObservabilityCreate",
-                "description": "Create managed observability model for requests."
-            },
-            "ManagedObservabilityPatch": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "observability": {
-                        "$ref": "#/components/schemas/idun_agent_schema__engine__observability_v2__ObservabilityConfig",
-                        "description": "Observability configuration"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "observability"],
-                "title": "ManagedObservabilityPatch",
-                "description": "Full replacement schema for PUT of a managed observability."
-            },
-            "ManagedObservabilityRead": {
-                "properties": {
-                    "id": { "type": "string", "format": "uuid", "title": "Id" },
-                    "name": { "type": "string", "title": "Name" },
-                    "observability": {
-                        "$ref": "#/components/schemas/idun_agent_schema__engine__observability_v2__ObservabilityConfig",
-                        "description": "Observability configuration"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Created At",
-                        "description": "Creation timestamp"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Updated At",
-                        "description": "Last update timestamp"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "name",
-                    "observability",
-                    "created_at",
-                    "updated_at"
-                ],
-                "title": "ManagedObservabilityRead",
-                "description": "Complete managed observability model for responses."
-            },
-            "ModelArmorConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "model_armor",
-                        "title": "Config Id",
-                        "default": "model_armor"
-                    },
-                    "name": {
-                        "type": "string",
-                        "title": "Name",
-                        "description": "Name of the armor config"
-                    },
-                    "project_id": {
-                        "type": "string",
-                        "title": "Project Id",
-                        "description": "ID of the project the model belongs to"
-                    },
-                    "location": {
-                        "type": "string",
-                        "title": "Location",
-                        "description": "Location of the model"
-                    },
-                    "template_id": {
-                        "type": "string",
-                        "title": "Template Id",
-                        "description": "ID of the template"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "project_id", "location", "template_id"],
-                "title": "ModelArmorConfig",
-                "description": "Model Armor configuration."
-            },
-            "NSFWTextConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "nsfw_text",
-                        "title": "Config Id",
-                        "default": "nsfw_text"
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "maximum": 1.0,
-                        "minimum": 0.0,
-                        "title": "Threshold",
-                        "description": "Sensitivity level for NSFW content"
-                    }
-                },
-                "type": "object",
-                "required": ["threshold"],
-                "title": "NSFWTextConfig",
-                "description": "NSFW Text configuration."
-            },
-            "ObservabilityProvider": {
-                "type": "string",
-                "enum": [
-                    "LANGFUSE",
-                    "PHOENIX",
-                    "GCP_LOGGING",
-                    "GCP_TRACE",
-                    "LANGSMITH"
-                ],
-                "title": "ObservabilityProvider",
-                "description": "Supported observability providers."
-            },
-            "PIIEntity": {
-                "type": "string",
-                "enum": [
-                    "Email",
-                    "Phone Number",
-                    "Credit Card",
-                    "SSN",
-                    "Location"
-                ],
-                "title": "PIIEntity",
-                "description": "Personally Identifiable Information entities."
-            },
-            "PhoenixConfig": {
-                "properties": {
-                    "collector_endpoint": {
-                        "type": "string",
-                        "title": "Collector Endpoint",
-                        "default": "https://collector.phoenix.com"
-                    },
-                    "project_name": {
-                        "type": "string",
-                        "title": "Project Name",
-                        "default": ""
-                    }
-                },
-                "type": "object",
-                "title": "PhoenixConfig",
-                "description": "Phoenix configuration."
-            },
-            "PostgresCheckpointConfig": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "postgres",
-                        "title": "Type"
-                    },
-                    "db_url": { "type": "string", "title": "Db Url" }
-                },
-                "type": "object",
-                "required": ["type", "db_url"],
-                "title": "PostgresCheckpointConfig",
-                "description": "Configuration for Postgres checkpointer."
-            },
-            "PromptInjectionConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "prompt_injection",
-                        "title": "Config Id",
-                        "default": "prompt_injection"
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "maximum": 1.0,
-                        "minimum": 0.0,
-                        "title": "Threshold",
-                        "description": "Sensitivity level for prompt injection"
-                    }
-                },
-                "type": "object",
-                "required": ["threshold"],
-                "title": "PromptInjectionConfig",
-                "description": "Prompt Injection configuration."
-            },
-            "RagHallucinationConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "rag_hallucination",
-                        "title": "Config Id",
-                        "default": "rag_hallucination"
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "maximum": 1.0,
-                        "minimum": 0.0,
-                        "title": "Threshold",
-                        "description": "Sensitivity level for hallucination detection"
-                    }
-                },
-                "type": "object",
-                "required": ["threshold"],
-                "title": "RagHallucinationConfig",
-                "description": "RAG Hallucination configuration."
-            },
-            "RestrictToTopicConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "restrict_to_topic",
-                        "title": "Config Id",
-                        "default": "restrict_to_topic"
-                    },
-                    "topics": {
-                        "items": { "type": "string" },
-                        "type": "array",
-                        "title": "Topics",
-                        "description": "List of allowed topics"
-                    }
-                },
-                "type": "object",
-                "required": ["topics"],
-                "title": "RestrictToTopicConfig",
-                "description": "Restrict To Topic configuration."
-            },
-            "ServerAPIConfig": {
-                "properties": {
-                    "port": {
-                        "type": "integer",
-                        "title": "Port",
-                        "default": 8000
-                    }
-                },
-                "type": "object",
-                "title": "ServerAPIConfig",
-                "description": "API server configuration."
-            },
-            "ServerConfig": {
-                "properties": {
-                    "api": { "$ref": "#/components/schemas/ServerAPIConfig" }
-                },
-                "type": "object",
-                "title": "ServerConfig",
-                "description": "Configuration for the Engine's universal settings."
-            },
-            "SqliteCheckpointConfig": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "sqlite",
-                        "title": "Type"
-                    },
-                    "db_url": { "type": "string", "title": "Db Url" }
-                },
-                "type": "object",
-                "required": ["type", "db_url"],
-                "title": "SqliteCheckpointConfig",
-                "description": "Configuration for SQLite checkpointer."
-            },
-            "ToxicLanguageConfig": {
-                "properties": {
-                    "config_id": {
-                        "type": "string",
-                        "const": "toxic_language",
-                        "title": "Config Id",
-                        "default": "toxic_language"
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "maximum": 1.0,
-                        "minimum": 0.0,
-                        "title": "Threshold",
-                        "description": "Sensitivity level for toxic language"
-                    }
-                },
-                "type": "object",
-                "required": ["threshold"],
-                "title": "ToxicLanguageConfig",
-                "description": "Toxic Language configuration."
-            },
-            "TranslationAgentConfig": {
-                "properties": {
-                    "name": { "type": "string", "title": "Name" },
-                    "input_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Input Schema Definition"
-                    },
-                    "output_schema_definition": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Output Schema Definition"
-                    },
-                    "observability": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
-                            },
-                            { "type": "null" }
-                        ]
-                    },
-                    "graph_definition": {
-                        "type": "string",
-                        "title": "Graph Definition"
-                    },
-                    "checkpointer": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/SqliteCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
-                            },
-                            {
-                                "$ref": "#/components/schemas/PostgresCheckpointConfig"
-                            },
-                            { "type": "null" }
-                        ],
-                        "title": "Checkpointer"
-                    },
-                    "store": {
-                        "anyOf": [
-                            { "additionalProperties": true, "type": "object" },
-                            { "type": "null" }
-                        ],
-                        "title": "Store"
-                    },
-                    "source_lang": {
-                        "type": "string",
-                        "title": "Source Lang",
-                        "description": "Source language to translate from",
-                        "default": "English"
-                    },
-                    "target_lang": {
-                        "type": "string",
-                        "title": "Target Lang",
-                        "description": "Target language to translate to",
-                        "default": "French"
-                    },
-                    "model_name": {
-                        "type": "string",
-                        "title": "Model Name",
-                        "description": "LLM model to use",
-                        "default": "gpt-3.5-turbo"
-                    }
-                },
-                "type": "object",
-                "required": ["name", "graph_definition"],
-                "title": "TranslationAgentConfig",
-                "description": "Configuration model for the Translation Agent Template."
-            },
-            "ValidationError": {
-                "properties": {
-                    "loc": {
-                        "items": {
-                            "anyOf": [
-                                { "type": "string" },
-                                { "type": "integer" }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Location"
-                    },
-                    "msg": { "type": "string", "title": "Message" },
-                    "type": { "type": "string", "title": "Error Type" }
-                },
-                "type": "object",
-                "required": ["loc", "msg", "type"],
-                "title": "ValidationError"
-            },
-            "idun_agent_schema__engine__observability__ObservabilityConfig": {
-                "properties": {
-                    "provider": {
-                        "anyOf": [{ "type": "string" }, { "type": "null" }],
-                        "title": "Provider"
-                    },
-                    "enabled": {
-                        "type": "boolean",
-                        "title": "Enabled",
-                        "default": false
-                    },
-                    "options": {
-                        "additionalProperties": true,
-                        "type": "object",
-                        "title": "Options"
-                    }
-                },
-                "type": "object",
-                "title": "ObservabilityConfig",
-                "description": "Provider-agnostic observability configuration based on Pydantic.\n\nExample YAML:\n  observability:\n    provider: \"langfuse\"  # or \"phoenix\"\n    enabled: true\n    options:\n      host: ${LANGFUSE_HOST}\n      public_key: ${LANGFUSE_PUBLIC_KEY}\n      secret_key: ${LANGFUSE_SECRET_KEY}\n      run_name: \"my-run\""
-            },
-            "idun_agent_schema__engine__observability_v2__ObservabilityConfig": {
-                "properties": {
-                    "provider": {
-                        "$ref": "#/components/schemas/ObservabilityProvider",
-                        "default": "LANGFUSE"
-                    },
-                    "enabled": {
-                        "type": "boolean",
-                        "title": "Enabled",
-                        "default": true
-                    },
-                    "config": {
-                        "anyOf": [
-                            { "$ref": "#/components/schemas/LangfuseConfig" },
-                            { "$ref": "#/components/schemas/PhoenixConfig" },
-                            { "$ref": "#/components/schemas/GCPLoggingConfig" },
-                            { "$ref": "#/components/schemas/GCPTraceConfig" },
-                            { "$ref": "#/components/schemas/LangsmithConfig" }
-                        ],
-                        "title": "Config"
-                    }
-                },
-                "type": "object",
-                "required": ["config"],
-                "title": "ObservabilityConfig",
-                "description": "Observability configuration."
+    "/api/v1/auth/callback": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "OIDC callback",
+        "description": "Exchanges the authorization code for tokens and sets a session cookie.",
+        "operationId": "callback_api_v1_auth_callback_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
             }
+          }
         }
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Get current session",
+        "description": "Returns the current user session with fresh workspace data from DB.",
+        "operationId": "me_api_v1_auth_me_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Me Api V1 Auth Me Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Logout",
+        "description": "Clears the session cookie.",
+        "operationId": "logout_api_v1_auth_logout_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "type": "object",
+                  "title": "Response Logout Api V1 Auth Logout Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/basic/signup": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Basic Signup",
+        "operationId": "basic_signup_api_v1_auth_basic_signup_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Basic Signup Api V1 Auth Basic Signup Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/basic/login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Basic Login",
+        "operationId": "basic_login_api_v1_auth_basic_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Basic Login Api V1 Auth Basic Login Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/": {
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Create managed agent",
+        "description": "Create a new managed agent with an EngineConfig. The agent is created in DRAFT status.",
+        "operationId": "create_agent_api_v1_agents__post",
+        "parameters": [
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedAgentCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedAgentRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "List managed agents",
+        "description": "List all managed agents with pagination.",
+        "operationId": "list_agents_api_v1_agents__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedAgentRead"
+                  },
+                  "title": "Response List Agents Api V1 Agents  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/key": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Generate agent API key",
+        "description": "Generate a unique API key (hash) for an agent to authenticate API requests.",
+        "operationId": "generate_key_api_v1_agents_key_get",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/config": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Get agent config by API key",
+        "description": "Retrieve agent configuration using API key authentication (Bearer token).",
+        "operationId": "config_api_v1_agents_config_get",
+        "parameters": [
+          {
+            "name": "auth",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Auth"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedAgentRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/{id}": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Get managed agent by ID",
+        "description": "Retrieve a specific managed agent by its UUID with complete configuration details.",
+        "operationId": "get_agent_api_v1_agents__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedAgentRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Delete managed agent",
+        "description": "Permanently delete a managed agent and all its configuration data.",
+        "operationId": "delete_agent_api_v1_agents__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Partially update agent (PATCH)",
+        "description": "Partially update an agent's configuration. Only the name and engine_config field can be updated if provided.",
+        "operationId": "patch_agent_api_v1_agents__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedAgentPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedAgentRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/{id}/status": {
+      "put": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Update agent status",
+        "description": "Update only the status field of an agent. Used by the health check flow to set active/draft without touching config.",
+        "operationId": "update_agent_status_api_v1_agents__id__status_put",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedAgentStatusUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedAgentRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/healthz": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Health Check",
+        "description": "Basic health check.",
+        "operationId": "health_check_api_v1_healthz_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Health Check Api V1 Healthz Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/readyz": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Readiness Check",
+        "description": "Readiness check including database connectivity.",
+        "operationId": "readiness_check_api_v1_readyz_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Readiness Check Api V1 Readyz Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/version": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Version",
+        "description": "Get application version and name from FastAPI app metadata.",
+        "operationId": "version_api_v1_version_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Version Api V1 Version Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp-servers/": {
+      "post": {
+        "tags": [
+          "MCP Servers"
+        ],
+        "summary": "Create managed MCP server",
+        "description": "Create a new managed MCP server configuration.",
+        "operationId": "create_mcp_server_api_v1_mcp_servers__post",
+        "parameters": [
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedMCPServerCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedMCPServerRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "MCP Servers"
+        ],
+        "summary": "List managed MCP servers",
+        "description": "List managed MCP server configurations with pagination.",
+        "operationId": "list_mcp_servers_api_v1_mcp_servers__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedMCPServerRead"
+                  },
+                  "title": "Response List Mcp Servers Api V1 Mcp Servers  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp-servers/{id}": {
+      "get": {
+        "tags": [
+          "MCP Servers"
+        ],
+        "summary": "Get managed MCP server by ID",
+        "description": "Get a managed MCP server configuration by ID.",
+        "operationId": "get_mcp_server_api_v1_mcp_servers__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedMCPServerRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "MCP Servers"
+        ],
+        "summary": "Delete managed MCP server",
+        "description": "Delete a managed MCP server configuration permanently.",
+        "operationId": "delete_mcp_server_api_v1_mcp_servers__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "MCP Servers"
+        ],
+        "summary": "Update managed MCP server",
+        "description": "Update an MCP server configuration.",
+        "operationId": "patch_mcp_server_api_v1_mcp_servers__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedMCPServerPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedMCPServerRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp-servers/{id}/tools": {
+      "post": {
+        "tags": [
+          "MCP Servers"
+        ],
+        "summary": "Discover tools from an MCP server",
+        "description": "Connect to an MCP server and return its available tools.",
+        "operationId": "discover_tools_api_v1_mcp_servers__id__tools_post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MCPToolsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/observability/": {
+      "post": {
+        "tags": [
+          "Observability"
+        ],
+        "summary": "Create managed observability config",
+        "description": "Create a new managed observability configuration.",
+        "operationId": "create_observability_api_v1_observability__post",
+        "parameters": [
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedObservabilityCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedObservabilityRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Observability"
+        ],
+        "summary": "List managed observability configs",
+        "description": "List managed observability configurations with pagination.",
+        "operationId": "list_observabilities_api_v1_observability__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedObservabilityRead"
+                  },
+                  "title": "Response List Observabilities Api V1 Observability  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/observability/{id}": {
+      "get": {
+        "tags": [
+          "Observability"
+        ],
+        "summary": "Get managed observability config by ID",
+        "description": "Get a managed observability configuration by ID.",
+        "operationId": "get_observability_api_v1_observability__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedObservabilityRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Observability"
+        ],
+        "summary": "Delete managed observability config",
+        "description": "Delete a managed observability configuration permanently.",
+        "operationId": "delete_observability_api_v1_observability__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Observability"
+        ],
+        "summary": "Update managed observability config",
+        "description": "Update an observability configuration.",
+        "operationId": "patch_observability_api_v1_observability__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedObservabilityPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedObservabilityRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/memory/": {
+      "post": {
+        "tags": [
+          "Memory"
+        ],
+        "summary": "Create managed memory config",
+        "description": "Create a new managed memory configuration.",
+        "operationId": "create_memory_api_v1_memory__post",
+        "parameters": [
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedMemoryCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedMemoryRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Memory"
+        ],
+        "summary": "List managed memory configs",
+        "description": "List managed memory configurations with pagination.",
+        "operationId": "list_memories_api_v1_memory__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "agent_framework",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/AgentFramework"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Framework"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedMemoryRead"
+                  },
+                  "title": "Response List Memories Api V1 Memory  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/memory/{id}": {
+      "get": {
+        "tags": [
+          "Memory"
+        ],
+        "summary": "Get managed memory config by ID",
+        "description": "Get a managed memory configuration by ID.",
+        "operationId": "get_memory_api_v1_memory__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedMemoryRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Memory"
+        ],
+        "summary": "Delete managed memory config",
+        "description": "Delete a managed memory configuration permanently.",
+        "operationId": "delete_memory_api_v1_memory__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Memory"
+        ],
+        "summary": "Update managed memory config",
+        "description": "Update a memory configuration.",
+        "operationId": "patch_memory_api_v1_memory__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedMemoryPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedMemoryRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agent-frameworks/": {
+      "get": {
+        "tags": [
+          "Agent Frameworks"
+        ],
+        "summary": "List available agent frameworks",
+        "description": "Retrieve the list of supported agent frameworks in the platform.",
+        "operationId": "list_agent_frameworks_api_v1_agent_frameworks__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "title": "Response List Agent Frameworks Api V1 Agent Frameworks  Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/guardrails/": {
+      "post": {
+        "tags": [
+          "Guardrails"
+        ],
+        "summary": "Create managed guardrail config",
+        "description": "Create a new managed guardrail configuration.",
+        "operationId": "create_guardrail_api_v1_guardrails__post",
+        "parameters": [
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedGuardrailCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedGuardrailRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Guardrails"
+        ],
+        "summary": "List managed guardrail configs",
+        "description": "List managed guardrail configurations with pagination.",
+        "operationId": "list_guardrails_api_v1_guardrails__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedGuardrailRead"
+                  },
+                  "title": "Response List Guardrails Api V1 Guardrails  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/guardrails/{id}": {
+      "get": {
+        "tags": [
+          "Guardrails"
+        ],
+        "summary": "Get managed guardrail config by ID",
+        "description": "Get a managed guardrail configuration by ID.",
+        "operationId": "get_guardrail_api_v1_guardrails__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedGuardrailRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Guardrails"
+        ],
+        "summary": "Delete managed guardrail config",
+        "description": "Delete a managed guardrail configuration permanently.",
+        "operationId": "delete_guardrail_api_v1_guardrails__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Guardrails"
+        ],
+        "summary": "Update managed guardrail config",
+        "description": "Update a guardrail configuration.",
+        "operationId": "patch_guardrail_api_v1_guardrails__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedGuardrailPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedGuardrailRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspaces/": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "List workspaces for current user",
+        "description": "Return all workspaces the current user is a member of.",
+        "operationId": "list_workspaces_api_v1_workspaces__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceRead"
+                  },
+                  "title": "Response List Workspaces Api V1 Workspaces  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Create a new workspace",
+        "description": "Create a workspace and add the current user as owner.",
+        "operationId": "create_workspace_api_v1_workspaces__post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspace_id}": {
+      "patch": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Update workspace",
+        "description": "Update a workspace name. Requires admin or owner role.",
+        "operationId": "patch_workspace_api_v1_workspaces__workspace_id__patch",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspacePatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Delete workspace (owner only)",
+        "description": "Delete a workspace. Only owners can delete workspaces.",
+        "operationId": "delete_workspace_api_v1_workspaces__workspace_id__delete",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/sso/": {
+      "post": {
+        "tags": [
+          "SSO"
+        ],
+        "summary": "Create managed SSO config",
+        "description": "Create a new managed SSO configuration.",
+        "operationId": "create_sso_api_v1_sso__post",
+        "parameters": [
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedSSOCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedSSORead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "SSO"
+        ],
+        "summary": "List managed SSO configs",
+        "description": "List managed SSO configurations with pagination.",
+        "operationId": "list_ssos_api_v1_sso__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedSSORead"
+                  },
+                  "title": "Response List Ssos Api V1 Sso  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/sso/{id}": {
+      "get": {
+        "tags": [
+          "SSO"
+        ],
+        "summary": "Get managed SSO config by ID",
+        "description": "Get a managed SSO configuration by ID.",
+        "operationId": "get_sso_api_v1_sso__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedSSORead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "SSO"
+        ],
+        "summary": "Delete managed SSO config",
+        "description": "Delete a managed SSO configuration permanently.",
+        "operationId": "delete_sso_api_v1_sso__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "SSO"
+        ],
+        "summary": "Update managed SSO config",
+        "description": "Update an SSO configuration.",
+        "operationId": "patch_sso_api_v1_sso__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedSSOPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedSSORead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/integrations/": {
+      "post": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "Create managed integration",
+        "description": "Create a new managed integration configuration.",
+        "operationId": "create_integration_api_v1_integrations__post",
+        "parameters": [
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedIntegrationCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedIntegrationRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "List managed integrations",
+        "description": "List managed integration configurations with pagination.",
+        "operationId": "list_integrations_api_v1_integrations__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedIntegrationRead"
+                  },
+                  "title": "Response List Integrations Api V1 Integrations  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/integrations/{id}": {
+      "get": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "Get managed integration by ID",
+        "description": "Get a managed integration configuration by ID.",
+        "operationId": "get_integration_api_v1_integrations__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedIntegrationRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "Delete managed integration",
+        "description": "Delete a managed integration configuration permanently.",
+        "operationId": "delete_integration_api_v1_integrations__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "Update managed integration",
+        "description": "Update an integration configuration.",
+        "operationId": "patch_integration_api_v1_integrations__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedIntegrationPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedIntegrationRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspace_id}/members": {
+      "get": {
+        "tags": [
+          "Workspace Members"
+        ],
+        "summary": "List workspace members",
+        "description": "Return all members of a workspace with user details.",
+        "operationId": "list_members_api_v1_workspaces__workspace_id__members_get",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Workspace Members"
+        ],
+        "summary": "Add a user to the workspace or create a pending invitation",
+        "description": "Add an existing user or create a pending invitation by email.",
+        "operationId": "add_member_api_v1_workspaces__workspace_id__members_post",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberAdd"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MemberRead"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvitationRead"
+                    }
+                  ],
+                  "title": "Response Add Member Api V1 Workspaces  Workspace Id  Members Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspace_id}/members/{membership_id}": {
+      "patch": {
+        "tags": [
+          "Workspace Members"
+        ],
+        "summary": "Update a member's role",
+        "description": "Change a workspace member's role.",
+        "operationId": "update_member_role_api_v1_workspaces__workspace_id__members__membership_id__patch",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "membership_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Membership Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Workspace Members"
+        ],
+        "summary": "Remove a member from the workspace",
+        "description": "Remove a member from the workspace.",
+        "operationId": "remove_member_api_v1_workspaces__workspace_id__members__membership_id__delete",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "membership_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Membership Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspace_id}/invitations/{invitation_id}": {
+      "delete": {
+        "tags": [
+          "Workspace Members"
+        ],
+        "summary": "Cancel a pending invitation",
+        "description": "Cancel a pending workspace invitation.",
+        "operationId": "cancel_invitation_api_v1_workspaces__workspace_id__invitations__invitation_id__delete",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "invitation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Invitation Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/prompts/": {
+      "post": {
+        "tags": [
+          "Prompts"
+        ],
+        "summary": "Create a new prompt version",
+        "description": "Create a new prompt version.\n\nAuto-increments the version number for the given ``prompt_id`` within the\nworkspace.  The ``latest`` tag is added automatically and removed from any\nprevious version that carried it.",
+        "operationId": "create_prompt_api_v1_prompts__post",
+        "parameters": [
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedPromptCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedPromptRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Prompts"
+        ],
+        "summary": "List prompts",
+        "description": "List prompts with optional filters and pagination.",
+        "operationId": "list_prompts_api_v1_prompts__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "prompt_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Prompt Id"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tag"
+            }
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Version"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedPromptRead"
+                  },
+                  "title": "Response List Prompts Api V1 Prompts  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/prompts/agent/{agent_id}": {
+      "get": {
+        "tags": [
+          "Prompts"
+        ],
+        "summary": "List prompts assigned to an agent",
+        "description": "List all prompts assigned to a specific agent.",
+        "operationId": "list_agent_prompts_api_v1_prompts_agent__agent_id__get",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedPromptRead"
+                  },
+                  "title": "Response List Agent Prompts Api V1 Prompts Agent  Agent Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/prompts/{id}": {
+      "get": {
+        "tags": [
+          "Prompts"
+        ],
+        "summary": "Get prompt by ID",
+        "description": "Get a prompt by its UUID.",
+        "operationId": "get_prompt_api_v1_prompts__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedPromptRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Prompts"
+        ],
+        "summary": "Update prompt tags",
+        "description": "Update a prompt's tags. Content is immutable.\n\nThe ``latest`` tag is auto-managed and cannot be manually added or removed.",
+        "operationId": "patch_prompt_api_v1_prompts__id__patch",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagedPromptPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedPromptRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Prompts"
+        ],
+        "summary": "Delete prompt",
+        "description": "Delete a prompt version permanently.\n\nIf the deleted version carried the ``latest`` tag, the next-highest\nversion is promoted automatically.",
+        "operationId": "delete_prompt_api_v1_prompts__id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/prompts/{id}/assign/{agent_id}": {
+      "post": {
+        "tags": [
+          "Prompts"
+        ],
+        "summary": "Assign prompt to agent",
+        "description": "Assign a prompt to an agent. Both must belong to the same workspace.",
+        "operationId": "assign_prompt_api_v1_prompts__id__assign__agent_id__post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Assign Prompt Api V1 Prompts  Id  Assign  Agent Id  Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Prompts"
+        ],
+        "summary": "Unassign prompt from agent",
+        "description": "Remove a prompt assignment from an agent.",
+        "operationId": "unassign_prompt_api_v1_prompts__id__assign__agent_id__delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "x-workspace-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
+  },
+  "components": {
+    "schemas": {
+      "AdkAgentConfig": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "(Deprecated) Observability config is deprecated and will be removed in a future release.",
+            "deprecated": true
+          },
+          "agent": {
+            "type": "string",
+            "title": "Agent",
+            "description": "Agent definition (e.g. module.path:agent_instance)"
+          },
+          "app_name": {
+            "type": "string",
+            "title": "App Name",
+            "description": "Application name for the agent"
+          },
+          "session_service": {
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AdkInMemorySessionConfig"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdkVertexAiSessionConfig"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdkDatabaseSessionConfig"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type",
+                  "mapping": {
+                    "database": "#/components/schemas/AdkDatabaseSessionConfig",
+                    "in_memory": "#/components/schemas/AdkInMemorySessionConfig",
+                    "vertex_ai": "#/components/schemas/AdkVertexAiSessionConfig"
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Service",
+            "description": "Session service configuration"
+          },
+          "memory_service": {
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AdkInMemoryMemoryConfig"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdkVertexAiMemoryConfig"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type",
+                  "mapping": {
+                    "in_memory": "#/components/schemas/AdkInMemoryMemoryConfig",
+                    "vertex_ai": "#/components/schemas/AdkVertexAiMemoryConfig"
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Service",
+            "description": "Memory service configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "agent",
+          "app_name"
+        ],
+        "title": "AdkAgentConfig",
+        "description": "Configuration model for ADK agents."
+      },
+      "AdkDatabaseSessionConfig": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "database",
+            "title": "Type",
+            "default": "database"
+          },
+          "db_url": {
+            "type": "string",
+            "title": "Db Url",
+            "description": "Database URL (e.g. postgresql://...)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "db_url"
+        ],
+        "title": "AdkDatabaseSessionConfig",
+        "description": "Configuration for Database Session Service."
+      },
+      "AdkInMemoryMemoryConfig": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "in_memory",
+            "title": "Type",
+            "default": "in_memory"
+          }
+        },
+        "type": "object",
+        "title": "AdkInMemoryMemoryConfig",
+        "description": "Configuration for In-Memory Memory Service."
+      },
+      "AdkInMemorySessionConfig": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "in_memory",
+            "title": "Type",
+            "default": "in_memory"
+          }
+        },
+        "type": "object",
+        "title": "AdkInMemorySessionConfig",
+        "description": "Configuration for In-Memory Session Service."
+      },
+      "AdkVertexAiMemoryConfig": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "vertex_ai",
+            "title": "Type",
+            "default": "vertex_ai"
+          },
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "description": "Google Cloud Project ID"
+          },
+          "location": {
+            "type": "string",
+            "title": "Location",
+            "description": "Google Cloud Location"
+          },
+          "memory_bank_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Bank Id",
+            "description": "Vertex AI Memory Bank Resource ID"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project_id",
+          "location"
+        ],
+        "title": "AdkVertexAiMemoryConfig",
+        "description": "Configuration for Vertex AI Memory Service."
+      },
+      "AdkVertexAiSessionConfig": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "vertex_ai",
+            "title": "Type",
+            "default": "vertex_ai"
+          },
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "description": "Google Cloud Project ID"
+          },
+          "location": {
+            "type": "string",
+            "title": "Location",
+            "description": "Google Cloud Location (e.g. us-central1)"
+          },
+          "reasoning_engine_app_name": {
+            "type": "string",
+            "title": "Reasoning Engine App Name",
+            "description": "Reasoning Engine Application Name or ID"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project_id",
+          "location",
+          "reasoning_engine_app_name"
+        ],
+        "title": "AdkVertexAiSessionConfig",
+        "description": "Configuration for Vertex AI Session Service."
+      },
+      "AgentConfig": {
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/AgentFramework"
+          },
+          "config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LangGraphAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/HaystackAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/AdkAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/TranslationAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/CorrectionAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/DeepResearchAgentConfig"
+              },
+              {
+                "$ref": "#/components/schemas/BaseAgentConfig"
+              }
+            ],
+            "title": "Config"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "config"
+        ],
+        "title": "AgentConfig",
+        "description": "Configuration for agent specification and settings."
+      },
+      "AgentFramework": {
+        "type": "string",
+        "enum": [
+          "LANGGRAPH",
+          "ADK",
+          "CREWAI",
+          "HAYSTACK",
+          "CUSTOM",
+          "TRANSLATION_AGENT",
+          "CORRECTION_AGENT",
+          "DEEP_RESEARCH_AGENT"
+        ],
+        "title": "AgentFramework",
+        "description": "Supported agent frameworks for engine."
+      },
+      "AgentResourceIds": {
+        "properties": {
+          "memory_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Id"
+          },
+          "sso_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sso Id"
+          },
+          "guardrail_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/GuardrailRef"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guardrail Ids"
+          },
+          "mcp_server_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mcp Server Ids"
+          },
+          "observability_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observability Ids"
+          },
+          "integration_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Integration Ids"
+          }
+        },
+        "type": "object",
+        "title": "AgentResourceIds",
+        "description": "Resource IDs for agent associations (source of truth for relations)."
+      },
+      "AgentStatus": {
+        "type": "string",
+        "enum": [
+          "draft",
+          "active",
+          "inactive",
+          "deprecated",
+          "error"
+        ],
+        "title": "AgentStatus",
+        "description": "Agent status enumeration."
+      },
+      "ApiKeyResponse": {
+        "properties": {
+          "api_key": {
+            "type": "string",
+            "title": "Api Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "api_key"
+        ],
+        "title": "ApiKeyResponse",
+        "description": "Response shape for a single agent resource."
+      },
+      "BanListConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "ban_list",
+            "title": "Config Id",
+            "default": "ban_list"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "ban!!"
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/ban_list"
+          },
+          "banned_words": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Banned Words",
+            "description": "A list of strings (words or phrases) to block"
+          }
+        },
+        "type": "object",
+        "required": [
+          "banned_words"
+        ],
+        "title": "BanListConfig",
+        "description": "Ban List configuration."
+      },
+      "BaseAgentConfig": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "(Deprecated) Observability config is deprecated and will be removed in a future release.",
+            "deprecated": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "BaseAgentConfig",
+        "description": "Base model for agent configurations. Extend for specific frameworks."
+      },
+      "BiasCheckConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "bias_check",
+            "title": "Config Id",
+            "default": "bias_check"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/bias_check"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Bias detected"
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for bias detection"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "BiasCheckConfig",
+        "description": "Bias Check configuration."
+      },
+      "CodeScannerConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "code_scanner",
+            "title": "Config Id",
+            "default": "code_scanner"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/code_scanner"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Unauthorized code detected"
+          },
+          "allowed_languages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Allowed Languages",
+            "description": "List of allowed programming languages"
+          }
+        },
+        "type": "object",
+        "required": [
+          "allowed_languages"
+        ],
+        "title": "CodeScannerConfig",
+        "description": "Code Scanner configuration."
+      },
+      "CompetitionCheckConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "competition_check",
+            "title": "Config Id",
+            "default": "competition_check"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/competitor_check"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Competitor mentioned"
+          },
+          "competitors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Competitors",
+            "description": "Names of competitor companies or products"
+          }
+        },
+        "type": "object",
+        "required": [
+          "competitors"
+        ],
+        "title": "CompetitionCheckConfig",
+        "description": "Competition Check configuration."
+      },
+      "CorrectLanguageConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "correct_language",
+            "title": "Config Id",
+            "default": "correct_language"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://scb-10x/correct_language"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Incorrect language detected"
+          },
+          "expected_languages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Expected Languages",
+            "description": "Valid ISO language codes (e.g., en, fr, es)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "expected_languages"
+        ],
+        "title": "CorrectLanguageConfig",
+        "description": "Correct Language configuration."
+      },
+      "CorrectionAgentConfig": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "(Deprecated) Observability config is deprecated and will be removed in a future release.",
+            "deprecated": true
+          },
+          "language": {
+            "type": "string",
+            "title": "Language",
+            "description": "Language to correct text in",
+            "default": "French"
+          },
+          "model_name": {
+            "type": "string",
+            "title": "Model Name",
+            "description": "LLM model to use",
+            "default": "gemini-2.5-flash"
+          },
+          "checkpointer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SqliteCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/PostgresCheckpointConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checkpointer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CorrectionAgentConfig",
+        "description": "Configuration model for the Correction Agent Template."
+      },
+      "DeepResearchAgentConfig": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "(Deprecated) Observability config is deprecated and will be removed in a future release.",
+            "deprecated": true
+          },
+          "model_name": {
+            "type": "string",
+            "title": "Model Name",
+            "description": "LLM model to use",
+            "default": "gemini-2.5-flash"
+          },
+          "project": {
+            "type": "string",
+            "title": "Project",
+            "description": "Project identifier"
+          },
+          "region": {
+            "type": "string",
+            "title": "Region",
+            "description": "Region identifier"
+          },
+          "tavily_api_key": {
+            "type": "string",
+            "title": "Tavily Api Key",
+            "description": "Tavily API key for web search"
+          },
+          "system_prompt": {
+            "type": "string",
+            "title": "System Prompt",
+            "description": "System prompt for the agent",
+            "default": "Conduct research and write a polished report."
+          },
+          "checkpointer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SqliteCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/PostgresCheckpointConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checkpointer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "project",
+          "region",
+          "tavily_api_key"
+        ],
+        "title": "DeepResearchAgentConfig",
+        "description": "Configuration model for the Deep Research Agent Template."
+      },
+      "DetectJailbreakConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "detect_jailbreak",
+            "title": "Config Id",
+            "default": "detect_jailbreak"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/detect_pii"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Jailbreak attempt detected"
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for jailbreak detection"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "DetectJailbreakConfig",
+        "description": "Detect Jailbreak configuration."
+      },
+      "DetectPIIConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "detect_pii",
+            "title": "Config Id",
+            "default": "detect_pii"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "PII detected"
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/detect_pii"
+          },
+          "pii_entities": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Pii Entities",
+            "description": "List of PII entity types to detect"
+          },
+          "on_fail": {
+            "type": "string",
+            "title": "On Fail",
+            "default": "exception"
+          }
+        },
+        "type": "object",
+        "required": [
+          "pii_entities"
+        ],
+        "title": "DetectPIIConfig",
+        "description": "Detect PII configuration."
+      },
+      "DiscordIntegrationConfig": {
+        "properties": {
+          "botToken": {
+            "type": "string",
+            "title": "Bottoken",
+            "description": "Discord bot token (used for REST API calls)."
+          },
+          "applicationId": {
+            "type": "string",
+            "title": "Applicationid",
+            "description": "Discord application ID."
+          },
+          "publicKey": {
+            "type": "string",
+            "title": "Publickey",
+            "description": "Ed25519 public key from the Discord application settings. Used to verify interaction webhook signatures."
+          },
+          "guildId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guildid",
+            "description": "Optional guild (server) ID to restrict the integration to."
+          }
+        },
+        "type": "object",
+        "required": [
+          "botToken",
+          "applicationId",
+          "publicKey"
+        ],
+        "title": "DiscordIntegrationConfig",
+        "description": "Discord bot configuration for the Interactions Endpoint webhook.\n\nRequires a Discord application with a bot user created at\nhttps://discord.com/developers/applications.  The ``public_key`` is used\nto verify Ed25519 signatures on incoming interaction payloads."
+      },
+      "EngineConfig": {
+        "properties": {
+          "server": {
+            "$ref": "#/components/schemas/ServerConfig"
+          },
+          "agent": {
+            "$ref": "#/components/schemas/AgentConfig"
+          },
+          "mcpServers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/MCPServer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mcpservers"
+          },
+          "guardrails": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GuardrailsV2"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "observability": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/idun_agent_schema__engine__observability_v2__ObservabilityConfig"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observability"
+          },
+          "sso": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SSOConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "integrations": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/IntegrationConfig"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Integrations"
+          },
+          "prompts": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PromptConfig"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "agent"
+        ],
+        "title": "EngineConfig",
+        "description": "Main engine configuration model for the entire Idun Agent Engine."
+      },
+      "GCPLoggingConfig": {
+        "properties": {
+          "gcpProjectId": {
+            "type": "string",
+            "title": "Gcpprojectid",
+            "description": "The project identifier where logs and traces will be sent.",
+            "default": ""
+          },
+          "region": {
+            "type": "string",
+            "title": "Region",
+            "description": "(Optional) The specific region/zone associated with the resource (e.g., us-central1).",
+            "default": ""
+          },
+          "logName": {
+            "type": "string",
+            "title": "Logname",
+            "description": "The identifier for the log stream (e.g., application-log).",
+            "default": ""
+          },
+          "resourceType": {
+            "type": "string",
+            "title": "Resourcetype",
+            "description": "The resource type label (e.g., global, gce_instance, cloud_run_revision).",
+            "default": ""
+          },
+          "severity": {
+            "type": "string",
+            "title": "Severity",
+            "description": "Minimum level to record (e.g., INFO, WARNING, ERROR, CRITICAL).",
+            "default": "INFO"
+          },
+          "transport": {
+            "type": "string",
+            "title": "Transport",
+            "description": "Selection for delivery method (e.g., BackgroundThread vs Synchronous).",
+            "default": "BackgroundThread"
+          }
+        },
+        "type": "object",
+        "title": "GCPLoggingConfig",
+        "description": "GCP Logging configuration."
+      },
+      "GCPTraceConfig": {
+        "properties": {
+          "gcpProjectId": {
+            "type": "string",
+            "title": "Gcpprojectid",
+            "description": "The project identifier where logs and traces will be sent.",
+            "default": ""
+          },
+          "region": {
+            "type": "string",
+            "title": "Region",
+            "description": "(Optional) The specific region/zone associated with the resource (e.g., us-central1).",
+            "default": ""
+          },
+          "traceName": {
+            "type": "string",
+            "title": "Tracename",
+            "description": "The name for the trace or tracing session.",
+            "default": ""
+          },
+          "samplingRate": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Samplingrate",
+            "description": "A number between 0.0 and 1.0 indicating the probability of a request being traced (e.g., 1.0 for 100%, 0.1 for 10%).",
+            "default": 1.0
+          },
+          "flushInterval": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Flushinterval",
+            "description": "Time in seconds to wait before sending buffered traces to the cloud.",
+            "default": 5
+          },
+          "ignoreUrls": {
+            "type": "string",
+            "title": "Ignoreurls",
+            "description": "A list or comma-separated string of URL paths to exclude from tracing (e.g., /health, /metrics).",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "GCPTraceConfig",
+        "description": "GCP Trace configuration."
+      },
+      "GibberishTextConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "gibberish_text",
+            "title": "Config Id",
+            "default": "gibberish_text"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/gibberish_text"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Gibberish text detected"
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for gibberish detection"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "GibberishTextConfig",
+        "description": "Gibberish Text configuration."
+      },
+      "GuardrailRef": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "position": {
+            "type": "string",
+            "enum": [
+              "input",
+              "output"
+            ],
+            "title": "Position",
+            "default": "input"
+          },
+          "sort_order": {
+            "type": "integer",
+            "title": "Sort Order",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "GuardrailRef",
+        "description": "Reference to a managed guardrail with position metadata."
+      },
+      "GuardrailsV2": {
+        "properties": {
+          "input": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/BanListConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/DetectPIIConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/BiasCheckConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/CompetitionCheckConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/CorrectLanguageConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/GibberishTextConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/NSFWTextConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/DetectJailbreakConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/PromptInjectionConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/RagHallucinationConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/RestrictToTopicConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/ToxicLanguageConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/CodeScannerConfig"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Input",
+            "description": "List of input guardrails"
+          },
+          "output": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/BanListConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/DetectPIIConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/BiasCheckConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/CompetitionCheckConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/CorrectLanguageConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/GibberishTextConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/NSFWTextConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/DetectJailbreakConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/PromptInjectionConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/RagHallucinationConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/RestrictToTopicConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/ToxicLanguageConfig"
+                },
+                {
+                  "$ref": "#/components/schemas/CodeScannerConfig"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Output",
+            "description": "List of output guardrails"
+          }
+        },
+        "type": "object",
+        "title": "GuardrailsV2",
+        "description": "Guardrails V2 configuration."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "HaystackAgentConfig": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "(Deprecated) Observability config is deprecated and will be removed in a future release.",
+            "deprecated": true
+          },
+          "type": {
+            "type": "string",
+            "const": "haystack",
+            "title": "Type",
+            "default": "haystack"
+          },
+          "component_type": {
+            "type": "string",
+            "enum": [
+              "pipeline",
+              "agent"
+            ],
+            "title": "Component Type"
+          },
+          "component_definition": {
+            "type": "string",
+            "title": "Component Definition"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "component_type",
+          "component_definition"
+        ],
+        "title": "HaystackAgentConfig",
+        "description": "Configuration model for Haystack Agents."
+      },
+      "InMemoryCheckpointConfig": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "memory",
+            "title": "Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "title": "InMemoryCheckpointConfig",
+        "description": "Configuration for In-Memory checkpointer."
+      },
+      "IntegrationConfig": {
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/IntegrationProvider",
+            "description": "The messaging provider type."
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "description": "Toggle this integration on or off.",
+            "default": true
+          },
+          "config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WhatsAppIntegrationConfig"
+              },
+              {
+                "$ref": "#/components/schemas/DiscordIntegrationConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SlackIntegrationConfig"
+              }
+            ],
+            "title": "Config",
+            "description": "Provider-specific configuration."
+          }
+        },
+        "type": "object",
+        "required": [
+          "provider",
+          "config"
+        ],
+        "title": "IntegrationConfig",
+        "description": "Top-level integration configuration.\n\nEach integration binds an external messaging provider to the agent.\nWhen the engine starts, it registers webhook endpoints for each\nenabled integration."
+      },
+      "IntegrationProvider": {
+        "type": "string",
+        "enum": [
+          "WHATSAPP",
+          "DISCORD",
+          "SLACK"
+        ],
+        "title": "IntegrationProvider",
+        "description": "Supported integration providers."
+      },
+      "InvitationRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "role": {
+            "$ref": "#/components/schemas/WorkspaceRole"
+          },
+          "invited_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Invited By"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "pending"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "role",
+          "created_at"
+        ],
+        "title": "InvitationRead",
+        "description": "A pending workspace invitation."
+      },
+      "LangGraphAgentConfig": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "(Deprecated) Observability config is deprecated and will be removed in a future release.",
+            "deprecated": true
+          },
+          "graph_definition": {
+            "type": "string",
+            "title": "Graph Definition"
+          },
+          "checkpointer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SqliteCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/PostgresCheckpointConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checkpointer"
+          },
+          "store": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "graph_definition"
+        ],
+        "title": "LangGraphAgentConfig",
+        "description": "Configuration model for LangGraph agents."
+      },
+      "LangfuseConfig": {
+        "properties": {
+          "host": {
+            "type": "string",
+            "title": "Host",
+            "default": "https://cloud.langfuse.com"
+          },
+          "publicKey": {
+            "type": "string",
+            "title": "Publickey",
+            "default": ""
+          },
+          "secretKey": {
+            "type": "string",
+            "title": "Secretkey",
+            "default": ""
+          },
+          "runName": {
+            "type": "string",
+            "title": "Runname",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "LangfuseConfig",
+        "description": "Langfuse configuration."
+      },
+      "LangsmithConfig": {
+        "properties": {
+          "apiKey": {
+            "type": "string",
+            "title": "Apikey",
+            "description": "The unique authentication key from the LangSmith settings page.",
+            "default": ""
+          },
+          "projectName": {
+            "type": "string",
+            "title": "Projectname",
+            "description": "The name of the project in LangSmith to bucket these traces under (e.g., prod-chatbot-v1).",
+            "default": ""
+          },
+          "endpoint": {
+            "type": "string",
+            "title": "Endpoint",
+            "description": "The URL endpoint, used primarily if you are self-hosting LangSmith or using a specific enterprise instance. (e.g., https://api.smith.langchain.com)",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "LangsmithConfig",
+        "description": "Langsmith configuration."
+      },
+      "LoginRequest": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "LoginRequest"
+      },
+      "MCPServer": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Unique identifier for this MCP server."
+          },
+          "transport": {
+            "type": "string",
+            "enum": [
+              "stdio",
+              "sse",
+              "streamable_http",
+              "websocket"
+            ],
+            "title": "Transport",
+            "description": "Transport type used to reach the MCP server.",
+            "default": "streamable_http"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url",
+            "description": "Endpoint URL for HTTP/S based transports (SSE, streamable_http, websocket)."
+          },
+          "command": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Command",
+            "description": "Executable to run when using stdio transport."
+          },
+          "args": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Args",
+            "description": "Arguments to pass to the command for stdio transport."
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Headers",
+            "description": "Optional headers for HTTP/S transports."
+          },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Env",
+            "description": "Environment variables to set when spawning stdio servers."
+          },
+          "cwd": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cwd",
+            "description": "Working directory for stdio transports."
+          },
+          "encoding": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Encoding",
+            "description": "Encoding used for stdio transport."
+          },
+          "encodingErrorHandler": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "strict",
+                  "ignore",
+                  "replace"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Encodingerrorhandler",
+            "description": "Encoding error handler for stdio transport."
+          },
+          "timeoutSeconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timeoutseconds",
+            "description": "Timeout in seconds for HTTP/S transports (maps to `timeout`)."
+          },
+          "sseReadTimeoutSeconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ssereadtimeoutseconds",
+            "description": "Timeout in seconds waiting for SSE events (maps to `sse_read_timeout`)."
+          },
+          "terminateOnClose": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Terminateonclose",
+            "description": "Whether to terminate Streamable HTTP sessions on close."
+          },
+          "sessionKwargs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Sessionkwargs",
+            "description": "Extra keyword arguments forwarded to MCP ClientSession."
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "MCPServer",
+        "description": "Configuration for a single MCP server connection."
+      },
+      "MCPToolSchema": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "input_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Schema"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "MCPToolSchema",
+        "description": "Schema for a single MCP tool."
+      },
+      "MCPToolsResponse": {
+        "properties": {
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/MCPToolSchema"
+            },
+            "type": "array",
+            "title": "Tools"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tools"
+        ],
+        "title": "MCPToolsResponse",
+        "description": "Response containing discovered MCP tools."
+      },
+      "ManagedAgentCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version",
+            "description": "Agent version"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url",
+            "description": "Base URL"
+          },
+          "engine_config": {
+            "$ref": "#/components/schemas/EngineConfig",
+            "description": "Idun Agent Engine configuration"
+          },
+          "resources": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentResourceIds"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Resource references (FK/junction)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "engine_config"
+        ],
+        "title": "ManagedAgentCreate",
+        "description": "Create managed agent model for requests."
+      },
+      "ManagedAgentPatch": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url",
+            "description": "Base URL"
+          },
+          "engine_config": {
+            "$ref": "#/components/schemas/EngineConfig",
+            "description": "Idun Agent Engine configuration"
+          },
+          "resources": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentResourceIds"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Resource references (FK/junction)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "engine_config"
+        ],
+        "title": "ManagedAgentPatch",
+        "description": "Full replacement schema for PUT of a managed agent."
+      },
+      "ManagedAgentRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentStatus",
+            "description": "Agent status",
+            "default": "draft"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version",
+            "description": "Agent version"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url",
+            "description": "Base URL"
+          },
+          "engine_config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Engine Config",
+            "description": "Materialized EngineConfig (full assembled config)"
+          },
+          "resources": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentResourceIds"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Resource references (FK/junction)"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Creation timestamp"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Last update timestamp"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "engine_config",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagedAgentRead",
+        "description": "Complete managed agent model for responses."
+      },
+      "ManagedAgentStatusUpdate": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/AgentStatus",
+            "description": "New agent status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "ManagedAgentStatusUpdate",
+        "description": "Schema for updating only the agent status."
+      },
+      "ManagedGuardrailCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "guardrail": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBanListConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimplePIIConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleNSFWTextConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleToxicLanguageConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleGibberishTextConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleBiasCheckConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleCompetitionCheckConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleCorrectLanguageConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleRestrictToTopicConfig"
+              }
+            ],
+            "title": "Guardrail",
+            "description": "Guardrail configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "guardrail"
+        ],
+        "title": "ManagedGuardrailCreate",
+        "description": "Create managed guardrail model for requests."
+      },
+      "ManagedGuardrailPatch": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "guardrail": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBanListConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimplePIIConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleNSFWTextConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleToxicLanguageConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleGibberishTextConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleBiasCheckConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleCompetitionCheckConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleCorrectLanguageConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleRestrictToTopicConfig"
+              }
+            ],
+            "title": "Guardrail",
+            "description": "Guardrail configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "guardrail"
+        ],
+        "title": "ManagedGuardrailPatch",
+        "description": "Full replacement schema for PUT of a managed guardrail."
+      },
+      "ManagedGuardrailRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "guardrail": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SimpleBanListConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimplePIIConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleNSFWTextConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleToxicLanguageConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleGibberishTextConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleBiasCheckConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleCompetitionCheckConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleCorrectLanguageConfig"
+              },
+              {
+                "$ref": "#/components/schemas/SimpleRestrictToTopicConfig"
+              }
+            ],
+            "title": "Guardrail",
+            "description": "Guardrail configuration"
+          },
+          "agent_count": {
+            "type": "integer",
+            "title": "Agent Count",
+            "description": "Number of agents using this guardrail",
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Creation timestamp"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Last update timestamp"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "guardrail",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagedGuardrailRead",
+        "description": "Complete managed guardrail model for responses."
+      },
+      "ManagedIntegrationCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "integration": {
+            "$ref": "#/components/schemas/IntegrationConfig",
+            "description": "Integration configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "integration"
+        ],
+        "title": "ManagedIntegrationCreate",
+        "description": "Create managed integration configuration request."
+      },
+      "ManagedIntegrationPatch": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "integration": {
+            "$ref": "#/components/schemas/IntegrationConfig",
+            "description": "Integration configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "integration"
+        ],
+        "title": "ManagedIntegrationPatch",
+        "description": "Update managed integration configuration request."
+      },
+      "ManagedIntegrationRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "integration": {
+            "$ref": "#/components/schemas/IntegrationConfig",
+            "description": "Integration configuration"
+          },
+          "agent_count": {
+            "type": "integer",
+            "title": "Agent Count",
+            "description": "Number of agents using this integration",
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Creation timestamp"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Last update timestamp"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "integration",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagedIntegrationRead",
+        "description": "Complete managed integration configuration response."
+      },
+      "ManagedMCPServerCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "mcp_server": {
+            "$ref": "#/components/schemas/MCPServer",
+            "description": "MCP server configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "mcp_server"
+        ],
+        "title": "ManagedMCPServerCreate",
+        "description": "Create managed MCP server model for requests."
+      },
+      "ManagedMCPServerPatch": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "mcp_server": {
+            "$ref": "#/components/schemas/MCPServer",
+            "description": "MCP server configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "mcp_server"
+        ],
+        "title": "ManagedMCPServerPatch",
+        "description": "Full replacement schema for PUT of a managed MCP server."
+      },
+      "ManagedMCPServerRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "mcp_server": {
+            "$ref": "#/components/schemas/MCPServer",
+            "description": "MCP server configuration"
+          },
+          "agent_count": {
+            "type": "integer",
+            "title": "Agent Count",
+            "description": "Number of agents using this MCP server",
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Creation timestamp"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Last update timestamp"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "mcp_server",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagedMCPServerRead",
+        "description": "Complete managed MCP server model for responses."
+      },
+      "ManagedMemoryCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "agent_framework": {
+            "$ref": "#/components/schemas/AgentFramework",
+            "description": "Agent framework"
+          },
+          "memory": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SqliteCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/PostgresCheckpointConfig"
+              },
+              {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AdkInMemorySessionConfig"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdkVertexAiSessionConfig"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdkDatabaseSessionConfig"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type",
+                  "mapping": {
+                    "database": "#/components/schemas/AdkDatabaseSessionConfig",
+                    "in_memory": "#/components/schemas/AdkInMemorySessionConfig",
+                    "vertex_ai": "#/components/schemas/AdkVertexAiSessionConfig"
+                  }
+                }
+              }
+            ],
+            "title": "Memory",
+            "description": "Memory (checkpoint) configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "agent_framework",
+          "memory"
+        ],
+        "title": "ManagedMemoryCreate",
+        "description": "Create managed memory model for requests."
+      },
+      "ManagedMemoryPatch": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "agent_framework": {
+            "$ref": "#/components/schemas/AgentFramework",
+            "description": "Agent framework"
+          },
+          "memory": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SqliteCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/PostgresCheckpointConfig"
+              },
+              {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AdkInMemorySessionConfig"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdkVertexAiSessionConfig"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdkDatabaseSessionConfig"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type",
+                  "mapping": {
+                    "database": "#/components/schemas/AdkDatabaseSessionConfig",
+                    "in_memory": "#/components/schemas/AdkInMemorySessionConfig",
+                    "vertex_ai": "#/components/schemas/AdkVertexAiSessionConfig"
+                  }
+                }
+              }
+            ],
+            "title": "Memory",
+            "description": "Memory (checkpoint) configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "agent_framework",
+          "memory"
+        ],
+        "title": "ManagedMemoryPatch",
+        "description": "Full replacement schema for PUT of a managed memory."
+      },
+      "ManagedMemoryRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "agent_framework": {
+            "$ref": "#/components/schemas/AgentFramework",
+            "description": "Agent framework"
+          },
+          "memory": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SqliteCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/PostgresCheckpointConfig"
+              },
+              {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AdkInMemorySessionConfig"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdkVertexAiSessionConfig"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AdkDatabaseSessionConfig"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type",
+                  "mapping": {
+                    "database": "#/components/schemas/AdkDatabaseSessionConfig",
+                    "in_memory": "#/components/schemas/AdkInMemorySessionConfig",
+                    "vertex_ai": "#/components/schemas/AdkVertexAiSessionConfig"
+                  }
+                }
+              }
+            ],
+            "title": "Memory",
+            "description": "Memory (checkpoint) configuration"
+          },
+          "agent_count": {
+            "type": "integer",
+            "title": "Agent Count",
+            "description": "Number of agents using this memory config",
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Creation timestamp"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Last update timestamp"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "agent_framework",
+          "memory",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagedMemoryRead",
+        "description": "Complete managed memory model for responses."
+      },
+      "ManagedObservabilityCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "$ref": "#/components/schemas/idun_agent_schema__engine__observability_v2__ObservabilityConfig",
+            "description": "Observability configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "observability"
+        ],
+        "title": "ManagedObservabilityCreate",
+        "description": "Create managed observability model for requests."
+      },
+      "ManagedObservabilityPatch": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "$ref": "#/components/schemas/idun_agent_schema__engine__observability_v2__ObservabilityConfig",
+            "description": "Observability configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "observability"
+        ],
+        "title": "ManagedObservabilityPatch",
+        "description": "Full replacement schema for PUT of a managed observability."
+      },
+      "ManagedObservabilityRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "$ref": "#/components/schemas/ObservabilityConfig-Output",
+            "description": "Observability configuration"
+          },
+          "agent_count": {
+            "type": "integer",
+            "title": "Agent Count",
+            "description": "Number of agents using this config",
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Creation timestamp"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Last update timestamp"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "observability",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagedObservabilityRead",
+        "description": "Complete managed observability model for responses."
+      },
+      "ManagedPromptCreate": {
+        "properties": {
+          "prompt_id": {
+            "type": "string",
+            "title": "Prompt Id",
+            "description": "Logical prompt identifier"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Prompt text, supports Jinja2 {{ variables }}"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "description": "User-defined tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prompt_id",
+          "content"
+        ],
+        "title": "ManagedPromptCreate",
+        "description": "Request body for creating a new prompt version."
+      },
+      "ManagedPromptPatch": {
+        "properties": {
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "description": "Updated tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tags"
+        ],
+        "title": "ManagedPromptPatch",
+        "description": "Request body for updating prompt tags. Content is immutable (append-only versioning)."
+      },
+      "ManagedPromptRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "prompt_id": {
+            "type": "string",
+            "title": "Prompt Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "prompt_id",
+          "version",
+          "content",
+          "tags",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagedPromptRead",
+        "description": "Response body for a prompt."
+      },
+      "ManagedSSOCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sso": {
+            "$ref": "#/components/schemas/SSOConfig",
+            "description": "SSO (OIDC) configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "sso"
+        ],
+        "title": "ManagedSSOCreate",
+        "description": "Create managed SSO configuration request."
+      },
+      "ManagedSSOPatch": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sso": {
+            "$ref": "#/components/schemas/SSOConfig",
+            "description": "SSO (OIDC) configuration"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "sso"
+        ],
+        "title": "ManagedSSOPatch",
+        "description": "Update managed SSO configuration request."
+      },
+      "ManagedSSORead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sso": {
+            "$ref": "#/components/schemas/SSOConfig",
+            "description": "SSO (OIDC) configuration"
+          },
+          "agent_count": {
+            "type": "integer",
+            "title": "Agent Count",
+            "description": "Number of agents using this SSO config",
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Creation timestamp"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Last update timestamp"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "sso",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ManagedSSORead",
+        "description": "Complete managed SSO configuration response."
+      },
+      "MemberAdd": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "role": {
+            "$ref": "#/components/schemas/WorkspaceRole",
+            "description": "Role to assign. Owners can assign any role; admins can assign member or viewer.",
+            "default": "member"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "title": "MemberAdd",
+        "description": "Request body to add a user to a workspace."
+      },
+      "MemberListResponse": {
+        "properties": {
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/MemberRead"
+            },
+            "type": "array",
+            "title": "Members"
+          },
+          "invitations": {
+            "items": {
+              "$ref": "#/components/schemas/InvitationRead"
+            },
+            "type": "array",
+            "title": "Invitations",
+            "default": []
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "members",
+          "total"
+        ],
+        "title": "MemberListResponse",
+        "description": "Paginated list of workspace members and pending invitations."
+      },
+      "MemberPatch": {
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/WorkspaceRole"
+          }
+        },
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "title": "MemberPatch",
+        "description": "Request body to update a member's role."
+      },
+      "MemberRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "picture_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Picture Url"
+          },
+          "role": {
+            "$ref": "#/components/schemas/WorkspaceRole"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "active"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "user_id",
+          "email",
+          "role",
+          "created_at"
+        ],
+        "title": "MemberRead",
+        "description": "A workspace member with user details."
+      },
+      "NSFWTextConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "nsfw_text",
+            "title": "Config Id",
+            "default": "nsfw_text"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/nsfw_text"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "NSFW content detected"
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for NSFW content"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "NSFWTextConfig",
+        "description": "NSFW Text configuration."
+      },
+      "ObservabilityConfig-Output": {
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/ObservabilityProvider",
+            "default": "LANGFUSE"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": true
+          },
+          "config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LangfuseConfig"
+              },
+              {
+                "$ref": "#/components/schemas/PhoenixConfig"
+              },
+              {
+                "$ref": "#/components/schemas/GCPLoggingConfig"
+              },
+              {
+                "$ref": "#/components/schemas/GCPTraceConfig"
+              },
+              {
+                "$ref": "#/components/schemas/LangsmithConfig"
+              }
+            ],
+            "title": "Config"
+          }
+        },
+        "type": "object",
+        "required": [
+          "config"
+        ],
+        "title": "ObservabilityConfig",
+        "description": "Observability configuration."
+      },
+      "ObservabilityProvider": {
+        "type": "string",
+        "enum": [
+          "LANGFUSE",
+          "PHOENIX",
+          "GCP_LOGGING",
+          "GCP_TRACE",
+          "LANGSMITH"
+        ],
+        "title": "ObservabilityProvider",
+        "description": "Supported observability providers."
+      },
+      "PhoenixConfig": {
+        "properties": {
+          "collectorEndpoint": {
+            "type": "string",
+            "title": "Collectorendpoint",
+            "default": "https://collector.phoenix.com"
+          },
+          "projectName": {
+            "type": "string",
+            "title": "Projectname",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "PhoenixConfig",
+        "description": "Phoenix configuration."
+      },
+      "PostgresCheckpointConfig": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "postgres",
+            "title": "Type"
+          },
+          "db_url": {
+            "type": "string",
+            "title": "Db Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "db_url"
+        ],
+        "title": "PostgresCheckpointConfig",
+        "description": "Configuration for Postgres checkpointer."
+      },
+      "PromptConfig": {
+        "properties": {
+          "promptId": {
+            "type": "string",
+            "title": "Promptid",
+            "description": "Logical prompt identifier"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "description": "Prompt version number"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Prompt text, supports Jinja2 variables"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "description": "Prompt tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "promptId",
+          "version",
+          "content"
+        ],
+        "title": "PromptConfig",
+        "description": "Engine-level prompt configuration."
+      },
+      "PromptInjectionConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "prompt_injection",
+            "title": "Config Id",
+            "default": "prompt_injection"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/detect_pii"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Prompt injection detected"
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for prompt injection"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "PromptInjectionConfig",
+        "description": "Prompt Injection configuration."
+      },
+      "RagHallucinationConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "rag_hallucination",
+            "title": "Config Id",
+            "default": "rag_hallucination"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/rag_hallucination"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Hallucination detected"
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for hallucination detection"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "RagHallucinationConfig",
+        "description": "RAG Hallucination configuration."
+      },
+      "RegisterRequest": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "minLength": 8,
+            "title": "Password"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "RegisterRequest"
+      },
+      "RestrictToTopicConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "restrict_to_topic",
+            "title": "Config Id",
+            "default": "restrict_to_topic"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/restrict_to_topic"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Off-topic content detected"
+          },
+          "topics": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Topics",
+            "description": "List of allowed topics"
+          }
+        },
+        "type": "object",
+        "required": [
+          "topics"
+        ],
+        "title": "RestrictToTopicConfig",
+        "description": "Restrict To Topic configuration."
+      },
+      "SSOConfig": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "description": "Toggle SSO enforcement on protected routes.",
+            "default": true
+          },
+          "issuer": {
+            "type": "string",
+            "title": "Issuer",
+            "description": "OIDC issuer URL (e.g. https://accounts.google.com). Used to discover the JWKS endpoint via .well-known/openid-configuration."
+          },
+          "clientId": {
+            "type": "string",
+            "title": "Clientid",
+            "description": "OAuth 2.0 client ID. Used as the default audience for JWT validation when 'audience' is not set."
+          },
+          "audience": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audience",
+            "description": "Expected JWT 'aud' claim. Defaults to client_id if not set. Okta client credentials tokens use 'api://default'."
+          },
+          "allowedDomains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alloweddomains",
+            "description": "Optional list of allowed email domains (e.g. ['company.com']). When set, only tokens whose email claim matches one of these domains are accepted."
+          },
+          "allowedEmails": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowedemails",
+            "description": "Optional list of specific email addresses allowed access. When set, only tokens whose email claim exactly matches one of these values are accepted."
+          }
+        },
+        "type": "object",
+        "required": [
+          "issuer",
+          "clientId"
+        ],
+        "title": "SSOConfig",
+        "description": "OIDC Single Sign-On configuration.\n\nWhen enabled, the engine validates JWT tokens on protected routes\n(``/agent/invoke``, ``/agent/stream``, ``/agent/copilotkit/stream``)\nagainst the configured OIDC provider's JWKS endpoint, discovered via\n``{issuer}/.well-known/openid-configuration``."
+      },
+      "ServerAPIConfig": {
+        "properties": {
+          "port": {
+            "type": "integer",
+            "title": "Port",
+            "default": 8000
+          }
+        },
+        "type": "object",
+        "title": "ServerAPIConfig",
+        "description": "API server configuration."
+      },
+      "ServerConfig": {
+        "properties": {
+          "api": {
+            "$ref": "#/components/schemas/ServerAPIConfig"
+          }
+        },
+        "type": "object",
+        "title": "ServerConfig",
+        "description": "Configuration for the Engine's universal settings."
+      },
+      "SimpleBanListConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "ban_list",
+            "title": "Config Id",
+            "default": "ban_list"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": ""
+          },
+          "banned_words": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Banned Words",
+            "description": "A list of strings (words or phrases) to block"
+          }
+        },
+        "type": "object",
+        "required": [
+          "banned_words"
+        ],
+        "title": "SimpleBanListConfig"
+      },
+      "SimpleBiasCheckConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "bias_check",
+            "title": "Config Id",
+            "default": "bias_check"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": ""
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for bias detection"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "SimpleBiasCheckConfig"
+      },
+      "SimpleCompetitionCheckConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "competition_check",
+            "title": "Config Id",
+            "default": "competition_check"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": ""
+          },
+          "competitors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Competitors",
+            "description": "Names of competitor companies or products"
+          }
+        },
+        "type": "object",
+        "required": [
+          "competitors"
+        ],
+        "title": "SimpleCompetitionCheckConfig"
+      },
+      "SimpleCorrectLanguageConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "correct_language",
+            "title": "Config Id",
+            "default": "correct_language"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": ""
+          },
+          "expected_languages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Expected Languages",
+            "description": "Valid ISO language codes (e.g., en, fr, es)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "expected_languages"
+        ],
+        "title": "SimpleCorrectLanguageConfig"
+      },
+      "SimpleGibberishTextConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "gibberish_text",
+            "title": "Config Id",
+            "default": "gibberish_text"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": ""
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for gibberish detection"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "SimpleGibberishTextConfig"
+      },
+      "SimpleNSFWTextConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "nsfw_text",
+            "title": "Config Id",
+            "default": "nsfw_text"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": ""
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for NSFW content"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "SimpleNSFWTextConfig"
+      },
+      "SimplePIIConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "detect_pii",
+            "title": "Config Id",
+            "default": "detect_pii"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": ""
+          },
+          "pii_entities": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Pii Entities",
+            "description": "List of PII entity types to detect"
+          }
+        },
+        "type": "object",
+        "required": [
+          "pii_entities"
+        ],
+        "title": "SimplePIIConfig"
+      },
+      "SimpleRestrictToTopicConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "restrict_to_topic",
+            "title": "Config Id",
+            "default": "restrict_to_topic"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": ""
+          },
+          "topics": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Topics",
+            "description": "List of allowed topics"
+          }
+        },
+        "type": "object",
+        "required": [
+          "topics"
+        ],
+        "title": "SimpleRestrictToTopicConfig"
+      },
+      "SimpleToxicLanguageConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "toxic_language",
+            "title": "Config Id",
+            "default": "toxic_language"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": ""
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for toxic language"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "SimpleToxicLanguageConfig"
+      },
+      "SlackIntegrationConfig": {
+        "properties": {
+          "botToken": {
+            "type": "string",
+            "title": "Bottoken",
+            "description": "Slack bot token (xoxb-...)."
+          },
+          "signingSecret": {
+            "type": "string",
+            "title": "Signingsecret",
+            "description": "Signing secret for verifying webhook requests."
+          }
+        },
+        "type": "object",
+        "required": [
+          "botToken",
+          "signingSecret"
+        ],
+        "title": "SlackIntegrationConfig",
+        "description": "Slack Events API configuration.\n\nRequires a Slack app with a bot token and signing secret.\nThe ``signing_secret`` is used to verify incoming webhook requests\nvia HMAC-SHA256."
+      },
+      "SqliteCheckpointConfig": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "sqlite",
+            "title": "Type"
+          },
+          "db_url": {
+            "type": "string",
+            "title": "Db Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "db_url"
+        ],
+        "title": "SqliteCheckpointConfig",
+        "description": "Configuration for SQLite checkpointer."
+      },
+      "ToxicLanguageConfig": {
+        "properties": {
+          "config_id": {
+            "type": "string",
+            "const": "toxic_language",
+            "title": "Config Id",
+            "default": "toxic_language"
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
+            "default": ""
+          },
+          "guard_url": {
+            "type": "string",
+            "title": "Guard Url",
+            "default": "hub://guardrails/toxic_language"
+          },
+          "reject_message": {
+            "type": "string",
+            "title": "Reject Message",
+            "default": "Toxic language detected"
+          },
+          "threshold": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "description": "Sensitivity level for toxic language"
+          }
+        },
+        "type": "object",
+        "required": [
+          "threshold"
+        ],
+        "title": "ToxicLanguageConfig",
+        "description": "Toxic Language configuration."
+      },
+      "TranslationAgentConfig": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "observability": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/idun_agent_schema__engine__observability__ObservabilityConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "(Deprecated) Observability config is deprecated and will be removed in a future release.",
+            "deprecated": true
+          },
+          "graph_definition": {
+            "type": "string",
+            "title": "Graph Definition"
+          },
+          "checkpointer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SqliteCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/InMemoryCheckpointConfig"
+              },
+              {
+                "$ref": "#/components/schemas/PostgresCheckpointConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checkpointer"
+          },
+          "store": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Store"
+          },
+          "source_lang": {
+            "type": "string",
+            "title": "Source Lang",
+            "description": "Source language to translate from",
+            "default": "English"
+          },
+          "target_lang": {
+            "type": "string",
+            "title": "Target Lang",
+            "description": "Target language to translate to",
+            "default": "French"
+          },
+          "model_name": {
+            "type": "string",
+            "title": "Model Name",
+            "description": "LLM model to use",
+            "default": "gpt-3.5-turbo"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "graph_definition"
+        ],
+        "title": "TranslationAgentConfig",
+        "description": "Configuration model for the Translation Agent Template."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WhatsAppIntegrationConfig": {
+        "properties": {
+          "accessToken": {
+            "type": "string",
+            "title": "Accesstoken",
+            "description": "Meta Graph API permanent access token."
+          },
+          "phoneNumberId": {
+            "type": "string",
+            "title": "Phonenumberid",
+            "description": "WhatsApp Business phone number ID."
+          },
+          "verifyToken": {
+            "type": "string",
+            "title": "Verifytoken",
+            "description": "Webhook verification token. Must match the token configured in the Meta App Dashboard webhook settings."
+          },
+          "apiVersion": {
+            "type": "string",
+            "title": "Apiversion",
+            "description": "Meta Graph API version.",
+            "default": "v21.0"
+          }
+        },
+        "type": "object",
+        "required": [
+          "accessToken",
+          "phoneNumberId",
+          "verifyToken"
+        ],
+        "title": "WhatsAppIntegrationConfig",
+        "description": "WhatsApp Business Cloud API configuration.\n\nRequires a Meta Business account with a WhatsApp Business API setup.\nThe ``verify_token`` is used by Meta to validate the webhook endpoint\nduring initial registration."
+      },
+      "WorkspaceCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "WorkspaceCreate"
+      },
+      "WorkspacePatch": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "title": "WorkspacePatch"
+      },
+      "WorkspaceRead": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "icon": {
+            "type": "string",
+            "title": "Icon",
+            "default": ""
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "slug"
+        ],
+        "title": "WorkspaceRead"
+      },
+      "WorkspaceRole": {
+        "type": "string",
+        "enum": [
+          "owner",
+          "admin",
+          "member",
+          "viewer"
+        ],
+        "title": "WorkspaceRole",
+        "description": "Workspace membership roles, ordered by privilege level."
+      },
+      "idun_agent_schema__engine__observability__ObservabilityConfig": {
+        "properties": {
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": false
+          },
+          "options": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Options"
+          }
+        },
+        "type": "object",
+        "title": "ObservabilityConfig",
+        "description": "Provider-agnostic observability configuration based on Pydantic.\n\nExample YAML:\n  observability:\n    provider: \"langfuse\"  # or \"phoenix\"\n    enabled: true\n    options:\n      host: ${LANGFUSE_HOST}\n      public_key: ${LANGFUSE_PUBLIC_KEY}\n      secret_key: ${LANGFUSE_SECRET_KEY}\n      run_name: \"my-run\""
+      },
+      "idun_agent_schema__engine__observability_v2__ObservabilityConfig": {
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/ObservabilityProvider",
+            "default": "LANGFUSE"
+          },
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": true
+          },
+          "config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LangfuseConfig"
+              },
+              {
+                "$ref": "#/components/schemas/PhoenixConfig"
+              },
+              {
+                "$ref": "#/components/schemas/GCPLoggingConfig"
+              },
+              {
+                "$ref": "#/components/schemas/GCPTraceConfig"
+              },
+              {
+                "$ref": "#/components/schemas/LangsmithConfig"
+              }
+            ],
+            "title": "Config"
+          }
+        },
+        "type": "object",
+        "required": [
+          "config"
+        ],
+        "title": "ObservabilityConfig",
+        "description": "Observability configuration."
+      }
+    }
+  }
 }

--- a/services/idun_agent_web/src/components/agent-detail/tabs/overview-tab/sections/framework-section.tsx
+++ b/services/idun_agent_web/src/components/agent-detail/tabs/overview-tab/sections/framework-section.tsx
@@ -77,7 +77,7 @@ export default function FrameworkSection({ agent, isEditing, agentConfig, rootSc
                             rootSchema={rootSchema}
                             data={agentConfig}
                             onChange={onConfigChange}
-                            excludeFields={['name', 'checkpointer', 'session_service', 'memory_service', 'observability', 'a2a']}
+                            excludeFields={['name', 'checkpointer', 'session_service', 'memory_service', 'observability', 'a2a', 'store']}
                         />
                     </div>
                 ) : (


### PR DESCRIPTION
fix (#388)

The create/patch agent endpoints used raw_request: Request with manual JSON parsing, which prevented FastAPI from including ManagedAgentCreate/Patch (and their nested types like LangGraphAgentConfig) in the OpenAPI schema. The frontend fetches this schema to render the framework config form — without it, the edit form showed "Loading schema..." permanently.

Also hides the store (JSON) field from the framework edit form.

## Summary

Describe the change and why it’s needed.

## Checklist

- [X] I ran the relevant checks (`make precommit` and/or `make test`)
- [X] I updated documentation where applicable
- [X] I added/updated tests where applicable
- [X] This change is not introducing secrets (API keys, tokens, credentials) into the repo

## Screenshots / Notes (optional)
