### PR TITLE
Bump 0.5.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     #   - idun_network
 
   manager:
-    image: freezaa9/idun-ai:0.5.0
+    image: freezaa9/idun-ai:0.5.1
     container_name: idun-manager
     ports:
       - "8000:8000"
@@ -54,7 +54,7 @@ services:
     restart: unless-stopped
 
   web:
-    image: freezaa9/idun-ai-web:0.5.0
+    image: freezaa9/idun-ai-web:0.5.1
     container_name: idun-web
     ports:
       - "3000:3000"

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Idun Agent Manager API",
     "description": "Idun service for managing AI agents",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "paths": {
     "/api/v1/auth/login": {

--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-agent-engine"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python SDK and runtime to serve AI agents with FastAPI, LangGraph, and observability."
 authors = [{ name = "Geoffrey HARRAZI", email = "geoffreyharrazi@gmail.com" }]
 requires-python = ">=3.12,<3.14"

--- a/services/idun_agent_manager/Dockerfile
+++ b/services/idun_agent_manager/Dockerfile
@@ -48,7 +48,7 @@ FROM python:3.12-slim AS runtime
 # Metadata
 LABEL maintainer="Idun Group <contact@idun-group.com>" \
       description="Idun Agent Manager - FastAPI service for managing AI agents" \
-      version="0.5.0"
+      version="0.5.1"
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/services/idun_agent_manager/pyproject.toml
+++ b/services/idun_agent_manager/pyproject.toml
@@ -1,7 +1,7 @@
 ## Project metadata and dependencies (PEP 621)
 [project]
 name = "idun-agent-manager"
-version = "0.5.0"
+version = "0.5.1"
 description = "Modern FastAPI backend for managing AI agents with PostgreSQL, SQLAlchemy, and observability"
 readme = "README.md"
 license = { text = "GPL-3.0-only" }

--- a/services/idun_agent_manager/src/app/__init__.py
+++ b/services/idun_agent_manager/src/app/__init__.py
@@ -1,3 +1,3 @@
 """Idun Agent Manager - Modern FastAPI Backend for the Idun Engine."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/services/idun_agent_manager/uv.lock
+++ b/services/idun_agent_manager/uv.lock
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "idun-agent-manager"
-version = "0.5.0"
+version = "0.5.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/services/idun_agent_web/package-lock.json
+++ b/services/idun_agent_web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idun-agent-web",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idun-agent-web",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@ag-ui/client": "^0.0.46",
         "@monaco-editor/react": "^4.7.0",

--- a/services/idun_agent_web/package.json
+++ b/services/idun_agent_web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "idun-agent-web",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/idun_agent_web/schema/manager-openapi.json
+++ b/services/idun_agent_web/schema/manager-openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Idun Agent Manager API",
     "description": "Idun service for managing AI agents",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "paths": {
     "/api/v1/auth/login": {

--- a/services/idun_agent_web/src/services/agents.test.ts
+++ b/services/idun_agent_web/src/services/agents.test.ts
@@ -17,7 +17,7 @@ describe('fetchEngineHealth', () => {
         vi.resetModules();
         fetchMock.mockReset();
         fetchMock.mockResolvedValue(
-            new Response(JSON.stringify({ status: 'ok', version: '0.5.0' }), {
+            new Response(JSON.stringify({ status: 'ok', version: '0.5.1' }), {
                 status: 200,
                 headers: { 'Content-Type': 'application/json' },
             }),
@@ -42,6 +42,6 @@ describe('fetchEngineHealth', () => {
                 targetAddressSpace: 'loopback',
             }),
         );
-        expect(result).toEqual({ status: 'ok', engineVersion: '0.5.0' });
+        expect(result).toEqual({ status: 'ok', engineVersion: '0.5.1' });
     });
 });

--- a/uv.lock
+++ b/uv.lock
@@ -2150,7 +2150,7 @@ wheels = [
 
 [[package]]
 name = "idun-agent-engine"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "libs/idun_agent_engine" }
 dependencies = [
     { name = "ag-ui-adk" },
@@ -2215,9 +2215,9 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0,<=0.134.0" },
     { name = "google-adk", specifier = ">=1.19.0,<2.0.0" },
     { name = "google-cloud-logging", specifier = ">=3.10.0,<4.0.0" },
-    { name = "guardrails-ai", specifier = ">=0.7.2,<1.0.0" },
+    { name = "guardrails-ai", specifier = "==0.9.2" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
-    { name = "idun-agent-schema", specifier = ">=0.3.8,<1.0.0" },
+    { name = "idun-agent-schema", specifier = ">=0.5.0,<1.0.0" },
     { name = "langchain", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-google-vertexai", specifier = ">=2.0.27,<4.0.0" },
@@ -2253,7 +2253,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=24.8.0,<26" },
+    { name = "black", specifier = ">=24.8.0,<27" },
     { name = "mypy", specifier = ">=1.10.0,<2" },
     { name = "posthog", specifier = ">=7.5.1" },
     { name = "pre-commit", specifier = ">=3.8.0,<5" },
@@ -2267,7 +2267,7 @@ dev = [
 
 [[package]]
 name = "idun-agent-manager"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "services/idun_agent_manager" }
 dependencies = [
     { name = "alembic" },
@@ -2333,7 +2333,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.22.1" },
-    { name = "black", specifier = "==24.10.0" },
+    { name = "black", specifier = "==26.3.1" },
     { name = "debugpy", specifier = ">=1.8.0" },
     { name = "factory-boy", specifier = "==3.3.1" },
     { name = "ipdb" },


### PR DESCRIPTION
## Summary

Bump all Idun component versions from 0.5.0 to 0.5.1.

- idun-agent-engine: 0.5.0 → 0.5.1
- idun-agent-manager: 0.5.0 → 0.5.1
- idun-agent-web: 0.5.0 → 0.5.1
- Docker images: freezaa9/idun-ai:0.5.1, freezaa9/idun-ai-web:0.5.1
- OpenAPI specs, test fixtures, lockfiles updated

## Test plan

- [ ] `make ci` passes
- [ ] `docker compose -f docker-compose.dev.yml up --build` starts cleanly
- [ ] Web UI shows correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)