### PR TITLE
fix-290: add langsmith run_name support for langgraph and adk agents

### DIFF
--- a/docs/observability/langsmith.mdx
+++ b/docs/observability/langsmith.mdx
@@ -59,7 +59,7 @@ Once your agent is running with observability enabled:
 2. Open your LangSmith dashboard at [smith.langchain.com](https://smith.langchain.com/)
 3. Navigate to your project to view traces
 
-You will see traces showing the execution run tree, LLM inputs/outputs, and latency.
+You will see traces showing the execution run tree, LLM inputs/outputs, and latency. Each trace run is named after your agent by default.
 
 ## Best practices
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
@@ -213,8 +213,10 @@ class AdkAgent(agent_base.BaseAgent):
                             configure_google_adk,
                         )
 
-                        configure_google_adk()
-                        logger.info("LangSmith Google ADK integration configured")
+                        if configure_google_adk(name=self._name):
+                            logger.info("LangSmith Google ADK integration configured")
+                        else:
+                            logger.warning("LangSmith Google ADK integration failed to configure")
                     except ImportError:
                         logger.warning(
                             "langsmith[google-adk] not installed, "

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -178,6 +178,10 @@ class LanggraphAgent(agent_base.BaseAgent):
                 if not self._obs_run_name:
                     self._obs_run_name = handler.get_run_name()
 
+            # Fallback: use agent name as run_name if not explicitly configured
+            if not self._obs_run_name:
+                self._obs_run_name = self._name
+
             if infos:
                 self._infos["observability"] = infos
 
@@ -233,7 +237,9 @@ class LanggraphAgent(agent_base.BaseAgent):
 
         if isinstance(graph_builder, StateGraph):
             self._agent_instance = graph_builder.compile(
-                checkpointer=self._checkpointer, store=self._store
+                checkpointer=self._checkpointer,
+                store=self._store,
+                name=self._obs_run_name or self._name,
             )
         elif isinstance(graph_builder, CompiledStateGraph):
             # TODO: this was made for supporting langgraph's DeepAgent, modernize.

--- a/libs/idun_agent_engine/tests/unit/observability/test_observability_factory.py
+++ b/libs/idun_agent_engine/tests/unit/observability/test_observability_factory.py
@@ -197,6 +197,39 @@ class TestObservabilityFactory:
         assert config.api_key == ""
         assert config.project_name == ""
         assert config.endpoint == ""
+        assert config.run_name == ""
+
+    def test_langsmith_config_with_run_name(self):
+        config = LangsmithConfig(
+            api_key="lsv2_test",
+            project_name="my-project",
+            run_name="my-agent",
+        )
+        assert config.run_name == "my-agent"
+
+    @patch(
+        "idun_agent_engine.observability.langsmith.langsmith_handler.LangsmithHandler"
+    )
+    def test_langsmith_run_name_flows_through_handler(self, mock_handler_class):
+        from idun_agent_engine.observability.base import create_observability_handler
+
+        mock_handler = MagicMock()
+        mock_handler.get_run_name.return_value = "my-agent"
+        mock_handler_class.return_value = mock_handler
+
+        config = ObservabilityConfig(
+            enabled=True,
+            provider=ObservabilityProvider.LANGSMITH,
+            config=LangsmithConfig(
+                api_key="lsv2_test",
+                run_name="my-agent",
+            ),
+        )
+
+        handler, info = create_observability_handler(config)
+
+        assert handler is not None
+        assert handler.get_run_name() == "my-agent"
 
     def test_create_handler_unsupported_provider(self):
         from idun_agent_engine.observability.base import create_observability_handler

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/observability_v2.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/observability_v2.py
@@ -163,3 +163,7 @@ class LangsmithConfig(BaseModel):
         default="",
         description="The URL endpoint, used primarily if you are self-hosting LangSmith or using a specific enterprise instance. (e.g., https://api.smith.langchain.com)",
     )
+    run_name: str = Field(
+        default="",
+        description="The display name for each trace run in LangSmith (e.g., my-agent).",
+    )


### PR DESCRIPTION
This pr fixes #290 : LangSmith traces showed the default name "LangGraph" / "google_adk.session" instead of the agent's actual name.

  - Added `run_name` field to `LangsmithConfig` schema
  - LangGraph: pass `name` to `graph.compile()` so traces use the agent name (or configured `run_name`)
  - LangGraph: fall back to agent name when no `run_name` is explicitly configured
  - ADK: pass `self._name` to `configure_google_adk(name=...)` and log based on its return value
  - Updated LangSmith docs to note that trace runs are named after the agent by default

  ## Checklist

  - [x] I ran the relevant checks (`make precommit` and/or `make test`)
  - [x] I updated documentation where applicable
  - [x] I added/updated tests where applicable
  - [x] This change is not introducing secrets (API keys, tokens, credentials) into the repo