### PR TITLE
fix: auto-convert postgresql:// to postgresql+psycopg:// for ADK async Engine

### DIFF
--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/adk.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/adk.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .base_agent import BaseAgentConfig
 
@@ -28,7 +28,16 @@ class AdkDatabaseSessionConfig(BaseModel):
     """Configuration for Database Session Service."""
 
     type: Literal["database"] = "database"
-    db_url: str = Field(..., description="Database URL (e.g. postgresql://...)")
+    db_url: str = Field(..., description="Database URL (e.g. postgresql+psycopg://...)")
+
+    @field_validator("db_url")
+    @classmethod
+    def ensure_async_driver(cls, v: str) -> str:
+        if v.startswith("postgresql://"):
+            return v.replace("postgresql://", "postgresql+psycopg://", 1)
+        if v.startswith("postgres://"):
+            return v.replace("postgres://", "postgresql+psycopg://", 1)
+        return v
 
 
 SessionServiceConfig = Annotated[


### PR DESCRIPTION
When adding a memory for adk, the user will most likely input postgresql://... However, this will fail because everything is async, and will raise an error: `database module not found`. So we add psycopg+postgresql when validating the schema in the manager, when a new memory is added. 

This way we reduce friction to the user, and make sure we account for all cases.