### PR TITLE
Feat 336/check connection: Adds "Check Connection" functionality for observability providers and memory stores

### DIFF
--- a/docs/memory/adk.mdx
+++ b/docs/memory/adk.mdx
@@ -156,7 +156,7 @@ The `VertexAiMemoryService` provides cloud-backed memory with long-term storage 
 
 ### Session service issues
 
-1. **Database connection errors**: Verify the connection string format, credentials, and that the database server is accessible from the agent
+1. **Database connection errors**: Use the **Verify** button on the memory configuration card to check connectivity. If the manager runs in Docker and the database is on the host, use `host.docker.internal` instead of `localhost`
 2. **Vertex AI authentication**: Verify Google Cloud credentials are configured and the service account has the required permissions
 3. **Session not persisting**: Confirm the session service is initialized and session IDs are used consistently
 

--- a/docs/memory/langgraph.mdx
+++ b/docs/memory/langgraph.mdx
@@ -125,7 +125,7 @@ You can retrieve the latest state or a specific checkpoint using `graph.get_stat
 
 ## Troubleshooting
 
-1. **Verify database connection**: Test the connection string independently before configuring
+1. **Verify database connection**: Use the **Verify** button on the memory configuration card to check connectivity. If the manager runs in Docker and the database is on the host, use `host.docker.internal` instead of `localhost`
 2. **Check permissions**: Confirm the agent has read/write access to the database or file system
 3. **Thread ID required**: Always provide a `thread_id` in the config when using checkpointers
 4. **Database schema**: PostgreSQL checkpointers automatically create required tables on first use

--- a/docs/observability/langfuse.mdx
+++ b/docs/observability/langfuse.mdx
@@ -32,6 +32,8 @@ Before starting, complete the [quickstart guide](/quickstart) to have an agent r
         - **Secret Key**: Your Langfuse secret key (starts with `sk-lf-...`)
     6. Click **Create configuration**
 
+    After creating, you can click the **Verify** button on the configuration card to check that the connection works.
+
     <Warning>
       Keep your secret key secure. Do not commit it to version control or share it publicly.
     </Warning>

--- a/docs/observability/langsmith.mdx
+++ b/docs/observability/langsmith.mdx
@@ -34,6 +34,8 @@ Before starting, complete the [quickstart guide](/quickstart) to have an agent r
         - **Capture Inputs/Outputs**: Toggle to log full text of inputs and outputs
     6. Click **Create configuration**
 
+    After creating, you can click the **Verify** button on the configuration card to check that the connection works.
+
     <Warning>
       Keep your API key secure. Do not commit it to version control or share it publicly.
     </Warning>

--- a/services/idun_agent_manager/src/app/api/v1/routers/memory.py
+++ b/services/idun_agent_manager/src/app/api/v1/routers/memory.py
@@ -29,6 +29,7 @@ from app.api.v1.deps import (
 )
 from app.infrastructure.db.models.managed_agent import ManagedAgentModel
 from app.infrastructure.db.models.managed_memory import ManagedMemoryModel
+from app.services.connection_check import ConnectionCheckResponse, check_memory
 from app.services.engine_config import recompute_engine_config
 
 router = APIRouter()
@@ -38,6 +39,20 @@ logger = logging.getLogger(__name__)
 # Constants
 PAGINATION_MAX_LIMIT = 1000
 PAGINATION_DEFAULT_LIMIT = 100
+
+
+@router.post(
+    "/check-connection",
+    response_model=ConnectionCheckResponse,
+    summary="Check memory store connectivity",
+)
+async def check_memory_connection(
+    request: dict,
+    user: CurrentUser = Depends(get_current_user),
+    workspace_id: UUID = Depends(require_workspace),
+) -> ConnectionCheckResponse:
+    """Check connectivity to a memory store before saving."""
+    return await check_memory(request)
 
 
 async def _get_memory(

--- a/services/idun_agent_manager/src/app/api/v1/routers/observability.py
+++ b/services/idun_agent_manager/src/app/api/v1/routers/observability.py
@@ -27,6 +27,7 @@ from app.api.v1.deps import (
 )
 from app.infrastructure.db.models.agent_observability import AgentObservabilityModel
 from app.infrastructure.db.models.managed_observability import ManagedObservabilityModel
+from app.services.connection_check import ConnectionCheckResponse, check_observability
 from app.services.engine_config import recompute_engine_config
 
 router = APIRouter()
@@ -36,6 +37,20 @@ logger = logging.getLogger(__name__)
 # Constants
 PAGINATION_MAX_LIMIT = 1000
 PAGINATION_DEFAULT_LIMIT = 100
+
+
+@router.post(
+    "/check-connection",
+    response_model=ConnectionCheckResponse,
+    summary="Check observability provider connectivity",
+)
+async def check_observability_connection(
+    request: ObservabilityConfig,
+    user: CurrentUser = Depends(get_current_user),
+    workspace_id: UUID = Depends(require_workspace),
+) -> ConnectionCheckResponse:
+    """Check connectivity to an observability provider before saving."""
+    return await check_observability(request)
 
 
 async def _get_observability(

--- a/services/idun_agent_manager/src/app/services/connection_check.py
+++ b/services/idun_agent_manager/src/app/services/connection_check.py
@@ -32,7 +32,7 @@ async def check_observability(config: ObservabilityConfig) -> ConnectionCheckRes
             _dispatch_observability(config.provider, opts),
             timeout=CHECK_TIMEOUT_SECONDS,
         )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         result = (False, f"Connection timed out after {CHECK_TIMEOUT_SECONDS}s")
     except Exception as e:
         logger.debug("Observability check failed", exc_info=True)
@@ -54,7 +54,7 @@ async def check_memory(config: dict) -> ConnectionCheckResponse:
             _dispatch_memory(config),
             timeout=CHECK_TIMEOUT_SECONDS,
         )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         result = (False, f"Connection timed out after {CHECK_TIMEOUT_SECONDS}s")
     except Exception as e:
         logger.debug("Memory check failed", exc_info=True)

--- a/services/idun_agent_manager/src/app/services/connection_check.py
+++ b/services/idun_agent_manager/src/app/services/connection_check.py
@@ -1,0 +1,168 @@
+"""Lightweight connectivity checks for observability and memory providers."""
+
+import asyncio
+import logging
+import time
+
+import httpx
+from idun_agent_schema.engine.observability_v2 import (
+    ObservabilityConfig,
+    ObservabilityProvider,
+)
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+CHECK_TIMEOUT_SECONDS = 10
+
+
+class ConnectionCheckResponse(BaseModel):
+    success: bool
+    message: str
+    provider: str
+    duration_ms: int
+
+
+async def check_observability(config: ObservabilityConfig) -> ConnectionCheckResponse:
+    start = time.monotonic()
+    opts = config.config.model_dump()
+
+    try:
+        result = await asyncio.wait_for(
+            _dispatch_observability(config.provider, opts),
+            timeout=CHECK_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        result = (False, f"Connection timed out after {CHECK_TIMEOUT_SECONDS}s")
+    except Exception as e:
+        logger.debug("Observability check failed", exc_info=True)
+        result = (False, f"Connection failed: {type(e).__name__}")
+
+    elapsed = int((time.monotonic() - start) * 1000)
+    return ConnectionCheckResponse(
+        success=result[0], message=result[1],
+        provider=config.provider.value, duration_ms=elapsed,
+    )
+
+
+async def check_memory(config: dict) -> ConnectionCheckResponse:
+    start = time.monotonic()
+    mem_type = config.get("type", "unknown")
+
+    try:
+        result = await asyncio.wait_for(
+            _dispatch_memory(config),
+            timeout=CHECK_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        result = (False, f"Connection timed out after {CHECK_TIMEOUT_SECONDS}s")
+    except Exception as e:
+        logger.debug("Memory check failed", exc_info=True)
+        result = (False, f"Connection failed: {type(e).__name__}")
+
+    elapsed = int((time.monotonic() - start) * 1000)
+    return ConnectionCheckResponse(
+        success=result[0], message=result[1], provider=mem_type, duration_ms=elapsed,
+    )
+
+
+async def _dispatch_observability(
+    provider: ObservabilityProvider, opts: dict,
+) -> tuple[bool, str]:
+    match provider:
+        case ObservabilityProvider.LANGFUSE:
+            return await _check_langfuse(opts)
+        case ObservabilityProvider.LANGSMITH:
+            return await _check_langsmith(opts)
+        case ObservabilityProvider.PHOENIX:
+            return await _check_phoenix(opts)
+        case ObservabilityProvider.GCP_LOGGING | ObservabilityProvider.GCP_TRACE:
+            return (True, "Config format is valid. GCP connectivity check is not supported.")
+        case _:
+            return (False, f"Unsupported provider: {provider.value}")
+
+
+async def _dispatch_memory(config: dict) -> tuple[bool, str]:
+    match config.get("type", ""):
+        case "postgres":
+            return await _check_postgres(config.get("db_url", ""))
+        case "sqlite":
+            return await _check_sqlite(config.get("db_url", ""))
+        case "memory" | "in_memory":
+            return (True, "In-memory store is always available")
+        case _:
+            return (False, f"Unsupported memory type: {config.get('type', '')}")
+
+
+async def _check_langfuse(opts: dict) -> tuple[bool, str]:
+    host = (opts.get("host") or "https://cloud.langfuse.com").rstrip("/")
+    public_key = opts.get("public_key", "")
+    secret_key = opts.get("secret_key", "")
+    if not public_key or not secret_key:
+        return (False, "Public key and secret key are required")
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{host}/api/public/ingestion",
+            auth=(public_key, secret_key),
+            json={"batch": []},
+        )
+        if resp.status_code in (200, 207):
+            return (True, "Connected to Langfuse successfully")
+        return (False, f"Langfuse returned status {resp.status_code}")
+
+
+async def _check_langsmith(opts: dict) -> tuple[bool, str]:
+    endpoint = (opts.get("endpoint") or "https://api.smith.langchain.com").rstrip("/")
+    api_key = opts.get("api_key", "")
+    if not api_key:
+        return (False, "API key is required")
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{endpoint}/info", headers={"x-api-key": api_key})
+        if resp.status_code == 200:
+            return (True, "Connected to LangSmith successfully")
+        return (False, f"LangSmith returned status {resp.status_code}")
+
+
+async def _check_phoenix(opts: dict) -> tuple[bool, str]:
+    endpoint = (opts.get("collector_endpoint") or "").rstrip("/")
+    if not endpoint:
+        return (False, "Collector endpoint is required")
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(endpoint)
+        if resp.status_code == 200:
+            return (True, "Connected to Phoenix successfully")
+        return (False, f"Phoenix returned status {resp.status_code}")
+
+
+async def _check_postgres(db_url: str) -> tuple[bool, str]:
+    if not db_url:
+        return (False, "Database URL is required")
+    try:
+        import psycopg
+    except ImportError:
+        return (False, "psycopg is not installed; cannot check PostgreSQL connectivity")
+    try:
+        async with await psycopg.AsyncConnection.connect(db_url, autocommit=True) as conn:
+            await (await conn.execute("SELECT 1")).fetchone()
+            return (True, "Connected to PostgreSQL successfully")
+    except Exception as e:
+        return (False, f"PostgreSQL error: {e}")
+
+
+async def _check_sqlite(db_url: str) -> tuple[bool, str]:
+    if not db_url:
+        return (False, "Database URL is required")
+    path = db_url.removeprefix("sqlite:///")
+    try:
+        import aiosqlite
+    except ImportError:
+        return (False, "aiosqlite is not installed; cannot check SQLite connectivity")
+    try:
+        async with aiosqlite.connect(path) as db:
+            await db.execute("SELECT 1")
+            return (True, "Connected to SQLite successfully")
+    except Exception as e:
+        return (False, f"SQLite error: {e}")

--- a/services/idun_agent_manager/src/app/services/connection_check.py
+++ b/services/idun_agent_manager/src/app/services/connection_check.py
@@ -145,11 +145,12 @@ async def _check_postgres(db_url: str) -> tuple[bool, str]:
     except ImportError:
         return (False, "psycopg is not installed; cannot check PostgreSQL connectivity")
     try:
-        async with await psycopg.AsyncConnection.connect(db_url, autocommit=True) as conn:
+        async with await psycopg.AsyncConnection.connect(db_url, autocommit=True, connect_timeout=5) as conn:
             await (await conn.execute("SELECT 1")).fetchone()
             return (True, "Connected to PostgreSQL successfully")
     except Exception as e:
-        return (False, f"PostgreSQL error: {e}")
+        msg = str(e).split("\n")[0]
+        return (False, f"PostgreSQL error: {msg}")
 
 
 async def _check_sqlite(db_url: str) -> tuple[bool, str]:

--- a/services/idun_agent_manager/src/app/services/connection_check.py
+++ b/services/idun_agent_manager/src/app/services/connection_check.py
@@ -84,7 +84,7 @@ async def _dispatch_observability(
 
 async def _dispatch_memory(config: dict) -> tuple[bool, str]:
     match config.get("type", ""):
-        case "postgres":
+        case "postgres" | "database":
             return await _check_postgres(config.get("db_url", ""))
         case "sqlite":
             return await _check_sqlite(config.get("db_url", ""))

--- a/services/idun_agent_manager/tests/unit/test_connection_check.py
+++ b/services/idun_agent_manager/tests/unit/test_connection_check.py
@@ -1,0 +1,205 @@
+"""Unit tests for connection check service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from idun_agent_schema.engine.observability_v2 import (
+    LangfuseConfig,
+    LangsmithConfig,
+    ObservabilityConfig,
+    ObservabilityProvider,
+    PhoenixConfig,
+)
+
+from app.services.connection_check import (
+    ConnectionCheckResponse,
+    check_memory,
+    check_observability,
+)
+
+
+@pytest.mark.asyncio
+class TestCheckObservability:
+    async def test_langfuse_success(self):
+        config = ObservabilityConfig(
+            provider=ObservabilityProvider.LANGFUSE,
+            enabled=True,
+            config=LangfuseConfig(
+                host="https://cloud.langfuse.com",
+                public_key="pk-lf-test",
+                secret_key="sk-lf-test",
+            ),
+        )
+        mock_resp = MagicMock(status_code=207)
+        with patch("app.services.connection_check.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await check_observability(config)
+
+        assert result.success is True
+        assert result.provider == "LANGFUSE"
+
+    async def test_langfuse_missing_keys(self):
+        config = ObservabilityConfig(
+            provider=ObservabilityProvider.LANGFUSE,
+            enabled=True,
+            config=LangfuseConfig(host="https://cloud.langfuse.com"),
+        )
+        result = await check_observability(config)
+        assert result.success is False
+        assert "required" in result.message.lower()
+
+    async def test_langsmith_success(self):
+        config = ObservabilityConfig(
+            provider=ObservabilityProvider.LANGSMITH,
+            enabled=True,
+            config=LangsmithConfig(api_key="lsv2_test"),
+        )
+        mock_resp = MagicMock(status_code=200)
+        with patch("app.services.connection_check.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await check_observability(config)
+
+        assert result.success is True
+        assert result.provider == "LANGSMITH"
+
+    async def test_langsmith_missing_key(self):
+        config = ObservabilityConfig(
+            provider=ObservabilityProvider.LANGSMITH,
+            enabled=True,
+            config=LangsmithConfig(),
+        )
+        result = await check_observability(config)
+        assert result.success is False
+        assert "required" in result.message.lower()
+
+    async def test_phoenix_success(self):
+        config = ObservabilityConfig(
+            provider=ObservabilityProvider.PHOENIX,
+            enabled=True,
+            config=PhoenixConfig(collector_endpoint="http://localhost:6006"),
+        )
+        mock_resp = MagicMock(status_code=200)
+        with patch("app.services.connection_check.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await check_observability(config)
+
+        assert result.success is True
+        assert result.provider == "PHOENIX"
+
+    async def test_phoenix_missing_endpoint(self):
+        config = ObservabilityConfig(
+            provider=ObservabilityProvider.PHOENIX,
+            enabled=True,
+            config=PhoenixConfig(collector_endpoint=""),
+        )
+        result = await check_observability(config)
+        assert result.success is False
+        assert "required" in result.message.lower()
+
+    async def test_gcp_returns_valid(self):
+        from idun_agent_schema.engine.observability_v2 import GCPLoggingConfig
+
+        config = ObservabilityConfig(
+            provider=ObservabilityProvider.GCP_LOGGING,
+            enabled=True,
+            config=GCPLoggingConfig(project_id="my-project"),
+        )
+        result = await check_observability(config)
+        assert result.success is True
+        assert "not supported" in result.message.lower()
+
+    async def test_response_has_duration(self):
+        config = ObservabilityConfig(
+            provider=ObservabilityProvider.LANGFUSE,
+            enabled=True,
+            config=LangfuseConfig(),
+        )
+        result = await check_observability(config)
+        assert result.duration_ms >= 0
+
+
+@pytest.mark.asyncio
+class TestCheckMemory:
+    async def test_postgres_success(self):
+        mock_conn = AsyncMock()
+        mock_cursor = AsyncMock()
+        mock_cursor.fetchone.return_value = (1,)
+        mock_conn.execute.return_value = mock_cursor
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.dict("sys.modules", {"psycopg": (mock_psycopg := MagicMock())}):
+            mock_psycopg.AsyncConnection.connect = AsyncMock(return_value=mock_conn)
+            result = await check_memory({"type": "postgres", "db_url": "postgresql://localhost/test"})
+
+        assert result.success is True
+        assert result.provider == "postgres"
+
+    async def test_database_type_routes_to_postgres(self):
+        mock_conn = AsyncMock()
+        mock_cursor = AsyncMock()
+        mock_cursor.fetchone.return_value = (1,)
+        mock_conn.execute.return_value = mock_cursor
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.dict("sys.modules", {"psycopg": (mock_psycopg := MagicMock())}):
+            mock_psycopg.AsyncConnection.connect = AsyncMock(return_value=mock_conn)
+            result = await check_memory({"type": "database", "db_url": "postgresql://localhost/test"})
+
+        assert result.success is True
+        assert result.provider == "database"
+
+    async def test_postgres_missing_url(self):
+        result = await check_memory({"type": "postgres", "db_url": ""})
+        assert result.success is False
+
+    async def test_sqlite_success(self):
+        mock_db = AsyncMock()
+        mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_db.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.dict("sys.modules", {"aiosqlite": (mock_aiosqlite := MagicMock())}):
+            mock_aiosqlite.connect.return_value = mock_db
+            result = await check_memory({"type": "sqlite", "db_url": "sqlite:///test.db"})
+
+        assert result.success is True
+        assert result.provider == "sqlite"
+
+    async def test_in_memory_always_succeeds(self):
+        result = await check_memory({"type": "in_memory"})
+        assert result.success is True
+
+    async def test_memory_type_always_succeeds(self):
+        result = await check_memory({"type": "memory"})
+        assert result.success is True
+
+    async def test_unsupported_type(self):
+        result = await check_memory({"type": "redis"})
+        assert result.success is False
+        assert "unsupported" in result.message.lower()
+
+    async def test_postgres_connection_error(self):
+        with patch.dict("sys.modules", {"psycopg": (mock_psycopg := MagicMock())}):
+            mock_psycopg.AsyncConnection.connect = AsyncMock(
+                side_effect=Exception("Connection refused")
+            )
+            result = await check_memory({"type": "postgres", "db_url": "postgresql://bad/db"})
+
+        assert result.success is False
+        assert "Connection refused" in result.message

--- a/services/idun_agent_manager/tests/unit/test_connection_check.py
+++ b/services/idun_agent_manager/tests/unit/test_connection_check.py
@@ -12,7 +12,6 @@ from idun_agent_schema.engine.observability_v2 import (
 )
 
 from app.services.connection_check import (
-    ConnectionCheckResponse,
     check_memory,
     check_observability,
 )

--- a/services/idun_agent_web/src/components/applications/check-connection-button/component.tsx
+++ b/services/idun_agent_web/src/components/applications/check-connection-button/component.tsx
@@ -1,0 +1,107 @@
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { Wifi, WifiOff, Loader2 } from 'lucide-react';
+import type { ConnectionCheckResponse } from '../../../services/applications';
+
+interface Props {
+    onCheck: () => Promise<ConnectionCheckResponse>;
+    disabled?: boolean;
+}
+
+type Status = 'idle' | 'checking' | 'success' | 'failed';
+
+const RESET_DELAY_MS = 5000;
+
+export default function CheckConnectionButton({ onCheck, disabled }: Props) {
+    const [status, setStatus] = useState<Status>('idle');
+    const [message, setMessage] = useState('');
+
+    useEffect(() => {
+        if (status !== 'success' && status !== 'failed') return;
+        const timer = setTimeout(() => setStatus('idle'), RESET_DELAY_MS);
+        return () => clearTimeout(timer);
+    }, [status]);
+
+    const handleClick = async () => {
+        setStatus('checking');
+        setMessage('');
+        try {
+            const result = await onCheck();
+            setStatus(result.success ? 'success' : 'failed');
+            setMessage(result.message);
+        } catch {
+            setStatus('failed');
+            setMessage('Connection check request failed');
+        }
+    };
+
+    return (
+        <Container>
+            <Button onClick={handleClick} disabled={disabled || status === 'checking'} type="button">
+                {status === 'checking' ? (
+                    <><SpinningLoader size={14} /> Checking...</>
+                ) : (
+                    <><Wifi size={14} /> Check Connection</>
+                )}
+            </Button>
+            {status === 'success' && (
+                <StatusMessage $variant="success">
+                    <Wifi size={12} /> {message}
+                </StatusMessage>
+            )}
+            {status === 'failed' && (
+                <StatusMessage $variant="error">
+                    <WifiOff size={12} /> {message}
+                </StatusMessage>
+            )}
+        </Container>
+    );
+}
+
+const Container = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 10px;
+`;
+
+const Button = styled.button`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    color: hsl(var(--foreground));
+    background-color: rgba(140, 82, 255, 0.15);
+    border: 1px solid rgba(140, 82, 255, 0.3);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s;
+
+    &:hover:not(:disabled) {
+        background-color: rgba(140, 82, 255, 0.25);
+        border-color: #8c52ff;
+    }
+
+    &:disabled {
+        opacity: 0.7;
+        cursor: wait;
+    }
+`;
+
+const SpinningLoader = styled(Loader2)`
+    animation: spin 1s linear infinite;
+    @keyframes spin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+    }
+`;
+
+const StatusMessage = styled.span<{ $variant: 'success' | 'error' }>`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    ${props => props.$variant === 'success' ? `color: #34d399;` : `color: #f87171;`}
+`;

--- a/services/idun_agent_web/src/components/applications/create-observability-modal/component.tsx
+++ b/services/idun_agent_web/src/components/applications/create-observability-modal/component.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { Eye, EyeOff } from 'lucide-react';
-import { createApplication, updateApplication } from '../../../services/applications';
+import { createApplication, updateApplication, checkObservabilityConnection, mapConfigToApi, mapTypeToProvider } from '../../../services/applications';
 import type { AppType, ApplicationConfig } from '../../../types/application.types';
+import CheckConnectionButton from '../check-connection-button/component';
 
 interface Props {
     isOpen: boolean;
@@ -287,7 +288,13 @@ const Footer = styled.div`
     padding: 20px 28px;
     border-top: 1px solid var(--border-subtle);
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+`;
+
+const FooterRight = styled.div`
+    display: flex;
     gap: 12px;
 `;
 
@@ -532,11 +539,23 @@ const CreateObservabilityModal: React.FC<Props> = ({ isOpen, onClose, onCreated,
                         </FormBody>
 
                         <Footer>
-                            <CancelBtn type="button" onClick={onClose}>Cancel</CancelBtn>
-                            <SubmitBtn type="submit" disabled={!provider || isLoading}>
-                                {isLoading && <Spinner />}
-                                {isEditMode ? 'Save Changes' : 'Connect'}
-                            </SubmitBtn>
+                            {provider && (
+                                <CheckConnectionButton
+                                    disabled={!provider || isLoading}
+                                    onCheck={() => checkObservabilityConnection({
+                                        provider: mapTypeToProvider(provider.id),
+                                        enabled: true,
+                                        config: mapConfigToApi(provider.id, formValues),
+                                    })}
+                                />
+                            )}
+                            <FooterRight>
+                                <CancelBtn type="button" onClick={onClose}>Cancel</CancelBtn>
+                                <SubmitBtn type="submit" disabled={!provider || isLoading}>
+                                    {isLoading && <Spinner />}
+                                    {isEditMode ? 'Save Changes' : 'Connect'}
+                                </SubmitBtn>
+                            </FooterRight>
                         </Footer>
                     </form>
                 </RightPanel>

--- a/services/idun_agent_web/src/pages/memory-page/page.tsx
+++ b/services/idun_agent_web/src/pages/memory-page/page.tsx
@@ -10,9 +10,12 @@ import {
     GitPullRequest,
     X,
     Search,
+    Wifi,
+    WifiOff,
+    Loader2,
 } from 'lucide-react';
 import DeleteConfirmModal from '../../components/applications/delete-confirm-modal/component';
-import { fetchApplications, deleteApplication, createApplication, updateApplication } from '../../services/applications';
+import { fetchApplications, deleteApplication, createApplication, updateApplication, checkMemoryConnection, mapConfigToApi } from '../../services/applications';
 import type { AppType } from '../../types/application.types';
 import type { ApplicationConfig } from '../../types/application.types';
 import { notify } from '../../components/toast/notify';
@@ -454,6 +457,43 @@ const DeleteBtn = styled.button`
     &:hover { background: rgba(248, 113, 113, 0.18); }
 `;
 
+const VerifyBtn = styled.button`
+    flex: 1;
+    padding: 7px;
+    background: rgba(140, 82, 255, 0.08);
+    border: 1px solid rgba(140, 82, 255, 0.25);
+    border-radius: 8px;
+    color: #8c52ff;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    &:hover:not(:disabled) { background: rgba(140, 82, 255, 0.18); }
+    &:disabled { opacity: 0.7; cursor: wait; }
+`;
+
+const VerifySpinner = styled(Loader2)`
+    animation: spin 1s linear infinite;
+    @keyframes spin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+    }
+`;
+
+const VerifyStatus = styled.div<{ $success: boolean }>`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    margin-top: 4px;
+    ${p => p.$success ? `color: #34d399;` : `color: #f87171;`}
+`;
+
 // ── Per-provider modal ───────────────────────────────────────────────────────
 
 const modalIn = keyframes`from { opacity: 0; transform: scale(0.97) translateY(6px); } to { opacity: 1; transform: scale(1) translateY(0); }`;
@@ -845,6 +885,27 @@ const MemoryPage: React.FC = () => {
     // Delete
     const [appToDelete, setAppToDelete] = useState<ApplicationConfig | null>(null);
 
+    // Verify
+    const [verifying, setVerifying] = useState<Record<string, boolean>>({});
+    const [verifyResult, setVerifyResult] = useState<Record<string, { success: boolean; message: string }>>({});
+
+    const handleVerify = async (mem: ApplicationConfig) => {
+        if (!mem.id) return;
+        setVerifying(prev => ({ ...prev, [mem.id!]: true }));
+        setVerifyResult(prev => { const next = { ...prev }; delete next[mem.id!]; return next; });
+        try {
+            const config = mapConfigToApi(mem.type, mem.config);
+            const result = await checkMemoryConnection(config);
+            setVerifyResult(prev => ({ ...prev, [mem.id!]: { success: result.success, message: result.message } }));
+            setTimeout(() => setVerifyResult(prev => { const next = { ...prev }; delete next[mem.id!]; return next; }), 10000);
+        } catch {
+            setVerifyResult(prev => ({ ...prev, [mem.id!]: { success: false, message: 'Request failed' } }));
+            setTimeout(() => setVerifyResult(prev => { const next = { ...prev }; delete next[mem.id!]; return next; }), 10000);
+        } finally {
+            setVerifying(prev => ({ ...prev, [mem.id!]: false }));
+        }
+    };
+
     const loadMemories = useCallback(async () => {
         setIsLoading(true);
         try {
@@ -1011,9 +1072,20 @@ const MemoryPage: React.FC = () => {
                                         </UpdatedLabel>
 
                                         <CardActions>
+                                            {mem.type !== 'AdkInMemory' && (
+                                                <VerifyBtn onClick={() => handleVerify(mem)} disabled={verifying[mem.id!]}>
+                                                    {verifying[mem.id!] ? <><VerifySpinner size={12} /> Checking...</> : <><Wifi size={12} /> Verify</>}
+                                                </VerifyBtn>
+                                            )}
                                             <EditBtn onClick={() => openEdit(mem)}>Edit</EditBtn>
                                             <DeleteBtn onClick={() => setAppToDelete(mem)}>Remove</DeleteBtn>
                                         </CardActions>
+                                        {verifyResult[mem.id!] && (
+                                            <VerifyStatus $success={verifyResult[mem.id!].success}>
+                                                {verifyResult[mem.id!].success ? <Wifi size={12} /> : <WifiOff size={12} />}
+                                                {verifyResult[mem.id!].message}
+                                            </VerifyStatus>
+                                        )}
                                     </Card>
                                 );
                             })}

--- a/services/idun_agent_web/src/pages/memory-page/page.tsx
+++ b/services/idun_agent_web/src/pages/memory-page/page.tsx
@@ -599,10 +599,19 @@ const Required = styled.span`
     color: hsl(var(--destructive));
 `;
 
+
 const FieldHint = styled.p`
     font-size: 11px;
     color: hsl(var(--muted-foreground));
-    margin: 4px 0 0;
+    margin: 8px 0 0;
+    line-height: 1.5;
+    code {
+        background: rgba(140, 82, 255, 0.1);
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 11px;
+        color: #8c52ff;
+    }
 `;
 
 const Input = styled.input`
@@ -810,6 +819,7 @@ const MemoryModal: React.FC<MemoryModalProps> = ({ provider, framework, appToEdi
                                     value={connectionUrl}
                                     onChange={e => setConnectionUrl(e.target.value)}
                                 />
+                                <FieldHint>If your database is on the host and the manager runs in Docker, use <code>host.docker.internal</code> instead of <code>localhost</code>.</FieldHint>
                             </FieldGroup>
                         )}
 

--- a/services/idun_agent_web/src/pages/observability-page/page.tsx
+++ b/services/idun_agent_web/src/pages/observability-page/page.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import styled, { keyframes } from 'styled-components';
-import { Eye, EyeOff, ExternalLink, X, BookOpen, GitPullRequest, Search } from 'lucide-react';
-import { fetchApplications, deleteApplication, createApplication, updateApplication } from '../../services/applications';
+import { Eye, EyeOff, X, BookOpen, GitPullRequest, Search, Wifi, WifiOff, Loader2 } from 'lucide-react';
+import { fetchApplications, deleteApplication, createApplication, updateApplication, checkObservabilityConnection, mapConfigToApi, mapTypeToProvider } from '../../services/applications';
 import type { ApplicationConfig } from '../../types/application.types';
 import type { AppType } from '../../types/application.types';
 import DeleteConfirmModal from '../../components/applications/delete-confirm-modal/component';
@@ -483,23 +483,41 @@ const CardActions = styled.div`
     margin-top: auto;
 `;
 
-const VisitBtn = styled.a`
+const VerifyBtn = styled.button`
     flex: 1;
     padding: 7px;
-    background: rgba(99, 179, 237, 0.08);
-    border: 1px solid rgba(99, 179, 237, 0.25);
+    background: rgba(140, 82, 255, 0.08);
+    border: 1px solid rgba(140, 82, 255, 0.25);
     border-radius: 8px;
-    color: #63b3ed;
+    color: #8c52ff;
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;
     transition: all 0.15s;
-    text-decoration: none;
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 4px;
-    &:hover { background: rgba(99, 179, 237, 0.18); }
+    &:hover:not(:disabled) { background: rgba(140, 82, 255, 0.18); }
+    &:disabled { opacity: 0.7; cursor: wait; }
+`;
+
+const VerifySpinner = styled(Loader2)`
+    animation: spin 1s linear infinite;
+    @keyframes spin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+    }
+`;
+
+const VerifyStatus = styled.div<{ $success: boolean }>`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    margin-top: 4px;
+    ${p => p.$success ? `color: #34d399;` : `color: #f87171;`}
 `;
 
 const EditBtn = styled.button`
@@ -930,6 +948,8 @@ const ObservabilityPage: React.FC = () => {
     const [modalProvider, setModalProvider] = useState<ProviderMeta | null>(null);
     const [appToEdit, setAppToEdit] = useState<ApplicationConfig | null>(null);
     const [appToDelete, setAppToDelete] = useState<ApplicationConfig | null>(null);
+    const [verifying, setVerifying] = useState<Record<string, boolean>>({});
+    const [verifyResult, setVerifyResult] = useState<Record<string, { success: boolean; message: string }>>({});
 
     const openModal = (provider: ProviderMeta, app?: ApplicationConfig) => {
         setModalProvider(provider);
@@ -950,6 +970,26 @@ const ObservabilityPage: React.FC = () => {
     }, []);
 
     useEffect(() => { loadApps(); }, [loadApps]);
+
+    const handleVerify = async (app: ApplicationConfig) => {
+        if (!app.id) return;
+        setVerifying(prev => ({ ...prev, [app.id!]: true }));
+        setVerifyResult(prev => { const next = { ...prev }; delete next[app.id!]; return next; });
+        try {
+            const result = await checkObservabilityConnection({
+                provider: mapTypeToProvider(app.type),
+                enabled: true,
+                config: mapConfigToApi(app.type, app.config),
+            });
+            setVerifyResult(prev => ({ ...prev, [app.id!]: { success: result.success, message: result.message } }));
+            setTimeout(() => setVerifyResult(prev => { const next = { ...prev }; delete next[app.id!]; return next; }), 10000);
+        } catch {
+            setVerifyResult(prev => ({ ...prev, [app.id!]: { success: false, message: 'Request failed' } }));
+            setTimeout(() => setVerifyResult(prev => { const next = { ...prev }; delete next[app.id!]; return next; }), 10000);
+        } finally {
+            setVerifying(prev => ({ ...prev, [app.id!]: false }));
+        }
+    };
 
     const handleDeleteConfirm = async () => {
         if (!appToDelete?.id) return;
@@ -1041,7 +1081,6 @@ const ObservabilityPage: React.FC = () => {
                             }).map(app => {
                                 const config = flattenConfig(app.config);
                                 const configEntries = Object.entries(config);
-                                const providerUrl = getProviderUrl(app);
                                 const providerMeta = OBS_PROVIDERS.find(p => p.id === app.type);
                                 return (
                                     <Card key={app.id}>
@@ -1072,14 +1111,18 @@ const ObservabilityPage: React.FC = () => {
                                             <AgentCountBadge>Used by {app.agentCount} agent{app.agentCount !== 1 ? 's' : ''}</AgentCountBadge>
                                         )}
                                         <CardActions>
-                                            {providerUrl && (
-                                                <VisitBtn href={providerUrl} target="_blank" rel="noopener noreferrer">
-                                                    <ExternalLink size={12} /> Visit
-                                                </VisitBtn>
-                                            )}
+                                            <VerifyBtn onClick={() => handleVerify(app)} disabled={verifying[app.id!]}>
+                                                {verifying[app.id!] ? <><VerifySpinner size={12} /> Checking...</> : <><Wifi size={12} /> Verify</>}
+                                            </VerifyBtn>
                                             <EditBtn onClick={() => providerMeta && openModal(providerMeta, app)}>Edit</EditBtn>
                                             <DeleteBtn onClick={() => setAppToDelete(app)}>Remove</DeleteBtn>
                                         </CardActions>
+                                        {verifyResult[app.id!] && (
+                                            <VerifyStatus $success={verifyResult[app.id!].success}>
+                                                {verifyResult[app.id!].success ? <Wifi size={12} /> : <WifiOff size={12} />}
+                                                {verifyResult[app.id!].message}
+                                            </VerifyStatus>
+                                        )}
                                     </Card>
                                 );
                             })}

--- a/services/idun_agent_web/src/services/applications.ts
+++ b/services/idun_agent_web/src/services/applications.ts
@@ -966,6 +966,19 @@ export const discoverTools = async (id: string): Promise<MCPTool[]> => {
     return res.tools;
 };
 
+export interface ConnectionCheckResponse {
+    success: boolean;
+    message: string;
+    provider: string;
+    duration_ms: number;
+}
+
+export const checkObservabilityConnection = (config: unknown): Promise<ConnectionCheckResponse> =>
+    postJson<ConnectionCheckResponse>('/api/v1/observability/check-connection', config);
+
+export const checkMemoryConnection = (config: unknown): Promise<ConnectionCheckResponse> =>
+    postJson<ConnectionCheckResponse>('/api/v1/memory/check-connection', config);
+
 const isConflictError = (e: unknown): boolean => {
     if (!(e instanceof Error)) return false;
     // The API returns JSON with a "detail" field for 409 errors


### PR DESCRIPTION
Adds "Check Connection" functionality for observability providers and memory stores (#336). Users can now verify their connection settings work before and
  after saving.

  - Backend: new `POST /observability/check-connection` and `POST /memory/check-connection` endpoints with lightweight connectivity checks (Langfuse,
  LangSmith, Phoenix, PostgreSQL, SQLite, ADK database)
  - Frontend: "Verify" button on observability and memory card views with loading/success/error states (auto-clears after 10s)
  - Reusable `CheckConnectionButton` component
  - Hint under database connection URL field explaining `host.docker.internal` for Docker setups
  - Docs updated for all providers

  ## Checklist

  - [x] I ran the relevant checks (`make precommit` and/or `make test`)
  - [x] I updated documentation where applicable
  - [x] I added/updated tests where applicable
  - [x] This change is not introducing secrets (API keys, tokens, credentials) into the repo

  ## Screenshots / Notes (optional)
  <img width="528" height="234" alt="Screenshot 2026-03-24 at 14 32 26" src="https://github.com/user-attachments/assets/d0b4b00d-81d9-43ac-8ffb-e05890dce6a6" />

  - GCP Logging/Trace returns "config valid" without a real connectivity check
  - MCP servers already have `discover_tools` which serves the same purpose
  - The verify runs from the manager's network — a hint explains to use `host.docker.internal` if the DB is on the host