### PR TITLE
Fix/docker compose production (#400)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,63 @@
-# OIDC Configuration
-AUTH__PROVIDER_TYPE=okta
-AUTH__ISSUER=
-AUTH__CLIENT_ID=
-AUTH__CLIENT_SECRET=
-AUTH__SCOPES=
-AUTH__REDIRECT_URI=http://localhost:8080/api/v1/auth/callback
+# =============================================================================
+# Idun Agent Platform — Environment Configuration
+# =============================================================================
+# Copy this file to .env and fill in the values:
+#   cp .env.example .env
+#
+# For production, generate secure secret keys:
+#   openssl rand -hex 32
+# =============================================================================
 
+# -----------------------------------------------------------------------------
+# Platform version (used by docker-compose.yml to pin image tags)
+# -----------------------------------------------------------------------------
+IDUN_VERSION=latest
 
-# local auth
-AUTH_DISABLE_USERNAME_PASSWORD=false # set this to true if using sso
-AUTH__SESSION_SECRET=$2b$... # salt for hashing your passwords, only used when above is false
-
+# -----------------------------------------------------------------------------
+# Database
+# -----------------------------------------------------------------------------
 DATABASE__URL=postgresql+asyncpg://postgres:postgres@db:5432/idun_agents
-AUTH__SECRET_KEY=
-ENVIRONMENT=development
-DEBUG=true
 
-# Set if using guardrails from guardrailsai.com
-GUARDRAILS_API_KEY=XXX.eyJzdWIiOiJnaXRodWJ8MTQzNDYzMzEiLCJhcGlLZXlJZCI6IjNhMWMyYmY2LTMwNzYtNDY1OC1hMjRhLTA5MjZjNWI2ZDM4NyIsInNjb3BlIjoicmVhZDpwYWNrYWdlcyIsInBlcm1pc3Npb25zIjpbXSwiaWF0IjoxNzY0NTg5MzIyLCJleHAiOjE3NzIzNjUzMjJ9.4KUsAXEQ8mGN_iVz46HGXIUQeBbZQLEAzOOfIL_ZYQA
-LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com
-LANGSMITH_API_KEY=XXX
-LANGSMITH_PROJECT="XXX"
+# -----------------------------------------------------------------------------
+# Auth — Session & secrets
+# -----------------------------------------------------------------------------
+# Secret key for signing agent API keys (scrypt). Required.
+AUTH__SECRET_KEY=change-me-generate-with-openssl-rand-hex-32
+
+# Secret key for signing session cookies. Required.
+AUTH__SESSION_SECRET=change-me-generate-with-openssl-rand-hex-32
+
+# Set to true to disable email/password login and force SSO only
+AUTH__DISABLE_USERNAME_PASSWORD=false
+
+# -----------------------------------------------------------------------------
+# Auth — OIDC / SSO (optional, only needed if AUTH__DISABLE_USERNAME_PASSWORD=true)
+# -----------------------------------------------------------------------------
+# AUTH__GOOGLE_CLIENT_ID=
+# AUTH__GOOGLE_CLIENT_SECRET=
+# AUTH__REDIRECT_URI=http://localhost:8080/api/v1/auth/callback
+# AUTH__FRONTEND_URL=http://localhost:3000
+
+# -----------------------------------------------------------------------------
+# Environment
+# -----------------------------------------------------------------------------
+ENVIRONMENT=production
+DEBUG=false
+
+# -----------------------------------------------------------------------------
+# Observability keys (optional, set if using these providers)
+# -----------------------------------------------------------------------------
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+# LANGFUSE_BASE_URL=https://cloud.langfuse.com
+
+# LANGSMITH_API_KEY=
+# LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com
+# LANGSMITH_PROJECT=
+
+# GUARDRAILS_API_KEY=
+
+# -----------------------------------------------------------------------------
+# Demo agent (optional, used with: docker compose --profile demo up)
+# -----------------------------------------------------------------------------
+# IDUN_AGENT_API_KEY=

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,3 +1,8 @@
+# Build-from-source Docker Compose for Idun Agent Platform
+# Builds images locally instead of pulling from Docker Hub.
+# Quick start: cp .env.example .env && docker compose -f docker-compose.build.yml up --build
+# With demo agent: docker compose -f docker-compose.build.yml --profile demo up --build
+
 services:
   db:
     image: postgres:16
@@ -9,33 +14,27 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_prod_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
-    networks:
-      - idun_network
+    restart: unless-stopped
 
   manager:
     build:
       context: ./services/idun_agent_manager
       dockerfile: Dockerfile
     container_name: idun-manager
+    env_file: .env
     ports:
       - "8080:8080"
     environment:
-      # Database connection
       DATABASE__URL: postgresql+asyncpg://postgres:postgres@db:5432/idun_agents
-      DATABASEAUTO_MIGRATE: true
-      AUTH__SECRET_KEY: your-super-secret-key-at-least-32-characters-long-dev
       ENVIRONMENT: production
-      # Server configuration
       PORT: 8080
       WORKERS: 2
-
-      # Database tuning
       DATABASE__ECHO: "false"
       DATABASE__POOL_SIZE: 10
       DATABASE__MAX_OVERFLOW: 20
@@ -48,8 +47,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
-    networks:
-      - idun_network
     restart: unless-stopped
 
   web:
@@ -58,36 +55,28 @@ services:
       dockerfile: Dockerfile
     container_name: idun-web
     ports:
-      - "3000:3000"
+      - "3000:8080"
     environment:
-      - VITE_API_URL=http://localhost:8080 # http://host.docker.internal:8000
-    networks:
-      - idun_network
+      - API_URL=http://localhost:8080
+      - AUTH_DISABLE_USERNAME_PASSWORD=${AUTH__DISABLE_USERNAME_PASSWORD:-false}
     depends_on:
       - manager
 
   agent:
+    profiles: ["demo"]
     build:
       context: ./libs/idun_agent_engine/examples/01_basic_config_file
       dockerfile: Dockerfile
     container_name: idun-agent
     ports:
-      - "8000:8000"
-      - "6006:6006" # For Phoenix local
+      - "8002:8002"
     environment:
-      IDUN_AGENT_API_KEY: 5301ca0c03f221b0aadda428bc335dd1811871e0bd32a30af5f73a5ab20ab733
-      IDUN_MANAGER_HOST: http://manager:8080/api/v1/agents/config
+      IDUN_AGENT_API_KEY: ${IDUN_AGENT_API_KEY:-}
+      IDUN_MANAGER_HOST: http://manager:8080
     depends_on:
       manager:
         condition: service_healthy
-    networks:
-      - idun_network
     restart: unless-stopped
 
 volumes:
-  postgres_prod_data:
-  phoenix_prod_data:
-
-networks:
-  idun_network:
-    driver: bridge
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,8 @@
+# Production Docker Compose for Idun Agent Platform
+# Uses prebuilt images from Docker Hub.
+# Quick start: cp .env.example .env && docker compose up
+# With demo agent: docker compose --profile demo up
+
 services:
   db:
     image: postgres:16
@@ -15,28 +20,19 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    # networks:
-    #   - idun_network
+    restart: unless-stopped
 
   manager:
-    image: freezaa9/idun-ai:0.5.1
+    image: freezaa9/idun-ai:${IDUN_VERSION:-latest}
     container_name: idun-manager
+    env_file: .env
     ports:
-      - "8000:8000"
-    volumes:
-      - ./services/idun_agent_manager/alembic:/app/alembic
-      - ./services/idun_agent_manager/src:/app/src
+      - "8080:8080"
     environment:
-      # Database connection
       DATABASE__URL: postgresql+asyncpg://postgres:postgres@db:5432/idun_agents
-      DATABASEAUTO_MIGRATE: true
-      AUTH__SECRET_KEY: your-super-secret-key-at-least-32-characters-long-dev
       ENVIRONMENT: production
-      # Server configuration
-      PORT: 8000
+      PORT: 8080
       WORKERS: 2
-
-      # Database tuning
       DATABASE__ECHO: "false"
       DATABASE__POOL_SIZE: 10
       DATABASE__MAX_OVERFLOW: 20
@@ -49,44 +45,34 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
-    # networks:
-    #   - idun_network
     restart: unless-stopped
 
   web:
-    image: freezaa9/idun-ai-web:0.5.1
+    image: freezaa9/idun-ai-web:${IDUN_VERSION:-latest}
     container_name: idun-web
     ports:
-      - "3000:3000"
+      - "3000:8080"
     environment:
-      - VITE_API_URL=http://localhost:8000 # http://host.docker.internal:8000
-      - CHOKIDAR_USEPOLLING=true
-    # networks:
-    #   - idun_network
+      - API_URL=http://localhost:8080
+      - AUTH_DISABLE_USERNAME_PASSWORD=${AUTH__DISABLE_USERNAME_PASSWORD:-false}
     depends_on:
       - manager
 
   agent:
+    profiles: ["demo"]
     build:
       context: ./libs/idun_agent_engine/examples/01_basic_config_file
       dockerfile: Dockerfile
     container_name: idun-agent
     ports:
       - "8002:8002"
-      - "6006:6006" # For Phoenix local
     environment:
-      IDUN_AGENT_API_KEY: 5301ca0c03f221b0aadda428bc335dd1811871e0bd32a30af5f73a5ab20ab733
-      IDUN_MANAGER_HOST: http://manager:8000
+      IDUN_AGENT_API_KEY: ${IDUN_AGENT_API_KEY:-}
+      IDUN_MANAGER_HOST: http://manager:8080
     depends_on:
       manager:
         condition: service_healthy
-    # networks:
-    #   - idun_network
     restart: unless-stopped
 
 volumes:
   postgres_data:
-
-# networks:
-#   idun_network:
-#     driver: bridge

--- a/docs/deployment/overview.mdx
+++ b/docs/deployment/overview.mdx
@@ -12,11 +12,25 @@ Idun Agent Platform supports two deployment modes depending on your needs. You c
   <Tab title="Managed (full stack)">
     Deploy the Manager API, PostgreSQL database, and web UI together. Agents fetch their config from the Manager at startup.
 
+    **Production** (prebuilt images from Docker Hub):
+
     ```bash
     git clone https://github.com/Idun-Group/idun-agent-platform.git
     cd idun-agent-platform
     cp .env.example .env
+    docker compose up
+    ```
+
+    **Development** (builds from source, hot reload):
+
+    ```bash
     docker compose -f docker-compose.dev.yml up --build
+    ```
+
+    **Build from source** (production images built locally):
+
+    ```bash
+    docker compose -f docker-compose.build.yml up --build
     ```
 
     This mode suits:
@@ -39,6 +53,23 @@ Idun Agent Platform supports two deployment modes depending on your needs. You c
     - CI/CD pipelines where you version config in Git
   </Tab>
 </Tabs>
+
+## Docker Compose variants
+
+| File | Purpose | Images |
+|---|---|---|
+| `docker-compose.yml` | Production | Pulls prebuilt images from Docker Hub |
+| `docker-compose.build.yml` | Build from source | Builds images locally from Dockerfiles |
+| `docker-compose.dev.yml` | Development | Builds from source with hot reload, Vite dev server |
+| `docker-compose.debug.yml` | Debug overlay | Adds debugpy to the manager (use with `-f` alongside dev) |
+
+All production and build compose files use `env_file: .env` for secrets and configuration. Copy `.env.example` to `.env` before starting.
+
+To include the demo agent service, add the `demo` profile:
+
+```bash
+docker compose --profile demo up
+```
 
 ## Agent lifecycle management
 
@@ -73,47 +104,16 @@ In managed mode, the platform consists of three services and a database:
 
 | Component | Description | Default port |
 |---|---|---|
-| **Manager** | FastAPI control plane API for agent configuration, auth, and workspace management | 8000 |
-| **Web UI** | React admin dashboard | 3000 |
+| **Manager** | FastAPI control plane API for agent configuration, auth, and workspace management | 8080 |
+| **Web UI** | React admin dashboard (nginx in production, Vite in dev) | 3000 |
 | **PostgreSQL** | Stores agent configs, user accounts, workspace data | 5432 |
-| **Agent engines** | Your agent services, each running the Idun engine SDK | 8008+ |
-
-```yaml docker-compose.dev.yml
-services:
-  postgres:
-    image: postgres:16
-    environment:
-      POSTGRES_USER: idun
-      POSTGRES_PASSWORD: idun
-      POSTGRES_DB: idun
-    ports:
-      - "5432:5432"
-
-  manager:
-    build:
-      context: .
-      dockerfile: services/idun_agent_manager/Dockerfile
-    ports:
-      - "8000:8000"
-    environment:
-      DATABASE__URL: postgresql+asyncpg://idun:idun@postgres:5432/idun
-    depends_on:
-      - postgres
-
-  web:
-    build:
-      context: services/idun_agent_web
-    ports:
-      - "3000:3000"
-    depends_on:
-      - manager
-```
+| **Agent engines** | Your agent services, each running the Idun engine SDK | 8000+ |
 
 ## Prerequisites
 
 | Requirement | Standalone | Managed |
 |---|---|---|
-| Python 3.12+ | Yes | Yes |
+| Python 3.12+ | Yes | Yes (for agent services) |
 | Docker + Docker Compose | No | Yes |
 | PostgreSQL 16 | No | Yes (included in Docker Compose) |
 | `idun-agent-engine` package | Yes | Yes (for agent services) |

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -30,11 +30,19 @@ Before you begin, install the following:
       <Step title="Start the platform">
         <Note>Make sure the Docker daemon is running before you proceed.</Note>
 
+        **Production** (prebuilt images, fastest):
+
+        ```bash
+        docker compose up
+        ```
+
+        **Development** (builds from source, hot reload):
+
         ```bash
         docker compose -f docker-compose.dev.yml up --build
         ```
 
-        This starts PostgreSQL, the Manager API, and the web UI.
+        Both start PostgreSQL, the Manager API, and the web UI.
 
         ![Idun login page](/images/ui/login.png)
       </Step>

--- a/services/idun_agent_manager/Dockerfile
+++ b/services/idun_agent_manager/Dockerfile
@@ -83,7 +83,7 @@ RUN groupadd -r appuser --gid 1000 && \
 USER appuser
 
 # Expose default port
-EXPOSE 8000
+EXPOSE 8080
 
 # Health check endpoint
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \


### PR DESCRIPTION
Fixed production Docker Compose (issue #400):                                                                         
  - Standardized manager on port 8080, fixed healthcheck                                                             
  - Removed hardcoded secrets, source volumes, dead env vars                                                            
  - Added env_file: .env, parameterized image versions                                                                  
  - Fixed web port mapping (3000:8080), VITE_API_URL → API_URL                                                          
  - Agent service behind --profile demo                                                                              
  - Fixed IDUN_MANAGER_HOST path in build compose, removed orphaned volume                                              
  - Rewrote .env.example with all vars documented, removed leaked keys                                                  
  - Updated deployment docs and quickstart  