### PR TITLE
fix: run health checks on agent list load with identity validation (#430)

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
@@ -22,9 +22,19 @@ class ReloadRequest(BaseModel):
 
 
 @base_router.get("/health")
-def health_check():
+def health_check(request: Request):
     """Health check endpoint for monitoring and load balancers."""
-    return {"status": "ok", "service": "idun-agent-engine", "version": __version__}
+    agent = getattr(request.app.state, "agent", None)
+    configuration = getattr(agent, "configuration", None)
+    agent_name = getattr(configuration, "name", None)
+    # TODO: return managed agent UUID (from manager API response) for stronger
+    # identity validation. Currently agent_name is the only shared identifier.
+    return {
+        "status": "ok",
+        "service": "idun-agent-engine",
+        "version": __version__,
+        "agent_name": agent_name,
+    }
 
 
 @base_router.post("/reload")

--- a/libs/idun_agent_engine/tests/unit/server/test_routes_run.py
+++ b/libs/idun_agent_engine/tests/unit/server/test_routes_run.py
@@ -149,6 +149,40 @@ class TestRunRoute:
 
 
 @pytest.mark.unit
+class TestHealthRoute:
+    """Test /health endpoint."""
+
+    def test_health_returns_agent_name(self):
+        """GET /health returns agent_name from loaded agent config."""
+        config = ConfigBuilder.from_dict(_make_config("graph")).build()
+        app = create_app(engine_config=config)
+
+        with TestClient(app) as client:
+            response = client.get("/health")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "ok"
+            assert data["agent_name"] == "test_agent"
+            assert "version" in data
+
+    def test_health_returns_null_agent_name_before_init(self):
+        """GET /health returns null agent_name when no agent is loaded."""
+        from fastapi import FastAPI
+
+        from idun_agent_engine.server.routers.base import base_router
+
+        app = FastAPI()
+        app.include_router(base_router)
+
+        with TestClient(app) as client:
+            response = client.get("/health")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "ok"
+            assert data["agent_name"] is None
+
+
+@pytest.mark.unit
 class TestDeprecatedInvokeRoute:
     """Test that deprecated /agent/invoke still works."""
 

--- a/services/idun_agent_web/src/pages/agent-dashboard/page.tsx
+++ b/services/idun_agent_web/src/pages/agent-dashboard/page.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { notify } from '../../components/toast/notify';
 import { Search, Plus, Bot } from 'lucide-react';
 import type { BackendAgent } from '../../services/agents';
-import { listAgents, deleteAgent } from '../../services/agents';
+import { listAgents, deleteAgent, performHealthCheck } from '../../services/agents';
 import AgentCard from '../../components/dashboard/agents/agent-card/component';
 import DeleteConfirmModal from '../../components/applications/delete-confirm-modal/component';
 
@@ -33,14 +33,25 @@ const AgentDashboardPage = () => {
     const [agentToDelete, setAgentToDelete] = useState<BackendAgent | null>(null);
 
     useEffect(() => {
+        let cancelled = false;
         setIsLoading(true);
         listAgents()
-            .then((rows) => setAgents(rows))
+            .then((rows) => {
+                setAgents(rows);
+                for (const agent of rows) {
+                    performHealthCheck(agent, (updated) => {
+                        if (!cancelled) {
+                            setAgents((prev) => prev.map((a) => a.id === updated.id ? updated : a));
+                        }
+                    });
+                }
+            })
             .catch((error) => {
                 const message = error instanceof Error ? error.message : String(error);
                 notify.error(message);
             })
             .finally(() => setIsLoading(false));
+        return () => { cancelled = true; };
     }, []);
 
     const filteredAgents = useMemo(() => {

--- a/services/idun_agent_web/src/services/agents.ts
+++ b/services/idun_agent_web/src/services/agents.ts
@@ -211,7 +211,11 @@ export function performHealthCheck(
         })
         .then(data => {
             const isHealthy = data?.status === 'ok';
-            return updateAgentStatus(agent.id, isHealthy ? 'active' : 'draft');
+            const config = agent.engine_config?.agent?.config as Record<string, unknown> | undefined;
+            const expectedName = config?.name;
+            const returnedName = data?.agent_name;
+            const identityMatch = !expectedName || !returnedName || returnedName === expectedName;
+            return updateAgentStatus(agent.id, (isHealthy && identityMatch) ? 'active' : 'draft');
         })
         .then(updated => onStatusChange?.(updated))
         .catch(() => {


### PR DESCRIPTION
- Engine /health now returns agent_name for identity verification
- Agent dashboard triggers health checks for all agents on page load
- performHealthCheck validates agent_name matches before marking active