### PR TITLE
fix: prefill ADK app_name from agent name (#174)

### DIFF
--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/adk.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/adk.py
@@ -1,8 +1,9 @@
 """Configuration models for ADK agents."""
 
+import re
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .base_agent import BaseAgentConfig
 
@@ -75,10 +76,17 @@ class AdkAgentConfig(BaseAgentConfig):
     agent: str = Field(
         ..., description="Agent definition (e.g. module.path:agent_instance)"
     )
-    app_name: str = Field(..., description="Application name for the agent")
+    app_name: str = Field(default="", description="Application name for the agent")
     session_service: SessionServiceConfig | None = Field(
         default=None, description="Session service configuration"
     )
     memory_service: MemoryServiceConfig | None = Field(
         default=None, description="Memory service configuration"
     )
+
+    @model_validator(mode="after")
+    def _default_app_name_from_name(self) -> "AdkAgentConfig":
+        """Derive app_name from name if not explicitly provided."""
+        if not self.app_name and self.name:
+            self.app_name = re.sub(r"[^a-z0-9]+", "_", self.name.lower()).strip("_")
+        return self

--- a/services/idun_agent_web/src/pages/agent-form/page.tsx
+++ b/services/idun_agent_web/src/pages/agent-form/page.tsx
@@ -32,8 +32,18 @@ export default function AgentFormPage() {
     const [currentStep, setCurrentStep] = useState(0);
     const [state, setState] = useState<WizardState>(INITIAL_WIZARD_STATE);
 
+    const toSnakeCase = (s: string) =>
+        s.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+
     const updateField = useCallback((field: string, value: string) => {
-        setState(prev => ({ ...prev, [field]: value }));
+        setState(prev => {
+            const next = { ...prev, [field]: value };
+            // Auto-derive adkAppName from agent name
+            if (field === 'name') {
+                next.adkAppName = toSnakeCase(value);
+            }
+            return next;
+        });
     }, []);
 
     const canGoNext = (): boolean => {


### PR DESCRIPTION
Frontend auto-derives adkAppName as snake_case from the agent name. Schema defaults app_name from name via model validator when not set.

- [X] I ran the relevant checks (`make precommit` and/or `make test`)
- [X] I updated documentation where applicable
- [X] I added/updated tests where applicable
- [X] This change is not introducing secrets (API keys, tokens, credentials) into the repo


