### PR TITLE
Fix/mcp tools use active registry

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/mcp/__init__.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/mcp/__init__.py
@@ -8,10 +8,12 @@ from .helpers import (
     get_langchain_tools_from_api,
     get_langchain_tools_from_file,
 )
-from .registry import MCPClientRegistry
+from .registry import MCPClientRegistry, get_active_registry, set_active_registry
 
 __all__ = [
     "MCPClientRegistry",
+    "get_active_registry",
+    "set_active_registry",
     "get_adk_tools_from_api",
     "get_adk_tools_from_file",
     "get_adk_tools",

--- a/libs/idun_agent_engine/src/idun_agent_engine/mcp/helpers.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/mcp/helpers.py
@@ -118,8 +118,9 @@ def get_adk_tools(config_path: str | Path | None = None) -> list[Any]:
 
     The function resolves configuration in the following order:
     1. Uses the provided config_path if specified
-    2. Uses IDUN_CONFIG_PATH environment variable if set
-    3. Falls back to fetching from Idun Manager API
+    2. Uses the active in-memory registry if set (engine is running)
+    3. Uses IDUN_CONFIG_PATH environment variable if set
+    4. Falls back to fetching from Idun Manager API
 
     Args:
         config_path: Optional path to configuration YAML file. If provided, takes precedence.
@@ -134,7 +135,12 @@ def get_adk_tools(config_path: str | Path | None = None) -> list[Any]:
     if config_path:
         return get_adk_tools_from_file(config_path)
 
-    # Check for IDUN_CONFIG_PATH environment variable
+    from .registry import get_active_registry
+
+    registry = get_active_registry()
+    if registry and registry.enabled:
+        return registry.get_adk_toolsets()
+
     env_config_path = os.environ.get("IDUN_CONFIG_PATH")
     if env_config_path:
         return get_adk_tools_from_file(env_config_path)
@@ -159,8 +165,9 @@ async def get_langchain_tools(config_path: str | Path | None = None) -> list[Any
 
     The function resolves configuration in the following order:
     1. Uses the provided config_path if specified
-    2. Uses IDUN_CONFIG_PATH environment variable if set
-    3. Falls back to fetching from Idun Manager API
+    2. Uses the active in-memory registry if set (engine is running)
+    3. Uses IDUN_CONFIG_PATH environment variable if set
+    4. Falls back to fetching from Idun Manager API
 
     Args:
         config_path: Optional path to configuration YAML file. If provided, takes precedence.
@@ -175,7 +182,12 @@ async def get_langchain_tools(config_path: str | Path | None = None) -> list[Any
     if config_path:
         return await get_langchain_tools_from_file(config_path)
 
-    # Check for IDUN_CONFIG_PATH environment variable
+    from .registry import get_active_registry
+
+    registry = get_active_registry()
+    if registry and registry.enabled:
+        return await registry.get_tools()
+
     env_config_path = os.environ.get("IDUN_CONFIG_PATH")
     if env_config_path:
         return await get_langchain_tools_from_file(env_config_path)

--- a/libs/idun_agent_engine/src/idun_agent_engine/mcp/registry.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/mcp/registry.py
@@ -87,6 +87,25 @@ def _sanitize_schema(schema: Any) -> None:
             _sanitize_schema(item)
 
 
+_active_registry: MCPClientRegistry | None = None
+
+
+def set_active_registry(registry: MCPClientRegistry | None) -> None:
+    """Set the process-wide active MCP registry.
+
+    Called by the engine lifespan on startup so that helper functions
+    (get_langchain_tools, get_adk_tools) can resolve tools from memory
+    instead of re-fetching from the manager API.
+    """
+    global _active_registry
+    _active_registry = registry
+
+
+def get_active_registry() -> MCPClientRegistry | None:
+    """Return the active MCP registry, or None if not set."""
+    return _active_registry
+
+
 class MCPClientRegistry:
     """Wraps `MultiServerMCPClient` with convenience helpers."""
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -73,7 +73,10 @@ async def configure_app(app: FastAPI, engine_config):
     if mcp_servers:
         try:
             app.state.mcp_servers = mcp_servers
-            logger.info(f"Available MCP Servers: {mcp_servers}")
+            for s in mcp_servers:
+                logger.info(
+                    f"🔧 MCP Server {s.name}: [{s.transport.upper()}] {s.url or s.command}"
+                )
         except Exception as e:
             logger.exception(f"Failed to assign mcp servers to agent: {e}, continuing without them")
             mcp_servers = []

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -2,7 +2,6 @@
 
 Initializes the agent at startup and cleans up resources on shutdown.
 """
-
 import inspect
 import logging
 from collections.abc import Sequence
@@ -10,6 +9,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from idun_agent_schema.engine.guardrails import Guardrails
+
+from idun_agent_engine.mcp.registry import MCPClientRegistry, set_active_registry
 
 from ..core.config_builder import ConfigBuilder
 from ..guardrails.base import BaseGuardrail
@@ -32,6 +33,7 @@ def _parse_guardrails(guardrails_obj: Guardrails) -> Sequence[BaseGuardrail]:
 
 async def cleanup_agent(app: FastAPI):
     """Clean up agent resources."""
+    set_active_registry(None)
     agent = getattr(app.state, "agent", None)
     if agent is not None:
         close_fn = getattr(agent, "close", None)
@@ -44,13 +46,19 @@ async def cleanup_agent(app: FastAPI):
 async def configure_app(app: FastAPI, engine_config):
     """Initialize the agent, MCP registry, guardrails, and app state with the given engine config."""
     guardrails_obj = engine_config.guardrails
-    guardrails = _parse_guardrails(guardrails_obj) if guardrails_obj else []
-
-    logger.debug(f"Guardrails: {guardrails}")
+    try:
+        guardrails = _parse_guardrails(guardrails_obj) if guardrails_obj else []
+        logger.debug(f"Guardrails: {guardrails}")
+    except Exception as e:
+        logger.exception(f"Failed to parse guardrails: {e}, continuing without them")
+        guardrails = []
 
     # Use ConfigBuilder's centralized agent initialization, passing the registry
+    mcp_registry = MCPClientRegistry(engine_config.mcp_servers or [])
+    set_active_registry(mcp_registry)
+    app.state.mcp_registry = mcp_registry
     try:
-        agent_instance = await ConfigBuilder.initialize_agent_from_config(engine_config)
+        agent_instance = await ConfigBuilder.initialize_agent_from_config(engine_config, mcp_registry)
     except Exception as e:
         raise ValueError(
             f"Error retrieving agent instance from ConfigBuilder: {e}"
@@ -61,14 +69,26 @@ async def configure_app(app: FastAPI, engine_config):
     app.state.engine_config = engine_config
 
     app.state.guardrails = guardrails
+    mcp_servers = engine_config.mcp_servers
+    if mcp_servers:
+        try:
+            app.state.mcp_servers = mcp_servers
+            logger.info(f"Available MCP Servers: {mcp_servers}")
+        except Exception as e:
+            logger.exception(f"Failed to assign mcp servers to agent: {e}, continuing without them")
+            mcp_servers = []
 
     # SSO / OIDC setup
     sso_config = engine_config.sso
     if sso_config and sso_config.enabled:
         from ..server.auth import OIDCValidator
 
-        app.state.sso_validator = OIDCValidator(sso_config)
-        logger.info(f"🔒 SSO enabled — issuer: {sso_config.issuer}")
+        try:
+            app.state.sso_validator = OIDCValidator(sso_config)
+            logger.info(f"🔒 SSO enabled — issuer: {sso_config.issuer}")
+        except Exception as e:
+            logger.exception(f"Failed to add SSO: {e}, continuing without them")
+            app.state.sso_validator = None
     else:
         app.state.sso_validator = None
 

--- a/libs/idun_agent_engine/tests/unit/mcp/test_active_registry.py
+++ b/libs/idun_agent_engine/tests/unit/mcp/test_active_registry.py
@@ -1,0 +1,57 @@
+"""Tests for the active registry module-level getter/setter."""
+
+import pytest
+from idun_agent_schema.engine.mcp_server import MCPServer
+
+from idun_agent_engine.mcp.registry import (
+    MCPClientRegistry,
+    get_active_registry,
+    set_active_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_active_registry():
+    """Ensure each test starts and ends with a clean active registry."""
+    set_active_registry(None)
+    yield
+    set_active_registry(None)
+
+
+def _make_registry() -> MCPClientRegistry:
+    return MCPClientRegistry(
+        configs=[
+            MCPServer(
+                name="test-server",
+                transport="stdio",
+                command="echo",
+                args=["hello"],
+            )
+        ]
+    )
+
+
+@pytest.mark.unit
+class TestActiveRegistryLifecycle:
+    def test_default_is_none(self):
+        assert get_active_registry() is None
+
+    def test_set_and_get_returns_same_instance(self):
+        registry = _make_registry()
+        set_active_registry(registry)
+        assert get_active_registry() is registry
+
+    def test_set_twice_replaces_first(self):
+        first = _make_registry()
+        second = _make_registry()
+        set_active_registry(first)
+        set_active_registry(second)
+        assert get_active_registry() is second
+        assert get_active_registry() is not first
+
+    def test_set_none_clears(self):
+        registry = _make_registry()
+        set_active_registry(registry)
+        assert get_active_registry() is not None
+        set_active_registry(None)
+        assert get_active_registry() is None

--- a/libs/idun_agent_engine/tests/unit/mcp/test_mcp_helpers.py
+++ b/libs/idun_agent_engine/tests/unit/mcp/test_mcp_helpers.py
@@ -1,0 +1,277 @@
+"""Tests for the MCP helper resolution chain (get_langchain_tools, get_adk_tools).
+
+Verifies the resolution order:
+  1. Explicit config_path argument
+  2. Active registry (engine running, config in memory)
+  3. IDUN_CONFIG_PATH env var
+  4. Manager API fallback
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from idun_agent_schema.engine.mcp_server import MCPServer
+
+from idun_agent_engine.mcp.helpers import get_adk_tools, get_langchain_tools
+from idun_agent_engine.mcp.registry import (
+    MCPClientRegistry,
+    set_active_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_active_registry():
+    """Ensure each test starts and ends with a clean active registry."""
+    set_active_registry(None)
+    yield
+    set_active_registry(None)
+
+
+def _make_enabled_registry(tools=None) -> MCPClientRegistry:
+    """Create an enabled registry with mocked tools."""
+    registry = MCPClientRegistry(
+        configs=[
+            MCPServer(
+                name="test-server",
+                transport="stdio",
+                command="echo",
+                args=["hello"],
+            )
+        ]
+    )
+    registry._client.get_tools = AsyncMock(return_value=tools or [])
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# get_langchain_tools resolution chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetLangchainToolsResolution:
+    @pytest.mark.asyncio
+    async def test_config_path_wins_over_active_registry(self, tmp_path):
+        """Explicit config_path takes priority even when active registry is set."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "mcp_servers:\n"
+            "  - name: file-server\n"
+            "    transport: stdio\n"
+            "    command: echo\n"
+            "    args: [hello]\n"
+        )
+        registry = _make_enabled_registry(tools=["from-registry"])
+        set_active_registry(registry)
+
+        with patch(
+            "idun_agent_engine.mcp.helpers.get_langchain_tools_from_file",
+            new_callable=AsyncMock,
+            return_value=["from-file"],
+        ) as mock_file:
+            result = await get_langchain_tools(config_path=str(config_file))
+            mock_file.assert_called_once_with(str(config_file))
+            assert result == ["from-file"]
+
+    @pytest.mark.asyncio
+    async def test_uses_active_registry_when_enabled(self):
+        """When no config_path and active registry is enabled, use it."""
+        expected_tools = [MagicMock(name="tool1"), MagicMock(name="tool2")]
+        registry = _make_enabled_registry(tools=expected_tools)
+        set_active_registry(registry)
+
+        result = await get_langchain_tools()
+        assert result == expected_tools
+        registry._client.get_tools.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_disabled_active_registry(self, monkeypatch):
+        """When active registry has no servers (disabled), fall through."""
+        registry = MCPClientRegistry()  # no configs → disabled
+        set_active_registry(registry)
+
+        monkeypatch.setenv("IDUN_CONFIG_PATH", "/fake/path.yaml")
+
+        with patch(
+            "idun_agent_engine.mcp.helpers.get_langchain_tools_from_file",
+            new_callable=AsyncMock,
+            return_value=["from-env"],
+        ) as mock_file:
+            result = await get_langchain_tools()
+            mock_file.assert_called_once_with("/fake/path.yaml")
+            assert result == ["from-env"]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_env_var(self, monkeypatch):
+        """No active registry, no config_path → uses IDUN_CONFIG_PATH."""
+        monkeypatch.setenv("IDUN_CONFIG_PATH", "/env/config.yaml")
+
+        with patch(
+            "idun_agent_engine.mcp.helpers.get_langchain_tools_from_file",
+            new_callable=AsyncMock,
+            return_value=["from-env"],
+        ) as mock_file:
+            result = await get_langchain_tools()
+            mock_file.assert_called_once_with("/env/config.yaml")
+            assert result == ["from-env"]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_api(self, monkeypatch):
+        """No registry, no config_path, no env var → calls API."""
+        monkeypatch.delenv("IDUN_CONFIG_PATH", raising=False)
+
+        with patch(
+            "idun_agent_engine.mcp.helpers.get_langchain_tools_from_api",
+            new_callable=AsyncMock,
+            return_value=["from-api"],
+        ) as mock_api:
+            result = await get_langchain_tools()
+            mock_api.assert_called_once()
+            assert result == ["from-api"]
+
+    @pytest.mark.asyncio
+    async def test_api_fallback_raises_without_credentials(self, monkeypatch):
+        """API fallback raises ValueError when env vars missing."""
+        monkeypatch.delenv("IDUN_CONFIG_PATH", raising=False)
+        monkeypatch.delenv("IDUN_AGENT_API_KEY", raising=False)
+        monkeypatch.delenv("IDUN_MANAGER_HOST", raising=False)
+
+        with pytest.raises(ValueError, match="IDUN_AGENT_API_KEY"):
+            await get_langchain_tools()
+
+    @pytest.mark.asyncio
+    async def test_no_new_registry_constructed_when_active(self):
+        """Active registry is used directly — no MCPClientRegistry is constructed."""
+        expected_tools = [MagicMock(name="tool1")]
+        registry = _make_enabled_registry(tools=expected_tools)
+        set_active_registry(registry)
+
+        with patch(
+            "idun_agent_engine.mcp.helpers._build_registry"
+        ) as mock_build:
+            result = await get_langchain_tools()
+            mock_build.assert_not_called()
+            assert result == expected_tools
+
+    @pytest.mark.asyncio
+    async def test_active_registry_returns_empty_list(self):
+        """Active registry enabled but no tools discovered — returns empty list."""
+        registry = _make_enabled_registry(tools=[])
+        set_active_registry(registry)
+
+        result = await get_langchain_tools()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_adk_tools resolution chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetAdkToolsResolution:
+    def test_config_path_wins_over_active_registry(self, tmp_path):
+        """Explicit config_path takes priority even when active registry is set."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "mcp_servers:\n"
+            "  - name: file-server\n"
+            "    transport: stdio\n"
+            "    command: echo\n"
+            "    args: [hello]\n"
+        )
+        registry = _make_enabled_registry()
+        set_active_registry(registry)
+
+        with patch(
+            "idun_agent_engine.mcp.helpers.get_adk_tools_from_file",
+            return_value=["from-file"],
+        ) as mock_file:
+            result = get_adk_tools(config_path=str(config_file))
+            mock_file.assert_called_once_with(str(config_file))
+            assert result == ["from-file"]
+
+    def test_uses_active_registry_when_enabled(self):
+        """When no config_path and active registry is enabled, use it."""
+        registry = _make_enabled_registry()
+        set_active_registry(registry)
+
+        expected_toolsets = [MagicMock(name="toolset1")]
+        with patch.object(
+            registry, "get_adk_toolsets", return_value=expected_toolsets
+        ):
+            result = get_adk_tools()
+            assert result == expected_toolsets
+
+    def test_skips_disabled_active_registry(self, monkeypatch):
+        """When active registry has no servers (disabled), fall through."""
+        registry = MCPClientRegistry()  # disabled
+        set_active_registry(registry)
+
+        monkeypatch.setenv("IDUN_CONFIG_PATH", "/fake/path.yaml")
+
+        with patch(
+            "idun_agent_engine.mcp.helpers.get_adk_tools_from_file",
+            return_value=["from-env"],
+        ) as mock_file:
+            result = get_adk_tools()
+            mock_file.assert_called_once_with("/fake/path.yaml")
+            assert result == ["from-env"]
+
+    def test_falls_back_to_env_var(self, monkeypatch):
+        """No active registry, no config_path → uses IDUN_CONFIG_PATH."""
+        monkeypatch.setenv("IDUN_CONFIG_PATH", "/env/config.yaml")
+
+        with patch(
+            "idun_agent_engine.mcp.helpers.get_adk_tools_from_file",
+            return_value=["from-env"],
+        ) as mock_file:
+            result = get_adk_tools()
+            mock_file.assert_called_once_with("/env/config.yaml")
+            assert result == ["from-env"]
+
+    def test_falls_back_to_api(self, monkeypatch):
+        """No registry, no config_path, no env var → calls API."""
+        monkeypatch.delenv("IDUN_CONFIG_PATH", raising=False)
+
+        with patch(
+            "idun_agent_engine.mcp.helpers.get_adk_tools_from_api",
+            return_value=["from-api"],
+        ) as mock_api:
+            result = get_adk_tools()
+            mock_api.assert_called_once()
+            assert result == ["from-api"]
+
+    def test_api_fallback_raises_without_credentials(self, monkeypatch):
+        """API fallback raises ValueError when env vars missing."""
+        monkeypatch.delenv("IDUN_CONFIG_PATH", raising=False)
+        monkeypatch.delenv("IDUN_AGENT_API_KEY", raising=False)
+        monkeypatch.delenv("IDUN_MANAGER_HOST", raising=False)
+
+        with pytest.raises(ValueError, match="IDUN_AGENT_API_KEY"):
+            get_adk_tools()
+
+    def test_no_new_registry_constructed_when_active(self):
+        """Active registry is used directly — no MCPClientRegistry is constructed."""
+        registry = _make_enabled_registry()
+        set_active_registry(registry)
+
+        expected_toolsets = [MagicMock(name="toolset1")]
+        with patch.object(
+            registry, "get_adk_toolsets", return_value=expected_toolsets
+        ):
+            with patch(
+                "idun_agent_engine.mcp.helpers._build_registry"
+            ) as mock_build:
+                result = get_adk_tools()
+                mock_build.assert_not_called()
+                assert result == expected_toolsets
+
+    def test_active_registry_returns_empty_list(self):
+        """Active registry enabled but no toolsets — returns empty list."""
+        registry = _make_enabled_registry()
+        set_active_registry(registry)
+
+        with patch.object(registry, "get_adk_toolsets", return_value=[]):
+            result = get_adk_tools()
+            assert result == []

--- a/libs/idun_agent_engine/tests/unit/mcp/test_mcp_lifespan.py
+++ b/libs/idun_agent_engine/tests/unit/mcp/test_mcp_lifespan.py
@@ -1,0 +1,66 @@
+"""Tests for active registry wiring in the server lifespan."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from idun_agent_engine.mcp.registry import get_active_registry, set_active_registry
+
+
+@pytest.fixture(autouse=True)
+def _clear_active_registry():
+    set_active_registry(None)
+    yield
+    set_active_registry(None)
+
+
+@pytest.mark.unit
+class TestLifespanActiveRegistry:
+    @pytest.mark.asyncio
+    async def test_configure_app_sets_active_registry(self):
+        """configure_app should call set_active_registry with the created MCPClientRegistry."""
+        from idun_agent_engine.server.lifespan import configure_app
+
+        mock_app = MagicMock()
+        mock_app.state = MagicMock()
+
+        mock_engine_config = MagicMock()
+        mock_engine_config.mcp_servers = None
+        mock_engine_config.guardrails = None
+        mock_engine_config.sso = None
+        mock_engine_config.integrations = None
+        mock_engine_config.agent.type = "LANGGRAPH"
+        mock_engine_config.agent.config = MagicMock()
+
+        with patch(
+            "idun_agent_engine.server.lifespan.ConfigBuilder.initialize_agent_from_config",
+            new_callable=AsyncMock,
+        ) as mock_init:
+            mock_agent = MagicMock()
+            mock_agent.discover_capabilities = MagicMock(return_value=MagicMock())
+            mock_agent.copilotkit_agent_instance = MagicMock()
+            mock_init.return_value = mock_agent
+
+            await configure_app(mock_app, mock_engine_config)
+
+            registry = get_active_registry()
+            assert registry is not None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_clears_active_registry(self):
+        """After cleanup_agent, the active registry should be None."""
+        from idun_agent_engine.mcp.registry import MCPClientRegistry
+        from idun_agent_engine.server.lifespan import cleanup_agent
+
+        # Set a registry first
+        registry = MCPClientRegistry()
+        set_active_registry(registry)
+        assert get_active_registry() is not None
+
+        mock_app = MagicMock()
+        mock_app.state = MagicMock()
+        mock_app.state.agent = None
+
+        await cleanup_agent(mock_app)
+
+        assert get_active_registry() is None

--- a/libs/idun_agent_engine/tests/unit/server/test_lifespan.py
+++ b/libs/idun_agent_engine/tests/unit/server/test_lifespan.py
@@ -47,7 +47,9 @@ class TestLifespan:
                 # During lifespan, agent should be initialized
                 assert app.state.agent == mock_agent
                 assert app.state.config == engine_config
-                mock_init.assert_called_once_with(engine_config)
+                mock_init.assert_called_once()
+                call_args = mock_init.call_args
+                assert call_args[0][0] is engine_config
 
             # After lifespan exits, agent should be closed
             mock_agent.close.assert_called_once()


### PR DESCRIPTION
## Summary

Load mcp from memory instead of calling the api again.

- [X] I ran the relevant checks (`make precommit` and/or `make test`)
- [X] I updated documentation where applicable
- [X] I added/updated tests where applicable
- [X] This change is not introducing secrets (API keys, tokens, credentials) into the repo


