### PR TITLE
fix: support multi-tenant Microsoft OIDC for platform login

### DIFF
--- a/docs/auth/overview.mdx
+++ b/docs/auth/overview.mdx
@@ -43,12 +43,15 @@ The Manager supports two mutually exclusive authentication modes, controlled by 
         AUTH__DISABLE_USERNAME_PASSWORD=true
         AUTH__MICROSOFT_CLIENT_ID=your-azure-app-client-id
         AUTH__MICROSOFT_CLIENT_SECRET=your-azure-app-client-secret
-        AUTH__MICROSOFT_TENANT_ID=your-tenant-id
+        # Optional: defaults to "common" (any Entra tenant + personal Microsoft accounts)
+        # AUTH__MICROSOFT_TENANT_ID=common
         AUTH__REDIRECT_URI=https://your-domain.com/api/v1/auth/callback
         AUTH__FRONTEND_URL=https://your-domain.com
         ```
 
-        Set `AUTH__MICROSOFT_TENANT_ID` to `common` to allow any Microsoft account, or use a specific tenant ID to restrict access to your organization.
+        `AUTH__MICROSOFT_TENANT_ID` defaults to `common`, which uses the multi-tenant Microsoft authority (`https://login.microsoftonline.com/common`) and accepts users from any Entra tenant as well as personal Microsoft accounts (Outlook, Hotmail, Live). Your Entra app registration must also be configured for **multi-tenant + personal Microsoft accounts** (the "Accounts in any organizational directory and personal Microsoft accounts" option).
+
+        To restrict sign-in to a single Entra tenant, set `AUTH__MICROSOFT_TENANT_ID` to that tenant's UUID. The Manager validates that ID tokens are issued by a Microsoft tenant (`https://login.microsoftonline.com/<tenant-uuid>/v2.0`) regardless of which authority is used; the JWKS signature check guarantees the token came from Microsoft.
       </Tab>
     </Tabs>
 
@@ -148,7 +151,7 @@ Protected routes:
 The Manager supports the following OIDC providers for SSO authentication:
 
 - **Google Workspace** (issuer: `https://accounts.google.com`)
-- **Microsoft Entra ID / Azure AD** (issuer: `https://login.microsoftonline.com/{tenant}/v2.0`)
+- **Microsoft Entra ID / Azure AD** (multi-tenant via `https://login.microsoftonline.com/common`, or single-tenant via `https://login.microsoftonline.com/<tenant-uuid>`)
 
 Both can be enabled simultaneously. The login page shows a button for each configured provider.
 

--- a/services/idun_agent_manager/src/app/api/v1/routers/auth.py
+++ b/services/idun_agent_manager/src/app/api/v1/routers/auth.py
@@ -20,6 +20,7 @@ Endpoints:
 import hashlib
 import logging
 import os
+import re
 import time
 from enum import StrEnum
 from typing import Any
@@ -62,6 +63,46 @@ _serializer: URLSafeTimedSerializer | None = None
 SESSION_COOKIE = "sid"
 _OAUTH_PROVIDER_SESSION_KEY = "_oauth_provider"
 
+# Microsoft v2.0 ID tokens carry an issuer of the form
+# ``https://login.microsoftonline.com/<tenant-uuid>/v2.0``. The /common discovery
+# document returns the literal template ``{tenantid}`` in its ``issuer`` field,
+# which Authlib cannot match against real per-tenant issuers — so we disable the
+# default strict iss check (see ``_microsoft_claims_options``) and re-validate the
+# issuer manually with this regex. JWKS signature verification (handled by Authlib
+# against Microsoft's signing keys) is what actually proves the token came from
+# Microsoft; this regex is defense-in-depth.
+_MICROSOFT_ISSUER_RE = re.compile(
+    r"^https://login\.microsoftonline\.com/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/v2\.0$"
+)
+
+
+def _microsoft_claims_options() -> dict[str, dict[str, Any]]:
+    """Return claims_options that disable Authlib's strict ``iss`` value match.
+
+    Multi-tenant Microsoft apps must use the /common (or /organizations) discovery
+    endpoint, whose ``issuer`` field is the literal template
+    ``https://login.microsoftonline.com/{tenantid}/v2.0``. Authlib's default behaviour
+    compares this template against the token's actual ``iss`` claim, which always
+    fails. Passing an empty dict for ``iss`` skips that values check; we then
+    re-validate the issuer pattern in :func:`_validate_microsoft_issuer`.
+    """
+    return {"iss": {}}
+
+
+def _validate_microsoft_issuer(userinfo: dict[str, Any]) -> None:
+    """Verify the parsed ID token's ``iss`` is a real Microsoft tenant URL.
+
+    Raises 401 otherwise. This complements JWKS signature verification, which
+    already proves the token was signed by Microsoft's keys.
+    """
+    iss = userinfo.get("iss", "")
+    if not isinstance(iss, str) or not _MICROSOFT_ISSUER_RE.match(iss):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ID token issuer is not a Microsoft tenant",
+        )
+
 
 def _get_serializer() -> URLSafeTimedSerializer:
     global _serializer
@@ -88,7 +129,11 @@ def _get_oauth() -> OAuth:
             )
 
         if settings.auth.microsoft.client_id:
-            tenant = settings.auth.microsoft.tenant_id
+            # Default to /common so any Microsoft tenant + personal accounts can
+            # sign in. Operators can opt into single-tenant restriction by setting
+            # AUTH__MICROSOFT_TENANT_ID to their tenant UUID, but this should match
+            # the audience configured in their Entra app registration.
+            tenant = settings.auth.microsoft.tenant_id or "common"
             _oauth.register(
                 name=OIDCProvider.MICROSOFT,
                 client_id=settings.auth.microsoft.client_id,
@@ -237,7 +282,9 @@ async def list_providers() -> dict[str, list[str]]:
     return {"providers": [p.value for p in _get_enabled_providers()]}
 
 
-async def _login_with_provider(request: Request, provider: OIDCProvider) -> RedirectResponse:
+async def _login_with_provider(
+    request: Request, provider: OIDCProvider
+) -> RedirectResponse:
     """Shared logic: validate provider and redirect to its authorization page."""
     settings = get_settings()
     if not settings.auth.disable_username_password:
@@ -264,10 +311,11 @@ async def _login_with_provider(request: Request, provider: OIDCProvider) -> Redi
     summary="Redirect to OIDC provider login",
     description="Initiates the OIDC authorization code flow for the specified provider.",
 )
-async def login_with_provider(request: Request, provider: OIDCProvider) -> RedirectResponse:
+async def login_with_provider(
+    request: Request, provider: OIDCProvider
+) -> RedirectResponse:
     """Redirect the user-agent to the specified provider's authorization page."""
     return await _login_with_provider(request, provider)
-
 
 
 @router.get(
@@ -308,8 +356,16 @@ async def callback(
             detail=f"Provider '{provider_name}' is not registered",
         )
 
+    # Microsoft's /common discovery doc returns a literal '{tenantid}' template as
+    # its issuer field, which Authlib cannot match against the real per-tenant iss
+    # claim of incoming ID tokens. Override claims_options to skip the strict iss
+    # values check and re-validate the issuer manually below.
+    authorize_kwargs: dict[str, Any] = {}
+    if provider == OIDCProvider.MICROSOFT:
+        authorize_kwargs["claims_options"] = _microsoft_claims_options()
+
     try:
-        token = await oauth_client.authorize_access_token(request)
+        token = await oauth_client.authorize_access_token(request, **authorize_kwargs)
     except Exception as exc:
         logger.exception("OIDC token exchange failed for provider %s", provider_name)
         raise HTTPException(
@@ -333,6 +389,11 @@ async def callback(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not retrieve user info from provider",
         )
+
+    # Defense in depth: ensure the parsed Microsoft ID token actually came from a
+    # Microsoft tenant (any tenant — multi-tenant is the whole point of /common).
+    if provider == OIDCProvider.MICROSOFT:
+        _validate_microsoft_issuer(userinfo)
 
     # Normalize userinfo across providers (Microsoft uses preferred_username)
     email: str = userinfo.get("email") or userinfo.get("preferred_username", "")

--- a/services/idun_agent_manager/tests/unit/test_oidc_providers.py
+++ b/services/idun_agent_manager/tests/unit/test_oidc_providers.py
@@ -97,9 +97,7 @@ def _make_mock_oauth(provider_name: str, userinfo: dict) -> MagicMock:
     an unregistered provider raises AttributeError instead of silently succeeding.
     """
     mock_client = MagicMock()
-    mock_client.authorize_access_token = AsyncMock(
-        return_value={"userinfo": userinfo}
-    )
+    mock_client.authorize_access_token = AsyncMock(return_value={"userinfo": userinfo})
     mock_oauth = MagicMock(spec=[])
     setattr(mock_oauth, provider_name, mock_client)
     return mock_oauth
@@ -140,7 +138,9 @@ class TestListProviders:
         assert response.json()["providers"] == ["microsoft"]
 
     @pytest.mark.usefixtures("_sso_enabled", "_no_providers")
-    async def test_returns_empty_when_no_providers_configured(self, client: AsyncClient):
+    async def test_returns_empty_when_no_providers_configured(
+        self, client: AsyncClient
+    ):
         response = await client.get("/api/v1/auth/providers")
         assert response.status_code == 200
         assert response.json() == {"providers": []}
@@ -156,28 +156,24 @@ class TestLoginProvider:
 
     @pytest.mark.usefixtures("_sso_disabled")
     async def test_returns_404_when_sso_disabled(self, client: AsyncClient):
-        response = await client.get(
-            "/api/v1/auth/login/google", follow_redirects=False
-        )
+        response = await client.get("/api/v1/auth/login/google", follow_redirects=False)
         assert response.status_code == 404
 
     @pytest.mark.usefixtures("_sso_enabled")
     async def test_returns_422_for_invalid_provider(self, client: AsyncClient):
-        response = await client.get(
-            "/api/v1/auth/login/github", follow_redirects=False
-        )
+        response = await client.get("/api/v1/auth/login/github", follow_redirects=False)
         assert response.status_code == 422
 
     @pytest.mark.usefixtures("_sso_enabled", "_no_providers")
     async def test_returns_400_for_unconfigured_provider(self, client: AsyncClient):
-        response = await client.get(
-            "/api/v1/auth/login/google", follow_redirects=False
-        )
+        response = await client.get("/api/v1/auth/login/google", follow_redirects=False)
         assert response.status_code == 400
         assert "not configured" in response.json()["detail"]
 
     @pytest.mark.usefixtures("_sso_enabled", "_only_google")
-    async def test_returns_400_for_microsoft_when_only_google(self, client: AsyncClient):
+    async def test_returns_400_for_microsoft_when_only_google(
+        self, client: AsyncClient
+    ):
         response = await client.get(
             "/api/v1/auth/login/microsoft", follow_redirects=False
         )
@@ -195,14 +191,20 @@ class TestCallback:
 
     @pytest.mark.usefixtures("_sso_enabled", "_only_google")
     async def test_creates_user_with_google(
-        self, client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        mock_oauth = _make_mock_oauth("google", {
-            "email": "test@google.com",
-            "name": "Google User",
-            "picture": "https://pic.example.com/g.jpg",
-            "sub": "google-sub-123",
-        })
+        mock_oauth = _make_mock_oauth(
+            "google",
+            {
+                "email": "test@google.com",
+                "name": "Google User",
+                "picture": "https://pic.example.com/g.jpg",
+                "sub": "google-sub-123",
+            },
+        )
         monkeypatch.setattr(auth_module, "_oauth", mock_oauth)
 
         response = await client.get(
@@ -224,14 +226,21 @@ class TestCallback:
 
     @pytest.mark.usefixtures("_sso_enabled", "_only_microsoft")
     async def test_creates_user_with_microsoft_preferred_username(
-        self, client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Microsoft userinfo uses preferred_username instead of email."""
-        mock_oauth = _make_mock_oauth("microsoft", {
-            "preferred_username": "user@microsoft.com",
-            "name": "Microsoft User",
-            "sub": "ms-sub-456",
-        })
+        mock_oauth = _make_mock_oauth(
+            "microsoft",
+            {
+                "preferred_username": "user@microsoft.com",
+                "name": "Microsoft User",
+                "sub": "ms-sub-456",
+                "iss": "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0",
+            },
+        )
         monkeypatch.setattr(auth_module, "_oauth", mock_oauth)
 
         response = await client.get(
@@ -254,7 +263,10 @@ class TestCallback:
 
     @pytest.mark.usefixtures("_sso_enabled", "_only_microsoft")
     async def test_updates_provider_on_returning_user(
-        self, client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """User who first logged in via Google, then logs in via Microsoft — provider is updated."""
         existing_user = UserModel(
@@ -267,11 +279,15 @@ class TestCallback:
         db_session.add(existing_user)
         await db_session.flush()
 
-        mock_oauth = _make_mock_oauth("microsoft", {
-            "preferred_username": "shared@example.com",
-            "name": "Updated Name",
-            "sub": "ms-sub-new",
-        })
+        mock_oauth = _make_mock_oauth(
+            "microsoft",
+            {
+                "preferred_username": "shared@example.com",
+                "name": "Updated Name",
+                "sub": "ms-sub-new",
+                "iss": "https://login.microsoftonline.com/22222222-2222-2222-2222-222222222222/v2.0",
+            },
+        )
         monkeypatch.setattr(auth_module, "_oauth", mock_oauth)
 
         response = await client.get(
@@ -290,16 +306,205 @@ class TestCallback:
     async def test_rejects_missing_email(
         self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
     ):
-        mock_oauth = _make_mock_oauth("google", {
-            "name": "No Email User",
-            "sub": "sub-no-email",
-        })
+        mock_oauth = _make_mock_oauth(
+            "google",
+            {
+                "name": "No Email User",
+                "sub": "sub-no-email",
+            },
+        )
         monkeypatch.setattr(auth_module, "_oauth", mock_oauth)
 
         response = await client.get(
             "/api/v1/auth/callback?code=fake&state=fake",
             follow_redirects=False,
             cookies={"session": _build_session_cookie("google")},
+        )
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Microsoft multi-tenant OAuth flow
+# ---------------------------------------------------------------------------
+
+
+class TestMicrosoftMultiTenant:
+    """Verify the Microsoft OIDC provider supports multi-tenant + personal accounts.
+
+    Bug fixed: the discovery URL used to embed a tenant-specific UUID, which made
+    Microsoft reject any external user with 'Selected user account does not exist
+    in tenant ...'. The provider must default to /common (any tenant + personal
+    Microsoft accounts) and the backend must accept ID tokens whose ``iss`` claim
+    is any Microsoft tenant URL — not the literal '{tenantid}' template returned
+    by the /common discovery doc.
+    """
+
+    def test_default_tenant_id_is_common(self):
+        """The Microsoft tenant defaults to ``common`` so any tenant is accepted."""
+        from app.infrastructure.db.models.settings import MicrosoftProviderSettings
+
+        assert MicrosoftProviderSettings().tenant_id == "common"
+
+    def test_discovery_url_uses_common_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """``_get_oauth`` registers Microsoft against the /common discovery endpoint."""
+        settings = get_settings()
+        monkeypatch.setattr(settings.auth.microsoft, "client_id", "fake-microsoft-id")
+        monkeypatch.setattr(settings.auth.microsoft, "client_secret", "fake-secret")
+        monkeypatch.setattr(settings.auth.microsoft, "tenant_id", "common")
+
+        oauth = auth_module._get_oauth()
+        ms_client = oauth.microsoft
+        assert ms_client is not None
+        assert ms_client._server_metadata_url == (
+            "https://login.microsoftonline.com/common"
+            "/v2.0/.well-known/openid-configuration"
+        )
+
+    @pytest.mark.usefixtures("_sso_enabled", "_only_microsoft")
+    async def test_callback_skips_strict_iss_value_check(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Callback must pass ``claims_options={"iss": {}}`` to authlib so that the
+        literal '{tenantid}' template returned by /common discovery is not compared
+        against the real per-tenant ``iss`` claim of incoming ID tokens.
+        """
+        mock_oauth = _make_mock_oauth(
+            "microsoft",
+            {
+                "preferred_username": "user@external-tenant.com",
+                "name": "External User",
+                "sub": "ms-sub-ext",
+                "iss": "https://login.microsoftonline.com/abcdef01-2345-6789-abcd-ef0123456789/v2.0",
+            },
+        )
+        monkeypatch.setattr(auth_module, "_oauth", mock_oauth)
+
+        response = await client.get(
+            "/api/v1/auth/callback?code=fake&state=fake",
+            follow_redirects=False,
+            cookies={"session": _build_session_cookie("microsoft")},
+        )
+        assert response.status_code == 302
+
+        # Critical: claims_options must explicitly disable the default iss-value
+        # check or authlib will reject the token because the discovery doc returns
+        # the literal '{tenantid}' template.
+        call_kwargs = mock_oauth.microsoft.authorize_access_token.call_args.kwargs
+        assert call_kwargs.get("claims_options") == {"iss": {}}
+
+    @pytest.mark.usefixtures("_sso_enabled", "_only_microsoft")
+    async def test_accepts_external_organization_tenant(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A user from an external Entra tenant must be allowed in."""
+        mock_oauth = _make_mock_oauth(
+            "microsoft",
+            {
+                "preferred_username": "alice@external.com",
+                "name": "External Alice",
+                "sub": "ext-tenant-sub",
+                "iss": "https://login.microsoftonline.com/abcdef01-2345-6789-abcd-ef0123456789/v2.0",
+            },
+        )
+        monkeypatch.setattr(auth_module, "_oauth", mock_oauth)
+
+        response = await client.get(
+            "/api/v1/auth/callback?code=fake&state=fake",
+            follow_redirects=False,
+            cookies={"session": _build_session_cookie("microsoft")},
+        )
+        assert response.status_code == 302
+
+        result = await db_session.execute(
+            select(UserModel).where(UserModel.email == "alice@external.com")
+        )
+        user = result.scalar_one()
+        assert user.provider == "microsoft"
+
+    @pytest.mark.usefixtures("_sso_enabled", "_only_microsoft")
+    async def test_accepts_personal_microsoft_account(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A personal Microsoft account (consumer tenant) must be allowed in.
+
+        Personal accounts are issued by the well-known consumer tenant
+        ``9188040d-6c67-4c5b-b112-36a304b66dad``.
+        """
+        mock_oauth = _make_mock_oauth(
+            "microsoft",
+            {
+                "preferred_username": "bob@outlook.com",
+                "name": "Bob Personal",
+                "sub": "personal-sub",
+                "iss": "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0",
+            },
+        )
+        monkeypatch.setattr(auth_module, "_oauth", mock_oauth)
+
+        response = await client.get(
+            "/api/v1/auth/callback?code=fake&state=fake",
+            follow_redirects=False,
+            cookies={"session": _build_session_cookie("microsoft")},
+        )
+        assert response.status_code == 302
+
+        result = await db_session.execute(
+            select(UserModel).where(UserModel.email == "bob@outlook.com")
+        )
+        user = result.scalar_one()
+        assert user.provider == "microsoft"
+
+    @pytest.mark.usefixtures("_sso_enabled", "_only_microsoft")
+    async def test_rejects_non_microsoft_issuer(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Defense in depth: a token whose iss is not a Microsoft tenant URL is rejected."""
+        mock_oauth = _make_mock_oauth(
+            "microsoft",
+            {
+                "preferred_username": "evil@attacker.com",
+                "name": "Evil",
+                "sub": "evil-sub",
+                "iss": "https://attacker.example.com/fake-tenant/v2.0",
+            },
+        )
+        monkeypatch.setattr(auth_module, "_oauth", mock_oauth)
+
+        response = await client.get(
+            "/api/v1/auth/callback?code=fake&state=fake",
+            follow_redirects=False,
+            cookies={"session": _build_session_cookie("microsoft")},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.usefixtures("_sso_enabled", "_only_microsoft")
+    async def test_rejects_microsoft_issuer_with_invalid_tenant_format(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A Microsoft URL with a non-UUID tenant segment must be rejected."""
+        mock_oauth = _make_mock_oauth(
+            "microsoft",
+            {
+                "preferred_username": "evil@attacker.com",
+                "name": "Evil",
+                "sub": "evil-sub",
+                "iss": "https://login.microsoftonline.com/not-a-uuid/v2.0",
+            },
+        )
+        monkeypatch.setattr(auth_module, "_oauth", mock_oauth)
+
+        response = await client.get(
+            "/api/v1/auth/callback?code=fake&state=fake",
+            follow_redirects=False,
+            cookies={"session": _build_session_cookie("microsoft")},
         )
         assert response.status_code == 401
 


### PR DESCRIPTION
## Summary

Fix the platform login Microsoft Entra OIDC flow so users from any Entra tenant — and personal Microsoft accounts (Outlook, Hotmail, Live) — can sign in to the Manager UI. The flow used to be tenant-restricted: external users were rejected with `Selected user account does not exist in tenant ...`.

This only touches the **platform login** OIDC path. The per-agent SSO feature (engine route protection) is untouched.

### Root cause

Two compounding bugs in `services/idun_agent_manager/src/app/api/v1/routers/auth.py`:

1. The Microsoft discovery URL was built with `{tenant}` interpolation. With `AUTH__MICROSOFT_TENANT_ID` set to the org's tenant (as our docs instructed), the authority became single-tenant and Microsoft itself rejected external accounts.
2. Even with `tenant_id=common`, Microsoft's `/common` discovery doc returns the literal template `"issuer": "https://login.microsoftonline.com/{tenantid}/v2.0"`. Authlib's default `parse_id_token` would compare this template against the real per-tenant `iss` claim and reject every token. Without fixing this second half, the bug looks "semi-fixed".

### Fix

- Default `tenant_id` to `"common"` so the multi-tenant authority is used out of the box. Operators can still opt into single-tenant restriction by setting `AUTH__MICROSOFT_TENANT_ID` to a tenant UUID.
- Pass `claims_options={"iss": {}}` to `authorize_access_token` for Microsoft, telling Authlib to skip its default strict `iss` value match against the template.
- Re-validate the parsed `iss` claim against `^https://login\.microsoftonline\.com/<UUID>/v2\.0$` as defense in depth. JWKS signature verification (handled by Authlib against Microsoft's signing keys) is what actually proves the token came from Microsoft.
- Update `docs/auth/overview.mdx` to document the new default and explain that the Entra app must also be configured for multi-tenant + personal accounts.

### Frontend

Untouched — the frontend has zero tenant logic. The `Continue with Microsoft` button just hits `GET /api/v1/auth/login/microsoft` and lets the backend build the redirect.

## Test plan

- [x] `uv run pytest services/idun_agent_manager/tests/unit/test_oidc_providers.py -q` — 23 passed
- [x] `uv run pytest services/idun_agent_manager/tests -q` — 191 passed, 1 unrelated skip
- [x] `uv run ruff check` and `ruff format --check` — clean
- [ ] Manual: with `AUTH__MICROSOFT_TENANT_ID` unset (defaults to `common`), sign in with an account from another Entra tenant — should land on `/agents` or `/onboarding`
- [ ] Manual: with `AUTH__MICROSOFT_TENANT_ID` unset, sign in with a personal Outlook/Hotmail account — should also succeed
- [ ] Manual: confirm an explicitly tenant-restricted setup (`AUTH__MICROSOFT_TENANT_ID=<tenant-uuid>`) still rejects external users as expected

### New unit tests
`TestMicrosoftMultiTenant` adds:
- `test_default_tenant_id_is_common`
- `test_discovery_url_uses_common_by_default`
- `test_callback_skips_strict_iss_value_check`
- `test_accepts_external_organization_tenant`
- `test_accepts_personal_microsoft_account`
- `test_rejects_non_microsoft_issuer`
- `test_rejects_microsoft_issuer_with_invalid_tenant_format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)