### PR TITLE
Fix/issue 477 mcp crash resilience

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/core/config_builder.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/core/config_builder.py
@@ -22,7 +22,6 @@ from idun_agent_schema.engine.mcp_server import MCPServer
 from idun_agent_schema.engine.observability_v2 import ObservabilityConfig
 from idun_agent_schema.engine.prompt import PromptConfig
 from idun_agent_schema.engine.sso import SSOConfig
-from yaml import YAMLError
 
 from idun_agent_engine.server.server_config import ServerAPIConfig
 
@@ -98,118 +97,39 @@ class ConfigBuilder:
         return self
 
     def with_config_from_api(self, agent_api_key: str, url: str) -> "ConfigBuilder":
-        """Fetches the yaml config file, from idun agent manager api.
+        """Fetch config from the idun agent manager API and populate the builder.
 
         Requires the agent api key to pass in the headers.
         """
-        import requests
+        import requests  # TODO: replace with httpx
         import yaml
 
         headers = {"auth": f"Bearer {agent_api_key}"}
         try:
             logger.info(f"Fetching config from {url}/api/v1/agents/config")
-            response = requests.get(url=url + "/api/v1/agents/config", headers=headers)
+            response = requests.get(
+                url=url + "/api/v1/agents/config", headers=headers
+            )
             if response.status_code != 200:
                 raise ValueError(
-                    f"Error sending retrieving config from url. response : {response.json()}"
+                    f"Error retrieving config from url. response: {response.text}"
                 )
-            yaml_config = yaml.safe_load(response.text)
-            try:
-                self._server_config = yaml_config.get("engine_config", {}).get("server")
-            except Exception as e:
-                raise YAMLError(
-                    f"Failed to parse yaml file for  ServerConfig: {e}"
-                ) from e
-            try:
-                self._agent_config = yaml_config.get("engine_config", {}).get("agent")
-            except Exception as e:
-                raise YAMLError(
-                    f"Failed to parse yaml file for Engine config: {e}"
-                ) from e
-            try:
-                guardrails_data = yaml_config.get("engine_config", {}).get("guardrails")
+            raw = yaml.safe_load(response.text)
+            engine_data = raw.get("engine_config", {})
+            engine_config = EngineConfig.model_validate(engine_data)
 
-                if not guardrails_data:
-                    self._guardrails = None
-                else:
-                    self._guardrails = Guardrails.model_validate(guardrails_data)
-
-            except Exception as e:
-                raise YAMLError(f"Failed to parse yaml file for Guardrails: {e}") from e
-
-            try:
-                observability_list = yaml_config.get("engine_config", {}).get(
-                    "observability"
-                )
-                if observability_list:
-                    self._observability = [
-                        ObservabilityConfig.model_validate(obs)
-                        for obs in observability_list
-                    ]
-                else:
-                    self._observability = None
-            except Exception as e:
-                raise YAMLError(
-                    f"Failed to parse yaml file for Observability: {e}"
-                ) from e
-            try:
-                sso_data = yaml_config.get("engine_config", {}).get("sso")
-                if sso_data:
-                    self._sso = SSOConfig.model_validate(sso_data)
-                else:
-                    self._sso = None
-            except Exception as e:
-                raise YAMLError(f"Failed to parse yaml file for SSO: {e}") from e
-
-            # try:
-            #     mcp_servers_list = yaml_config.get("engine_config", {}).get("mcp_servers") or yaml_config.get("engine_config", {}).get("mcpServers") # TODO to fix camelcase issues
-            #     if mcp_servers_list:
-            #         self._mcp_servers = [
-            #             MCPServer.model_validate(server) for server in mcp_servers_list
-            #         ]
-            #     else:
-            #         self._mcp_servers = None
-            # except Exception as e:
-            #     raise YAMLError(f"Failed to parse yaml file for MCP Servers: {e}") from e
-
-            try:
-                from idun_agent_schema.engine.integrations import IntegrationConfig
-
-                integrations_list = yaml_config.get("engine_config", {}).get(
-                    "integrations"
-                )
-                if integrations_list:
-                    self._integrations = [
-                        IntegrationConfig.model_validate(i) for i in integrations_list
-                    ]
-                else:
-                    self._integrations = None
-            except Exception as e:
-                raise YAMLError(
-                    f"Failed to parse yaml file for Integrations: {e}"
-                ) from e
-
-            try:
-                prompts_list = yaml_config.get("engine_config", {}).get("prompts")
-                if prompts_list:
-                    self._prompts = [
-                        PromptConfig.model_validate(p) for p in prompts_list
-                    ]
-                    logger.info(
-                        f"Loaded {len(self._prompts)} prompt(s) from API config"
-                    )
-                else:
-                    self._prompts = None
-                    logger.debug("No prompts found in API config")
-            except Exception as e:
-                raise YAMLError(
-                    f"Failed to parse yaml file for Prompts: {e}"
-                ) from e
+            self._server_config = engine_config.server
+            self._agent_config = engine_config.agent
+            self._guardrails = engine_config.guardrails
+            self._observability = engine_config.observability
+            self._mcp_servers = engine_config.mcp_servers
+            self._sso = engine_config.sso
+            self._integrations = engine_config.integrations
+            self._prompts = engine_config.prompts
 
             return self
-
         except Exception as e:
-            raise ValueError(f"Error occured while getting config from api: {e}") from e
+            raise ValueError(f"Error occurred while getting config from api: {e}") from e
 
     def with_langgraph_agent(
         self,

--- a/libs/idun_agent_engine/src/idun_agent_engine/mcp/registry.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/mcp/registry.py
@@ -114,11 +114,26 @@ class MCPClientRegistry:
         self._client: MultiServerMCPClient | None = None
 
         if self._configs:
-            connections: dict[str, Connection] = {
-                config.name: cast(Connection, config.as_connection_dict())
-                for config in self._configs
-            }
-            self._client = MultiServerMCPClient(connections)
+            connections: dict[str, Connection] = {}
+            for config in self._configs:
+                try:
+                    connections[config.name] = cast(
+                        Connection, config.as_connection_dict()
+                    )
+                except Exception:
+                    logger.exception(
+                        "⚠️ Failed to build connection for MCP server '%s', skipping.",
+                        config.name,
+                    )
+
+            if connections:
+                try:
+                    self._client = MultiServerMCPClient(connections)
+                except Exception:
+                    logger.exception(
+                        "⚠️ Failed to create MultiServerMCPClient, "
+                        "continuing without MCP servers."
+                    )
 
     @property
     def enabled(self) -> bool:

--- a/libs/idun_agent_engine/src/idun_agent_engine/mcp/registry.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/mcp/registry.py
@@ -174,10 +174,30 @@ class MCPClientRegistry:
         return self.client.session(name)
 
     async def get_tools(self, name: str | None = None) -> list[Any]:
-        """Load tools from all servers or a specific one."""
+        """Load tools from all servers or a specific one.
+
+        When loading from all servers, each server is tried individually
+        so a single broken server does not prevent the others from loading.
+        """
         if not self._client:
             raise RuntimeError("MCP client registry is not enabled.")
-        tools = await self._client.get_tools(server_name=name)
+
+        if name:
+            tools = await self._client.get_tools(server_name=name)
+        else:
+            tools = []
+            for server_name in self._client.connections:
+                try:
+                    server_tools = await self._client.get_tools(
+                        server_name=server_name
+                    )
+                    tools.extend(server_tools)
+                except Exception:
+                    logger.exception(
+                        "⚠️ Failed to load tools from MCP server '%s', skipping.",
+                        server_name,
+                    )
+
         for tool in tools:
             if hasattr(tool, "args_schema"):
                 _sanitize_schema(tool.args_schema)

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -54,7 +54,11 @@ async def configure_app(app: FastAPI, engine_config):
         guardrails = []
 
     # Use ConfigBuilder's centralized agent initialization, passing the registry
-    mcp_registry = MCPClientRegistry(engine_config.mcp_servers or [])
+    try:
+        mcp_registry = MCPClientRegistry(engine_config.mcp_servers or [])
+    except Exception as e:
+        logger.exception(f"⚠️ Failed to initialize MCP registry: {e}, continuing without MCP servers")
+        mcp_registry = MCPClientRegistry()
     set_active_registry(mcp_registry)
     app.state.mcp_registry = mcp_registry
     try:

--- a/libs/idun_agent_engine/tests/unit/core/test_config_builder.py
+++ b/libs/idun_agent_engine/tests/unit/core/test_config_builder.py
@@ -374,7 +374,7 @@ class TestConfigBuilderWithConfigFromAPI:
         mock_response.json.return_value = {"error": "Unauthorized"}
         mock_get.return_value = mock_response
 
-        with pytest.raises(ValueError, match="Error sending retrieving config"):
+        with pytest.raises(ValueError, match="Error retrieving config from url"):
             ConfigBuilder().with_config_from_api(
                 agent_api_key="invalid-key", url="http://localhost:8000"
             )
@@ -859,6 +859,195 @@ class TestConfigBuilderPrompts:
 
         engine_config = builder.build()
         assert engine_config.prompts is None
+
+
+@pytest.mark.unit
+class TestConfigBuilderMCPServers:
+    """Test MCP server configuration in ConfigBuilder."""
+
+    _BASE_AGENT = {
+        "type": "LANGGRAPH",
+        "config": {"name": "MCP Agent", "graph_definition": "./agent.py:graph"},
+    }
+
+    _STDIO_MCP = {
+        "name": "time",
+        "transport": "stdio",
+        "command": "docker",
+        "args": ["run", "-i", "--rm", "mcp/time"],
+    }
+
+    _HTTP_MCP = {
+        "name": "docs",
+        "transport": "streamable_http",
+        "url": "https://docs.example.com/mcp",
+    }
+
+    def test_build_includes_mcp_servers_when_set(self, tmp_path: Path) -> None:
+        """build() includes MCP servers in the EngineConfig."""
+        from idun_agent_schema.engine.mcp_server import MCPServer
+
+        builder = ConfigBuilder().with_langgraph_agent(
+            name="MCP Agent", graph_definition=str(tmp_path / "agent.py:graph")
+        )
+        builder._mcp_servers = [MCPServer.model_validate(self._STDIO_MCP)]
+        engine_config = builder.build()
+        assert engine_config.mcp_servers is not None
+        assert len(engine_config.mcp_servers) == 1
+        assert engine_config.mcp_servers[0].name == "time"
+        assert engine_config.mcp_servers[0].transport == "stdio"
+
+    def test_build_mcp_servers_none_by_default(self) -> None:
+        """build() sets mcp_servers to None when not configured."""
+        builder = ConfigBuilder().with_langgraph_agent(
+            name="No MCP Agent", graph_definition="./agent.py:graph"
+        )
+        engine_config = builder.build()
+        assert engine_config.mcp_servers is None
+
+    def test_from_dict_preserves_mcp_servers(self) -> None:
+        """from_dict copies MCP servers into the builder."""
+        config_dict = {
+            "server": {"api": {"port": 8000}},
+            "agent": self._BASE_AGENT,
+            "mcp_servers": [self._STDIO_MCP],
+        }
+        builder = ConfigBuilder.from_dict(config_dict)
+        assert builder._mcp_servers is not None
+        assert len(builder._mcp_servers) == 1
+
+        engine_config = builder.build()
+        assert engine_config.mcp_servers is not None
+        assert engine_config.mcp_servers[0].name == "time"
+        assert engine_config.mcp_servers[0].transport == "stdio"
+        assert engine_config.mcp_servers[0].command == "docker"
+
+    def test_from_engine_config_preserves_mcp_servers(self, tmp_path: Path) -> None:
+        """from_engine_config copies MCP servers into the builder."""
+        from idun_agent_schema.engine.mcp_server import MCPServer
+
+        builder = ConfigBuilder().with_langgraph_agent(
+            name="MCP Agent", graph_definition=str(tmp_path / "agent.py:graph")
+        )
+        builder._mcp_servers = [MCPServer.model_validate(self._HTTP_MCP)]
+        engine_config = builder.build()
+
+        new_builder = ConfigBuilder.from_engine_config(engine_config)
+        assert new_builder._mcp_servers is not None
+        assert len(new_builder._mcp_servers) == 1
+        assert new_builder._mcp_servers[0].name == "docs"
+        assert new_builder._mcp_servers[0].transport == "streamable_http"
+        assert new_builder._mcp_servers[0].url == "https://docs.example.com/mcp"
+
+    def test_from_dict_empty_mcp_servers_list(self) -> None:
+        """from_dict treats empty mcp_servers list as None."""
+        config_dict = {
+            "server": {"api": {"port": 8000}},
+            "agent": self._BASE_AGENT,
+            "mcp_servers": [],
+        }
+        builder = ConfigBuilder.from_dict(config_dict)
+        engine_config = builder.build()
+        # Empty list is preserved (not coerced to None) — Pydantic keeps it
+        assert engine_config.mcp_servers is not None
+        assert len(engine_config.mcp_servers) == 0
+
+    @patch("requests.get")
+    def test_with_config_from_api_parses_mcp_servers(self, mock_get: Mock) -> None:
+        """with_config_from_api parses MCP servers from API response."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = yaml.dump(
+            {
+                "engine_config": {
+                    "server": {"api": {"port": 8000}},
+                    "agent": self._BASE_AGENT,
+                    "mcp_servers": [self._STDIO_MCP, self._HTTP_MCP],
+                }
+            }
+        )
+        mock_get.return_value = mock_response
+
+        builder = ConfigBuilder().with_config_from_api(
+            agent_api_key="test-key", url="http://localhost:8000"
+        )
+
+        engine_config = builder.build()
+        assert engine_config.mcp_servers is not None
+        assert len(engine_config.mcp_servers) == 2
+        assert engine_config.mcp_servers[0].name == "time"
+        assert engine_config.mcp_servers[0].transport == "stdio"
+        assert engine_config.mcp_servers[0].command == "docker"
+        assert engine_config.mcp_servers[1].name == "docs"
+        assert engine_config.mcp_servers[1].transport == "streamable_http"
+        assert engine_config.mcp_servers[1].url == "https://docs.example.com/mcp"
+
+    @patch("requests.get")
+    def test_with_config_from_api_without_mcp_servers(self, mock_get: Mock) -> None:
+        """with_config_from_api sets mcp_servers to None when not in response."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = yaml.dump(
+            {
+                "engine_config": {
+                    "server": {"api": {"port": 8000}},
+                    "agent": self._BASE_AGENT,
+                }
+            }
+        )
+        mock_get.return_value = mock_response
+
+        builder = ConfigBuilder().with_config_from_api(
+            agent_api_key="test-key", url="http://localhost:8000"
+        )
+
+        engine_config = builder.build()
+        assert engine_config.mcp_servers is None
+
+    @patch("requests.get")
+    def test_with_config_from_api_full_config(self, mock_get: Mock) -> None:
+        """with_config_from_api parses all sections together."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = yaml.dump(
+            {
+                "engine_config": {
+                    "server": {"api": {"port": 9000}},
+                    "agent": self._BASE_AGENT,
+                    "mcp_servers": [self._STDIO_MCP],
+                    "observability": [
+                        {
+                            "provider": "LANGFUSE",
+                            "enabled": True,
+                            "config": {
+                                "host": "https://cloud.langfuse.com",
+                                "public_key": "pk",
+                                "secret_key": "sk",
+                            },
+                        }
+                    ],
+                    "sso": {
+                        "issuer": "https://accounts.google.com",
+                        "client_id": "cid",
+                    },
+                }
+            }
+        )
+        mock_get.return_value = mock_response
+
+        builder = ConfigBuilder().with_config_from_api(
+            agent_api_key="test-key", url="http://localhost:8000"
+        )
+
+        engine_config = builder.build()
+        assert engine_config.server.api.port == 9000
+        assert engine_config.agent.config.name == "MCP Agent"
+        assert engine_config.mcp_servers is not None
+        assert len(engine_config.mcp_servers) == 1
+        assert engine_config.observability is not None
+        assert len(engine_config.observability) == 1
+        assert engine_config.sso is not None
+        assert engine_config.sso.issuer == "https://accounts.google.com"
 
 
 @pytest.mark.unit

--- a/libs/idun_agent_engine/tests/unit/mcp/test_mcp_registry.py
+++ b/libs/idun_agent_engine/tests/unit/mcp/test_mcp_registry.py
@@ -193,7 +193,7 @@ class TestMCPRegistryGetTools:
 
         tools = await registry.get_tools()
         assert tools == mock_tools
-        registry._client.get_tools.assert_called_once_with(server_name=None)
+        registry._client.get_tools.assert_called_once_with(server_name="test-server")
 
     @pytest.mark.asyncio
     async def test_get_tools_with_server_name(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,4 @@ markers =
     requires_langfuse: Test requires Langfuse service
     requires_phoenix: Test requires Phoenix service
     requires_postgres: Test requires PostgreSQL
+    requires_langsmith: Test requires LangSmith service


### PR DESCRIPTION
## Summary

Server does not crash when an mcp tool hits an error. every tool is checked and validated before being returned to the agent. If the tool has issues, will skip it and warn the user with the stack trace error.

## Checklist

- [X] I ran the relevant checks (`make precommit` and/or `make test`)
- [  ] I updated documentation where applicable
- [X] I added/updated tests where applicable
- [X] This change is not introducing secrets (API keys, tokens, credentials) into the repo


