### PR TITLE
fix(engine): gracefully fall back when graph schema introspection fails

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -406,12 +406,12 @@ class LanggraphAgent(agent_base.BaseAgent):
             )
 
             # Preserve interrupt_before/after from the user's compile() call
-            self._interrupt_before = getattr(
-                graph_builder, "interrupt_before_nodes", None
-            ) or None
-            self._interrupt_after = getattr(
-                graph_builder, "interrupt_after_nodes", None
-            ) or None
+            self._interrupt_before = (
+                getattr(graph_builder, "interrupt_before_nodes", None) or None
+            )
+            self._interrupt_after = (
+                getattr(graph_builder, "interrupt_after_nodes", None) or None
+            )
 
             if self._interrupt_before or self._interrupt_after:
                 logger.info(
@@ -648,11 +648,34 @@ class LanggraphAgent(agent_base.BaseAgent):
         # wrapper's ``model_fields`` contain a single ``root`` entry whose
         # annotation is the original TypedDict.  Otherwise the wrapper
         # directly exposes the state fields.
-        input_schema_cls = getattr(graph, "input_schema", None)
-        output_schema_cls = getattr(graph, "output_schema", None)
-
-        input_fields = self._unwrap_schema_fields(input_schema_cls)
-        output_fields = self._unwrap_schema_fields(output_schema_cls)
+        #
+        # Schema materialization goes through ``pydantic.create_model`` on
+        # the state annotations.  That can fail on valid LangGraph state
+        # schemas whose annotations use TypedDict-only qualifiers like
+        # ``NotRequired`` (e.g. LangChain's ``PlanningState`` used by
+        # DeepAgents' ``TodoListMiddleware`` triggers
+        # ``PydanticForbiddenQualifier``).  Schema introspection is
+        # metadata — a failure here must not take down the runtime.  Fall
+        # back to chat/text mode and cache the fallback so subsequent calls
+        # are O(1) and ``/agent/run`` keeps streaming.
+        try:
+            input_schema_cls = getattr(graph, "input_schema", None)
+            output_schema_cls = getattr(graph, "output_schema", None)
+            input_fields = self._unwrap_schema_fields(input_schema_cls)
+            output_fields = self._unwrap_schema_fields(output_schema_cls)
+        except Exception as e:
+            logger.warning(
+                "Graph schema introspection failed (%s: %s). Falling back "
+                "to chat/text capabilities. Streaming is unaffected. This "
+                "is commonly seen with LangChain middleware that uses "
+                "TypedDict-only qualifiers (e.g. DeepAgents + PlanningState).",
+                type(e).__name__,
+                e,
+            )
+            input_schema_cls = None
+            output_schema_cls = None
+            input_fields = None
+            output_fields = None
 
         # Detect input mode
         input_mode = "chat"

--- a/libs/idun_agent_engine/tests/unit/agent/test_discovery.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_discovery.py
@@ -1,5 +1,6 @@
 """Tests for agent capability auto-discovery."""
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -148,3 +149,82 @@ async def test_langgraph_structured_discovery_json_schema_shape():
     assert output_schema is not None
     assert output_schema["type"] == "object"
     assert "graph_output" in output_schema["properties"]
+
+
+@pytest.mark.asyncio
+async def test_discover_capabilities_falls_back_when_schema_introspection_raises(
+    caplog,
+):
+    """Schema introspection failures must not crash discovery.
+
+    Reproduces the LangChain 1.2 / LangGraph 1.x / Pydantic 2
+    ``PydanticForbiddenQualifier`` condition that breaks DeepAgents on
+    Idun (LangChain's ``PlanningState.todos`` uses ``NotRequired``, which
+    LangGraph forwards to ``pydantic.create_model`` without unwrapping).
+
+    Contract: any exception while accessing ``graph.input_schema`` or
+    ``graph.output_schema`` must degrade to chat/text mode, emit a
+    warning, and cache the fallback so subsequent calls are O(1).
+    """
+    from idun_agent_engine.core.config_builder import ConfigBuilder
+
+    mock_graph_path = (
+        Path(__file__).parent.parent.parent / "fixtures" / "agents" / "mock_graph.py"
+    )
+
+    config = {
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "boom_agent",
+                "graph_definition": f"{mock_graph_path}:graph",
+            },
+        },
+    }
+
+    engine_config = ConfigBuilder.from_dict(config).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
+
+    # Replace the compiled graph with one whose schema @properties raise,
+    # mimicking LangGraph's pregel create_model failure on a state schema
+    # that includes TypedDict-only qualifiers (e.g. PlanningState).
+    class _BoomGraph:
+        @property
+        def input_schema(self):
+            raise RuntimeError("boom: NotRequired not allowed here")
+
+        @property
+        def output_schema(self):
+            raise RuntimeError("boom: NotRequired not allowed here")
+
+    agent._agent_instance = _BoomGraph()
+    agent._cached_capabilities = None
+
+    with caplog.at_level(logging.WARNING, logger="idun_agent_engine"):
+        capabilities = agent.discover_capabilities()
+
+    assert capabilities.framework.value == "LANGGRAPH"
+    assert capabilities.input.mode == "chat"
+    assert capabilities.input.schema_ is None
+    assert capabilities.output.mode == "text"
+    assert capabilities.output.schema_ is None
+
+    assert any(
+        "Graph schema introspection failed" in rec.message for rec in caplog.records
+    ), "expected a warning log describing the introspection failure"
+
+    # Second call must hit the cache — the raising @property must not be
+    # accessed again, proving the fallback was cached on the first call.
+    class _ExplodeIfTouched:
+        @property
+        def input_schema(self):
+            raise AssertionError("cache was not used — input_schema re-accessed")
+
+        @property
+        def output_schema(self):
+            raise AssertionError("cache was not used — output_schema re-accessed")
+
+    agent._agent_instance = _ExplodeIfTouched()
+
+    cached = agent.discover_capabilities()
+    assert cached is capabilities


### PR DESCRIPTION
## Summary

- Wrap ``LanggraphAgent.discover_capabilities()`` schema-access block in a broad ``except Exception`` that logs the failure and falls back to chat/text capabilities
- Unblocks ``/agent/run`` and ``/agent/capabilities`` for DeepAgents (and any future agent hit by a similar LangGraph ↔ Pydantic mismatch)
- Add regression test asserting fallback + warning log + cache behavior

## Why

A developer using DeepAgents with idun-agent-engine reported that every ``POST /agent/run`` returns 500 with ``pydantic.errors.PydanticForbiddenQualifier``. Root cause chain:

1. LangChain 1.2's ``PlanningState.todos`` is typed ``Annotated[NotRequired[list[Todo]], OmitFromInput]`` (valid TypedDict).
2. DeepAgents' ``create_deep_agent`` unconditionally injects ``TodoListMiddleware``, so ``PlanningState`` ends up in the compiled graph's state.
3. LangGraph's ``_internal._pydantic.create_model`` forwards ``NotRequired[...]`` to ``pydantic.create_model`` without unwrapping.
4. Pydantic 2 forbids ``NotRequired`` outside TypedDict context → raises ``PydanticForbiddenQualifier``.
5. Engine's ``discover_capabilities()`` (langgraph.py line 652) accesses ``graph.output_schema`` — a ``@property`` that triggers the broken materialization — and the exception propagates out of ``run()`` into the SSE stream.

The true root cause lives in LangGraph (``NotRequired`` should be stripped before Pydantic sees it) or LangChain (``PlanningState.todos`` declaration). But the engine is the first user-visible crash site, and capability introspection is metadata — it must not be able to take down the runtime.

## What this changes

Only ``discover_capabilities()`` in ``libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py``:

- Introspection lines wrapped in ``try: ... except Exception``.
- On failure: log a warning (with exception class + message, and a hint about ``NotRequired``/DeepAgents), set all four schema variables to ``None``.
- Existing downstream logic already handles ``None`` fields → ``input_mode="chat"``, ``output_mode="text"``.
- ``AgentCapabilities`` is built normally and cached at line 657, so subsequent calls are O(1).

``run()`` at line 716 is untouched. The method it calls is now safe, so every caller (``run()``, ``/agent/capabilities``, lifespan startup) benefits from one guard in one place.

## What this does NOT change

- No fix in LangGraph or LangChain — that belongs upstream. See 'Follow-ups' below.
- No new config flag. Graceful degradation is unconditional — it's a robustness invariant, not a feature.
- No change to JSON validation: structured-input agents still validate. Only agents whose schema failed to materialize skip validation (correct — we have no schema to validate against).
- No change to lifespan handling (``server/lifespan.py:99`` already logs at startup; it will now find ``app.state.capabilities`` populated with a safe fallback instead of ``None``).

## Test

Adds ``test_discover_capabilities_falls_back_when_schema_introspection_raises`` in ``libs/idun_agent_engine/tests/unit/agent/test_discovery.py``:

1. Initialize a real agent via ``ConfigBuilder``.
2. Replace ``agent._agent_instance`` with a mock whose ``input_schema``/``output_schema`` ``@property``s raise ``RuntimeError``.
3. Clear the cache, call ``discover_capabilities()``.
4. Assert: framework is LANGGRAPH, ``input.mode == "chat"``, ``output.mode == "text"``, both schemas are ``None``, warning log is emitted.
5. Swap the mock for one that raises ``AssertionError`` on any property access, call ``discover_capabilities()`` again, assert it returns the cached result (proving the raising properties were never touched).

All 18 agent unit tests pass locally.

## Follow-ups (separate issues, not this PR)

1. File an upstream LangGraph issue asking ``_internal._pydantic.create_model`` to strip ``NotRequired[X]`` → ``X`` before handing fields to Pydantic. Reference the reporter's 50-line patch.
2. Update the DeepAgents usage guide with a 'known issue resolved in engine ≥ <next-version>' note once this ships.
3. Optional: restructure ``capabilities.py`` to make the fallback explicit as a named constructor (e.g. ``AgentCapabilities.chat_fallback(framework)``) if we want the fallback path reusable across adapters.

## Test plan

- [ ] Unit test ``test_discover_capabilities_falls_back_when_schema_introspection_raises`` passes in CI
- [ ] Existing discovery / langgraph / adk / haystack unit tests still pass
- [ ] Manual: serve a DeepAgents agent against this branch, ``POST /agent/run``, confirm streaming succeeds and the startup log shows the warning once
- [ ] Manual: ``GET /agent/capabilities`` returns 200 with ``input.mode = "chat"`` and ``output.mode = "text"`` for a DeepAgents agent
- [ ] Lint (``make lint``) clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)