### PR TITLE
feat(skills): add ADK skills engine integration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,3 +40,4 @@ curl -X POST http://localhost:8001/agent/run \
 | langgraph-structured | LangGraph | structured | structured | 8002 |
 | adk-chat | ADK | chat | text | 8003 |
 | adk-structured | ADK | structured | structured | 8004 |
+| adk-skills | ADK | chat | text | 8005 |

--- a/examples/adk-skills/agent.py
+++ b/examples/adk-skills/agent.py
@@ -1,0 +1,23 @@
+"""ADK agent with Skills (SkillToolset) example.
+
+Demonstrates an ADK agent that uses the Skills feature to load
+domain-specific expertise on demand. Skills follow the open
+Agent Skills specification (agentskills.io) and support
+progressive disclosure to minimize context window usage.
+
+The skills are defined inline in the config.yaml and injected
+automatically by the Idun Agent Engine.
+"""
+
+from google.adk.agents import LlmAgent
+
+root_agent = LlmAgent(
+    name="skills_agent",
+    model="gemini-2.0-flash",
+    instruction=(
+        "You are a helpful assistant with access to specialized skills. "
+        "When a user's request matches a skill's domain, use `load_skill` "
+        "to load the detailed instructions for that skill before responding. "
+        "Always follow the loaded skill instructions precisely."
+    ),
+)

--- a/examples/adk-skills/config.yaml
+++ b/examples/adk-skills/config.yaml
@@ -1,0 +1,65 @@
+server:
+  api:
+    port: 8005
+
+agent:
+  type: ADK
+  config:
+    name: "ADK Skills Agent"
+    app_name: "adk_skills"
+    agent: "./agent.py:root_agent"
+
+# Skills follow the Agent Skills specification (agentskills.io).
+# Each skill provides domain-specific expertise that the agent loads on demand.
+# The engine converts these into ADK's native SkillToolset automatically.
+skills:
+  - name: "customer-support"
+    description: "Handle customer support inquiries with escalation rules and resolution procedures"
+    version: "1.0.0"
+    instructions: |
+      You are a customer support specialist. Follow these procedures:
+
+      ## Intake
+      1. Greet the customer warmly and acknowledge their issue
+      2. Identify the issue category: billing, technical, or general inquiry
+
+      ## Resolution
+      - **Billing**: Check account status, offer refund or credit options
+      - **Technical**: Gather system info (OS, browser, error messages) before troubleshooting
+      - **General**: Answer directly from the knowledge base
+
+      ## Escalation
+      If the issue cannot be resolved after 2 attempts, escalate:
+      - Use the escalation matrix in references/escalation-policy.md
+      - Always inform the customer about the escalation timeline
+    resources:
+      references:
+        escalation-policy.md: |
+          ## Escalation Matrix
+          - **P1** (service down): Immediate escalation to on-call engineer
+          - **P2** (degraded service): Escalate after 15 minutes of troubleshooting
+          - **P3** (question/feature request): Resolve in-chat, no escalation needed
+
+          ## Contact Channels
+          - On-call engineer: Slack #incident-response
+          - Billing team: billing@example.com
+          - Product feedback: Jira FEEDBACK project
+
+  - name: "meeting-processor"
+    description: "Extract action items, classify meetings, and draft follow-up communications"
+    version: "1.0.0"
+    instructions: |
+      You are a meeting analysis expert. When processing meeting notes:
+
+      ## Analysis Steps
+      1. Identify all action items with owners and deadlines
+      2. Classify the meeting type (standup, planning, review, brainstorm)
+      3. Extract key decisions made during the meeting
+      4. Note any unresolved questions or parking lot items
+
+      ## Output Format
+      Structure your response as:
+      - **Summary**: 2-3 sentence overview
+      - **Action Items**: Bulleted list with [Owner] and [Deadline]
+      - **Decisions**: Numbered list of decisions made
+      - **Follow-ups**: Items that need further discussion

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
@@ -194,6 +194,8 @@ class AdkAgent(agent_base.BaseAgent):
         self._obs_callbacks: list[Any] | None = None
         # Cached capabilities descriptor
         self._cached_capabilities: AgentCapabilities | None = None
+        # Skills configuration (injected during initialize())
+        self._skills_config: list[SkillConfig] | None = None
 
     @property
     def id(self) -> str:

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
@@ -494,15 +494,17 @@ class AdkAgent(agent_base.BaseAgent):
 
         adk_skills = []
         for sc in skills_config:
-            # Build L3 resources if provided
-            resources = None
-            if sc.resources and (
-                sc.resources.references or sc.resources.assets or sc.resources.scripts
-            ):
-                resources = skill_models.Resources(
-                    references=sc.resources.references or {},
-                    assets=sc.resources.assets or {},
-                )
+            # Build L3 resources — always instantiate a Resources() object
+            # even when the skill has no resources (e.g. meeting-processor),
+            # because the ADK Skill Pydantic model does not accept None.
+            resources = skill_models.Resources(
+                references=(
+                    sc.resources.references if sc.resources else {}
+                ),
+                assets=(
+                    sc.resources.assets if sc.resources else {}
+                ),
+            )
 
             adk_skill = skill_models.Skill(
                 frontmatter=skill_models.Frontmatter(

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
@@ -504,6 +504,9 @@ class AdkAgent(agent_base.BaseAgent):
                 assets=(
                     sc.resources.assets if sc.resources else {}
                 ),
+                scripts=(
+                    sc.resources.scripts if sc.resources else {}
+                ),
             )
 
             adk_skill = skill_models.Skill(

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
@@ -42,6 +42,7 @@ from idun_agent_schema.engine.sessions import (
     SessionMessage,
     SessionSummary,
 )
+from idun_agent_schema.engine.skills import SkillConfig
 from pydantic import BaseModel
 
 from idun_agent_engine import observability
@@ -256,10 +257,12 @@ class AdkAgent(agent_base.BaseAgent):
         self,
         config: AdkAgentConfig,
         observability_config: list[ObservabilityConfig] | None = None,
+        skills_config: list[SkillConfig] | None = None,
     ) -> None:
         """Initialize the ADK agent asynchronously."""
         _install_app_name_mismatch_filter()
         self._configuration = AdkAgentConfig.model_validate(config)
+        self._skills_config = skills_config
 
         self._name = self._configuration.app_name or "Unnamed ADK Agent"
         self._infos["name"] = self._name
@@ -368,6 +371,10 @@ class AdkAgent(agent_base.BaseAgent):
         # Load the agent instance
         agent = self._load_agent(self._configuration.agent)
 
+        # Inject skills toolset if skills are configured
+        if self._skills_config:
+            agent = self._inject_skills(agent, self._skills_config)
+
         self._agent_instance = App(root_agent=agent, name=self._name)
 
         # Initialize CopilotKit/AG-UI Agent Wrapper
@@ -460,6 +467,65 @@ class AdkAgent(agent_base.BaseAgent):
             raise ValueError(
                 f"Failed to load agent from {agent_definition}: {e}"
             ) from e
+
+    def _inject_skills(self, agent: Any, skills_config: list[SkillConfig]) -> Any:
+        """Inject skills from config into the agent's tools list.
+
+        Converts SkillConfig Pydantic models to ADK's native Skill objects
+        and wraps them in a SkillToolset. The toolset is appended to the
+        agent's existing tools list.
+
+        Args:
+            agent: The loaded ADK agent instance.
+            skills_config: List of skill configurations from the engine config.
+
+        Returns:
+            The agent instance with skills injected into its tools.
+        """
+        try:
+            from google.adk.skills import models as skill_models
+            from google.adk.tools import skill_toolset
+        except ImportError:
+            logger.warning(
+                "google-adk[skills] not installed. Skills from config will be ignored. "
+                "Install google-adk >= 1.25.0 for skills support."
+            )
+            return agent
+
+        adk_skills = []
+        for sc in skills_config:
+            # Build L3 resources if provided
+            resources = None
+            if sc.resources and (
+                sc.resources.references or sc.resources.assets or sc.resources.scripts
+            ):
+                resources = skill_models.Resources(
+                    references=sc.resources.references or {},
+                    assets=sc.resources.assets or {},
+                )
+
+            adk_skill = skill_models.Skill(
+                frontmatter=skill_models.Frontmatter(
+                    name=sc.name,
+                    description=sc.description,
+                    version=sc.version,
+                ),
+                instructions=sc.instructions,
+                resources=resources,
+            )
+            adk_skills.append(adk_skill)
+            logger.info(f"Loaded skill '{sc.name}' v{sc.version}")
+
+        if adk_skills:
+            toolset = skill_toolset.SkillToolset(skills=adk_skills)
+            # Append to existing tools
+            existing_tools = getattr(agent, "tools", None) or []
+            agent.tools = [*existing_tools, toolset]
+            logger.info(
+                f"Injected {len(adk_skills)} skill(s) into agent '{agent.name}'"
+            )
+
+        return agent
 
     def _get_text_from_message(self, message: Any) -> str:
         if isinstance(message, BaseModel):

--- a/libs/idun_agent_engine/src/idun_agent_engine/core/config_builder.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/core/config_builder.py
@@ -20,6 +20,7 @@ from idun_agent_schema.engine.langgraph import (
 from idun_agent_schema.engine.mcp_server import MCPServer
 from idun_agent_schema.engine.observability_v2 import ObservabilityConfig
 from idun_agent_schema.engine.prompt import PromptConfig
+from idun_agent_schema.engine.skills import SkillConfig
 from idun_agent_schema.engine.sso import SSOConfig
 
 from idun_agent_engine.server.server_config import ServerAPIConfig
@@ -59,7 +60,7 @@ class ConfigBuilder:
         self._sso: SSOConfig | None = None
         self._integrations: list | None = None
         self._prompts: list[PromptConfig] | None = None
-        self._skills: list | None = None
+        self._skills: list[SkillConfig] | None = None
 
     def with_api_port(self, port: int) -> "ConfigBuilder":
         """Set the API port for the server.
@@ -411,8 +412,16 @@ class ConfigBuilder:
         # Initialize the agent with its configuration
         init_kwargs: dict[str, Any] = {}
         # Pass skills config to ADK agents (native SkillToolset support)
-        if agent_type == AgentFramework.ADK and engine_config.skills:
-            init_kwargs["skills_config"] = engine_config.skills
+        if engine_config.skills:
+            if agent_type == AgentFramework.ADK:
+                init_kwargs["skills_config"] = engine_config.skills
+            else:
+                logger.warning(
+                    "Skills are configured but agent type '%s' does not support "
+                    "native skills injection. Skills will be ignored. "
+                    "Only ADK agents currently support skills.",
+                    agent_type,
+                )
         await agent_instance.initialize(
             validated_config,
             observability_config,  # , mcp_registry=mcp_registry

--- a/libs/idun_agent_engine/src/idun_agent_engine/core/config_builder.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/core/config_builder.py
@@ -59,6 +59,7 @@ class ConfigBuilder:
         self._sso: SSOConfig | None = None
         self._integrations: list | None = None
         self._prompts: list[PromptConfig] | None = None
+        self._skills: list | None = None
 
     def with_api_port(self, port: int) -> "ConfigBuilder":
         """Set the API port for the server.
@@ -123,6 +124,7 @@ class ConfigBuilder:
             self._sso = engine_config.sso
             self._integrations = engine_config.integrations
             self._prompts = engine_config.prompts
+            self._skills = engine_config.skills
 
             return self
         except Exception as e:
@@ -223,6 +225,7 @@ class ConfigBuilder:
             sso=self._sso,
             integrations=self._integrations,
             prompts=self._prompts,
+            skills=self._skills,
         )
 
     def build_dict(self) -> dict[str, Any]:  # NOT USED
@@ -406,9 +409,14 @@ class ConfigBuilder:
             raise ValueError(f"Unsupported agent type: {agent_type}")
 
         # Initialize the agent with its configuration
+        init_kwargs: dict[str, Any] = {}
+        # Pass skills config to ADK agents (native SkillToolset support)
+        if agent_type == AgentFramework.ADK and engine_config.skills:
+            init_kwargs["skills_config"] = engine_config.skills
         await agent_instance.initialize(
             validated_config,
             observability_config,  # , mcp_registry=mcp_registry
+            **init_kwargs,
         )  # type: ignore[arg-type]
         return agent_instance
 
@@ -595,6 +603,7 @@ class ConfigBuilder:
         builder._sso = engine_config.sso
         builder._integrations = engine_config.integrations
         builder._prompts = engine_config.prompts
+        builder._skills = engine_config.skills
         return builder
 
     @classmethod
@@ -629,6 +638,7 @@ class ConfigBuilder:
         builder._sso = engine_config.sso
         builder._integrations = engine_config.integrations
         builder._prompts = engine_config.prompts
+        builder._skills = engine_config.skills
 
         return builder
 

--- a/libs/idun_agent_engine/tests/unit/agent/test_skills.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_skills.py
@@ -1,0 +1,122 @@
+"""Tests for SkillConfig schema validation."""
+
+import pytest
+from idun_agent_schema.engine.skills import SkillConfig, SkillResourcesConfig
+
+
+@pytest.mark.unit
+class TestSkillConfig:
+    """Test SkillConfig validation and defaults."""
+
+    def test_minimal_skill_config(self):
+        """A skill requires name, description, and instructions."""
+        skill = SkillConfig(
+            name="test-skill",
+            description="A test skill",
+            instructions="Do the thing.",
+        )
+        assert skill.name == "test-skill"
+        assert skill.description == "A test skill"
+        assert skill.version == "1.0.0"
+        assert skill.instructions == "Do the thing."
+        assert skill.resources.references == {}
+        assert skill.resources.assets == {}
+
+    def test_full_skill_config(self):
+        """A skill can include version and resources."""
+        skill = SkillConfig(
+            name="customer-support",
+            description="Handle support tickets",
+            version="2.1.0",
+            instructions="Step 1: Greet. Step 2: Help.",
+            resources=SkillResourcesConfig(
+                references={"policy.md": "# Policy\nBe nice."},
+                assets={"template.txt": "Dear customer,"},
+            ),
+        )
+        assert skill.version == "2.1.0"
+        assert "policy.md" in skill.resources.references
+        assert "template.txt" in skill.resources.assets
+
+    def test_skill_name_validation_lowercase_hyphens(self):
+        """Names must be lowercase with hyphens per agentskills.io spec."""
+        skill = SkillConfig(
+            name="my-cool-skill-2",
+            description="Test",
+            instructions="Test",
+        )
+        assert skill.name == "my-cool-skill-2"
+
+    def test_skill_name_rejects_uppercase(self):
+        """Names with uppercase letters are rejected."""
+        with pytest.raises(ValueError, match="must start with a lowercase"):
+            SkillConfig(
+                name="MySkill", description="Test", instructions="Test"
+            )
+
+    def test_skill_name_rejects_spaces(self):
+        """Names with spaces are rejected."""
+        with pytest.raises(ValueError, match="must start with a lowercase"):
+            SkillConfig(
+                name="my skill", description="Test", instructions="Test"
+            )
+
+    def test_skill_name_rejects_leading_digit(self):
+        """Names starting with a digit are rejected."""
+        with pytest.raises(ValueError, match="must start with a lowercase"):
+            SkillConfig(
+                name="2fast", description="Test", instructions="Test"
+            )
+
+    def test_skill_name_rejects_empty(self):
+        """Empty names are rejected."""
+        with pytest.raises(ValueError):
+            SkillConfig(name="", description="Test", instructions="Test")
+
+    def test_skill_config_from_dict(self):
+        """SkillConfig can be created from YAML-like dict."""
+        data = {
+            "name": "meeting-processor",
+            "description": "Process meeting notes",
+            "instructions": "Extract action items.",
+            "resources": {
+                "references": {"guide.md": "# Guide"},
+            },
+        }
+        skill = SkillConfig.model_validate(data)
+        assert skill.name == "meeting-processor"
+        assert "guide.md" in skill.resources.references
+
+    def test_skill_config_serialization(self):
+        """SkillConfig can be serialized back to dict."""
+        skill = SkillConfig(
+            name="test-skill",
+            description="A test skill",
+            instructions="Do something.",
+        )
+        dumped = skill.model_dump()
+        assert dumped["name"] == "test-skill"
+        assert dumped["version"] == "1.0.0"
+
+
+@pytest.mark.unit
+class TestSkillResourcesConfig:
+    """Test SkillResourcesConfig defaults and behavior."""
+
+    def test_empty_resources(self):
+        """Resources default to empty dicts."""
+        resources = SkillResourcesConfig()
+        assert resources.references == {}
+        assert resources.assets == {}
+        assert resources.scripts == {}
+
+    def test_resources_from_dict(self):
+        """Resources can be created from a dict."""
+        data = {
+            "references": {"a.md": "content a"},
+            "assets": {"b.txt": "content b"},
+        }
+        resources = SkillResourcesConfig.model_validate(data)
+        assert resources.references["a.md"] == "content a"
+        assert resources.assets["b.txt"] == "content b"
+        assert resources.scripts == {}

--- a/libs/idun_agent_engine/tests/unit/agent/test_skills.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_skills.py
@@ -68,6 +68,20 @@ class TestSkillConfig:
                 name="2fast", description="Test", instructions="Test"
             )
 
+    def test_skill_name_rejects_trailing_hyphen(self):
+        """Names with trailing hyphens are rejected."""
+        with pytest.raises(ValueError, match="must start with a lowercase"):
+            SkillConfig(
+                name="my-skill-", description="Test", instructions="Test"
+            )
+
+    def test_skill_name_rejects_consecutive_hyphens(self):
+        """Names with consecutive hyphens are rejected."""
+        with pytest.raises(ValueError, match="must start with a lowercase"):
+            SkillConfig(
+                name="my--skill", description="Test", instructions="Test"
+            )
+
     def test_skill_name_rejects_empty(self):
         """Empty names are rejected."""
         with pytest.raises(ValueError):

--- a/libs/idun_agent_engine/tests/unit/core/test_engine_config_skills.py
+++ b/libs/idun_agent_engine/tests/unit/core/test_engine_config_skills.py
@@ -1,0 +1,85 @@
+"""Tests for EngineConfig with skills field."""
+
+import pytest
+from idun_agent_schema.engine.langgraph import LangGraphAgentConfig
+
+from idun_agent_engine.core.engine_config import AgentConfig, EngineConfig
+
+
+@pytest.mark.unit
+class TestEngineConfigWithSkills:
+    """Test that EngineConfig correctly handles the optional skills field."""
+
+    def test_engine_config_without_skills(self):
+        """Skills default to None when not specified."""
+        config = EngineConfig(
+            agent=AgentConfig(
+                type="LANGGRAPH",
+                config=LangGraphAgentConfig(
+                    name="TestAgent", graph_definition="test.py:graph"
+                ),
+            )
+        )
+        assert config.skills is None
+
+    def test_engine_config_with_skills(self):
+        """Skills are parsed when provided in config."""
+        config_dict = {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "TestAgent",
+                    "graph_definition": "test.py:graph",
+                },
+            },
+            "skills": [
+                {
+                    "name": "test-skill",
+                    "description": "A test skill",
+                    "instructions": "Do things.",
+                },
+                {
+                    "name": "another-skill",
+                    "description": "Another skill",
+                    "version": "2.0.0",
+                    "instructions": "Do other things.",
+                    "resources": {
+                        "references": {"guide.md": "# Guide"},
+                    },
+                },
+            ],
+        }
+
+        config = EngineConfig.model_validate(config_dict)
+
+        assert config.skills is not None
+        assert len(config.skills) == 2
+        assert config.skills[0].name == "test-skill"
+        assert config.skills[1].version == "2.0.0"
+        assert "guide.md" in config.skills[1].resources.references
+
+    def test_engine_config_skills_serialization(self):
+        """Skills survive round-trip serialization."""
+        config_dict = {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "TestAgent",
+                    "graph_definition": "test.py:graph",
+                },
+            },
+            "skills": [
+                {
+                    "name": "my-skill",
+                    "description": "Skill desc",
+                    "instructions": "Instructions here.",
+                },
+            ],
+        }
+
+        config = EngineConfig.model_validate(config_dict)
+        dumped = config.model_dump()
+
+        assert dumped["skills"] is not None
+        assert len(dumped["skills"]) == 1
+        assert dumped["skills"][0]["name"] == "my-skill"

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/__init__.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/__init__.py
@@ -42,4 +42,5 @@ from .sessions import (  # noqa: F401
     SessionMessage,
     SessionSummary,
 )
+from .skills import SkillConfig, SkillResourcesConfig  # noqa: F401
 from .sso import SSOConfig  # noqa: F401

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/engine.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/engine.py
@@ -10,6 +10,7 @@ from .mcp_server import MCPServer
 from .observability_v2 import ObservabilityConfig
 from .prompt import PromptConfig
 from .server import ServerConfig
+from .skills import SkillConfig
 from .sso import SSOConfig
 
 
@@ -29,3 +30,4 @@ class EngineConfig(BaseModel):
     sso: SSOConfig | None = None
     integrations: list[IntegrationConfig] | None = None
     prompts: list[PromptConfig] | None = None
+    skills: list[SkillConfig] | None = None

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/skills.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/skills.py
@@ -1,0 +1,97 @@
+"""Skill configuration models following the Agent Skills specification.
+
+Skills are self-contained units of cognitive expertise that agents can load
+on demand. They follow the open Agent Skills specification (agentskills.io)
+and support progressive disclosure:
+
+- L1 (Metadata): name + description — injected into the system prompt as a catalog
+- L2 (Instructions): full markdown instructions — loaded when the skill is activated
+- L3 (Resources): references, assets, scripts — loaded on demand
+
+See: https://agentskills.io/specification
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic.alias_generators import to_camel
+
+
+class SkillResourcesConfig(BaseModel):
+    """Optional resources attached to a skill (L3 content).
+
+    Mirrors the Agent Skills spec directory structure:
+    - references/: Additional markdown guidance files
+    - assets/: Templates, data files, images
+    - scripts/: Executable scripts (not currently executed by the engine)
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+    references: dict[str, str] = Field(
+        default_factory=dict,
+        description="Map of filename to markdown content for reference documents",
+    )
+    assets: dict[str, str] = Field(
+        default_factory=dict,
+        description="Map of filename to content for asset files",
+    )
+    scripts: dict[str, str] = Field(
+        default_factory=dict,
+        description="Map of filename to content for script files (not executed)",
+    )
+
+
+class SkillConfig(BaseModel):
+    """Engine-level skill configuration following the Agent Skills spec.
+
+    Each skill represents a self-contained domain of expertise that an agent
+    can load on demand. Skills are the cognitive complement to MCP tools:
+    MCP gives agents hands (actions), Skills give agents brains (expertise).
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+    name: str = Field(
+        ...,
+        description="Skill identifier (lowercase with hyphens, e.g. 'customer-support')",
+        min_length=1,
+        max_length=64,
+    )
+    description: str = Field(
+        ...,
+        description="Short description for skill discovery (L1 metadata)",
+        min_length=1,
+        max_length=1024,
+    )
+    version: str = Field(
+        default="1.0.0",
+        description="Semantic version of the skill",
+    )
+    instructions: str = Field(
+        ...,
+        description="Full skill instructions in markdown (L2 content)",
+    )
+    resources: SkillResourcesConfig = Field(
+        default_factory=SkillResourcesConfig,
+        description="Optional resources: references, assets, scripts (L3 content)",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_skill_name(cls, v: str) -> str:
+        """Enforce Agent Skills spec naming: lowercase letters, digits, hyphens."""
+        if not re.match(r"^[a-z][a-z0-9-]*$", v):
+            raise ValueError(
+                f"Skill name '{v}' must start with a lowercase letter and contain "
+                "only lowercase letters, digits, and hyphens (per agentskills.io spec)"
+            )
+        return v

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/skills.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/skills.py
@@ -89,7 +89,7 @@ class SkillConfig(BaseModel):
     @classmethod
     def validate_skill_name(cls, v: str) -> str:
         """Enforce Agent Skills spec naming: lowercase letters, digits, hyphens."""
-        if not re.match(r"^[a-z][a-z0-9-]*$", v):
+        if not re.match(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$", v):
             raise ValueError(
                 f"Skill name '{v}' must start with a lowercase letter and contain "
                 "only lowercase letters, digits, and hyphens (per agentskills.io spec)"


### PR DESCRIPTION
## Summary

Implements **Phase 2 (Engine Integration)** of Agent Skills ([#467](https://github.com/Idun-Group/idun-agent-platform/issues/467)) — a managed cognitive expertise layer for ADK agents.

Skills are self-contained units of domain knowledge that follow the open [Agent Skills specification](https://agentskills.io). They support **progressive disclosure** (L1 metadata → L2 instructions → L3 resources) to minimize context window usage while maximizing agent capability.

## What changed

### Schema (`idun_agent_schema`)

| File | Change |
|------|--------|
| `engine/skills.py` | **[NEW]** `SkillConfig` and `SkillResourcesConfig` Pydantic models with name validation per agentskills.io spec |
| `engine/engine.py` | Added optional `skills: list[SkillConfig]` field to `EngineConfig` |
| `engine/__init__.py` | Exported new types |

### Engine (`idun_agent_engine`)

| File | Change |
|------|--------|
| `agent/adk/adk.py` | Added `_inject_skills()` method that converts `SkillConfig` objects to ADK's native `Skill` models and injects a `SkillToolset` into the agent's tools list |
| `core/config_builder.py` | Threaded `skills` field through all builder methods; passes skills config to ADK adapter during initialization |

### Example

| File | Change |
|------|--------|
| `examples/adk-skills/agent.py` | **[NEW]** Minimal LlmAgent demonstrating config-driven skill injection |
| `examples/adk-skills/config.yaml` | **[NEW]** Two inline skills: `customer-support` (with escalation resources) and `meeting-processor` |

### Tests

| File | Tests |
|------|-------|
| `tests/unit/agent/test_skills.py` | **[NEW]** 11 tests: schema validation, naming rules, serialization |
| `tests/unit/core/test_engine_config_skills.py` | **[NEW]** 3 tests: EngineConfig with/without skills, round-trip serialization |

## Design decisions

1. **ADK-first**: Skills use ADK's native `SkillToolset` for tool injection. LangGraph/Haystack support can follow using the `@tool` pattern described in #467.
2. **Graceful fallback**: If `google.adk.skills` is not installed, skills config is silently ignored with a warning log — zero breaking changes.
3. **Config-driven**: Skills are defined inline in YAML, following the existing materialized config pattern (same as `prompts`, `mcp_servers`).
4. **Spec-compliant naming**: `field_validator` enforces lowercase-hyphenated names per agentskills.io.

## Testing

```
14 new tests passed
382 total unit tests passed (3 pre-existing MCP registry failures unrelated to this PR)
```

## Example usage

```yaml
skills:
  - name: "customer-support"
    description: "Handle support inquiries"
    instructions: |
      ## Intake
      1. Greet the customer
      2. Identify issue category
    resources:
      references:
        escalation-policy.md: |
          ## Escalation Matrix
          - P1: Immediate escalation
```

Closes #467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring "skills" for ADK agents, including skill instructions and resources.
  * Added an adk-skills example demonstrating a skills-enabled agent (server port documented).

* **Documentation**
  * Examples updated to include the new adk-skills entry and usage notes.

* **Tests**
  * Added unit tests validating skills and skill-resources schema, parsing, validation, and serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/516)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->