### PR TITLE
Phase 3 — Cross-cutting plumbing

### DIFF
--- a/docs/superpowers/plans/2026-04-27-rework-phase3.md
+++ b/docs/superpowers/plans/2026-04-27-rework-phase3.md
@@ -1,0 +1,3081 @@
+# Phase 3 — Cross-Cutting Plumbing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the cross-cutting plumbing every later phase needs — reload pipeline (asyncio mutex + 3-round validation + structural-change detection), slug rules, RFC 8785 config hash, runtime-state persistence — and retrofit Phase 1's agent + memory routers from stub reload constants to the real pipeline.
+
+**Architecture:** Sequential SDD tasks. T2 cross-cutting helpers (runtime_state, slugs, config_hash) land first because T1's reload pipeline calls them. T1 reload pipeline lands next. T3 retrofits the routers. T4 flips FORWARD → ESTABLISHED transitions in the patterns reference doc.
+
+**Tech Stack:** Python 3.12, Pydantic 2.11+, SQLAlchemy 2.x async, FastAPI, pytest. New runtime dep: `rfc8785>=0.1` (RFC 8785 / JCS canonicalization).
+
+**Spec:** `docs/superpowers/specs/2026-04-27-rework-phase3-plumbing-design.md`
+**Patterns reference:** `docs/superpowers/specs/2026-04-27-rework-patterns.md`
+**Rework spec:** `docs/superpowers/specs/2026-04-27-standalone-admin-config-db-design.md`
+
+**Working branch:** `feat/rework-phase3-plumbing` (off `feat/standalone-admin-db-rework`).
+**PR target:** `feat/standalone-admin-db-rework`.
+
+**Commit sequence (target):**
+1. `4d3d86d3 docs(rework-phase3): add Phase 3 design doc` — already landed (pre-plan).
+2. `docs(rework-phase3): add Phase 3 plan` — Task 0.
+3. `feat(rework-phase3): cross-cutting helpers (slugs, config hash, runtime state)` — Task 1 (T2).
+4. `feat(rework-phase3): reload pipeline + 3-round validation` — Task 2 (T1).
+5. `refactor(rework-phase3): agent + memory routers use real reload pipeline` — Task 3 (T3).
+6. `docs(rework-phase3): patterns reference — flip FORWARD sections to ESTABLISHED` — Task 4 (T4).
+
+---
+
+## Task 0: Pre-flight + plan commit
+
+**Files:** none (verification + plan commit).
+
+- [ ] **Step 1: Verify branch and tip**
+
+Run:
+```bash
+git status -sb && git log --oneline -1
+```
+Expected: `## feat/rework-phase3-plumbing` and tip is `4d3d86d3 docs(rework-phase3): add Phase 3 design doc`.
+
+- [ ] **Step 2: Verify umbrella tip**
+
+Run:
+```bash
+git log --oneline -1 feat/standalone-admin-db-rework
+```
+Expected: `53342bd6 Phase 2 — Schema namespace completion (#522)` (or a later commit if other phases have already merged).
+
+- [ ] **Step 3: Verify the narrowed CI baseline is green**
+
+Run:
+```bash
+make lint
+```
+Expected: exit 0.
+
+```bash
+uv run mypy --follow-imports=silent \
+  libs/idun_agent_schema/src/idun_agent_schema/standalone \
+  libs/idun_agent_standalone/src/idun_agent_standalone/api \
+  libs/idun_agent_standalone/src/idun_agent_standalone/core \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services \
+  libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure
+```
+Expected: `Success: no issues found in 38 source files` (Phase 2 close-state).
+
+```bash
+uv run pytest libs/idun_agent_schema -q
+```
+Expected: `62 passed`.
+
+```bash
+uv run pytest libs/idun_agent_standalone -q \
+  -m "not requires_postgres and not requires_langfuse and not requires_phoenix" \
+  --ignore=libs/idun_agent_standalone/tests/unit/test_admin_bootstrap.py \
+  --ignore=libs/idun_agent_standalone/tests/unit/test_reload.py \
+  --ignore=libs/idun_agent_standalone/tests/unit/test_scaffold.py \
+  --ignore=libs/idun_agent_standalone/tests/unit/test_cli.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_app_health.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_integrations_casing.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_structural_change_restart.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_reload_state_correctness.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_auth_bootstrap.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_reload_atomic.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_engine_reload_reattaches_observer.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_reload_flow.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_prompts_wiring.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_bootstrap_hash.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_config_io.py
+```
+Expected: `64 passed` (Phase 1 close-state baseline).
+
+If any baseline check fails, STOP and escalate — Phase 3 does not start on a degraded baseline.
+
+- [ ] **Step 4: Commit this plan**
+
+```bash
+git add docs/superpowers/plans/2026-04-27-rework-phase3.md
+git commit -m "$(cat <<'EOF'
+docs(rework-phase3): add Phase 3 plan
+
+Task-by-task implementation plan for Phase 3 of the standalone admin/db
+rework. Six tasks (pre-flight, T2 helpers, T1 reload pipeline, T3
+retrofit, T4 patterns doc, CI gate, PR). Dispatch order T2 -> T1 -> T3
+-> T4 satisfies dependencies (reload.py imports from runtime_state,
+config_hash; routers import reload.commit_with_reload).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1: Cross-cutting helpers (T2)
+
+**Files:**
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py`
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py`
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py`
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py`
+- Modify: `libs/idun_agent_standalone/pyproject.toml` (add `rfc8785>=0.1`)
+- Create: `libs/idun_agent_standalone/tests/unit/db/test_runtime_state_model.py` (note: file already exists for legacy db tests; create at this path)
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/__init__.py` (register the new ORM)
+- Create: `libs/idun_agent_standalone/tests/unit/services/__init__.py`
+- Create: `libs/idun_agent_standalone/tests/unit/services/test_runtime_state.py`
+- Create: `libs/idun_agent_standalone/tests/unit/services/test_slugs.py`
+- Create: `libs/idun_agent_standalone/tests/unit/services/test_config_hash.py`
+- Create: `libs/idun_agent_standalone/tests/conftest.py` (shared fixtures: `async_session`, `frozen_now`)
+
+**Subagent dispatch model:** standard.
+
+This task ships 4 helpers + 1 ORM + their unit tests + the shared conftest. The four helpers are independent; build in any order, but commit all together to keep the SDD review focused.
+
+### 1.1 Add rfc8785 dependency
+
+- [ ] **Step 1: Update pyproject.toml**
+
+Open `libs/idun_agent_standalone/pyproject.toml` with the Read tool, find the `dependencies = [...]` list, and add `"rfc8785>=0.1"` to it (alphabetically positioned). Exact change depends on existing list shape; the new entry should look like:
+
+```toml
+"rfc8785>=0.1",
+```
+
+After the edit, run:
+```bash
+uv sync --all-groups
+```
+Expected: `rfc8785` resolves and installs.
+
+- [ ] **Step 2: Verify import**
+
+```bash
+uv run python -c "import rfc8785; print(rfc8785.canonicalize({'b': 2, 'a': 1}))"
+```
+Expected output: `b'{"a":1,"b":2}'` (bytes, sorted keys, no whitespace).
+
+### 1.2 Runtime state ORM
+
+- [ ] **Step 3: Create the ORM model**
+
+Write to `libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py`:
+
+```python
+"""SQLAlchemy model for the singleton runtime state row.
+
+Records the last reload outcome (status, message, error, timestamp,
+applied config hash). The boot-path state machine that derives the
+top-level StandaloneRuntimeStatusKind from this row + agent presence
++ engine state is Phase 6's responsibility.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from idun_agent_standalone.infrastructure.db.session import Base
+
+
+class StandaloneRuntimeStateRow(Base):
+    """The singleton runtime state row.
+
+    Uses a fixed primary key (``"singleton"``) because the row is
+    addressed by service helpers, not by id. Absence of the row means
+    no reload has been attempted yet (first boot).
+    """
+
+    __tablename__ = "standalone_runtime_state"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    last_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    last_message: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_reloaded_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_applied_config_hash: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+```
+
+- [ ] **Step 4: Register the new ORM in models/__init__.py**
+
+Read `libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/__init__.py`. It currently has `# noqa: F401` re-exports for `StandaloneAgentRow` and `StandaloneMemoryRow`. Add `StandaloneRuntimeStateRow` to the same pattern.
+
+If the file currently looks like:
+
+```python
+"""Standalone DB models."""
+
+from idun_agent_standalone.infrastructure.db.models.agent import (  # noqa: F401
+    StandaloneAgentRow,
+)
+from idun_agent_standalone.infrastructure.db.models.memory import (  # noqa: F401
+    StandaloneMemoryRow,
+)
+```
+
+Add the new import alphabetically positioned (after memory):
+
+```python
+from idun_agent_standalone.infrastructure.db.models.runtime_state import (  # noqa: F401
+    StandaloneRuntimeStateRow,
+)
+```
+
+Verify the existing pattern by reading the file before editing — the exact existing content may differ.
+
+### 1.3 Conftest
+
+- [ ] **Step 5: Create the shared conftest.py**
+
+Write to `libs/idun_agent_standalone/tests/conftest.py`:
+
+```python
+"""Shared pytest fixtures for the standalone test suite.
+
+Phase 3 introduces async DB session and stub reload fixtures used by
+unit + integration tests. Existing legacy tests are unaffected.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from idun_agent_standalone.infrastructure.db import models  # noqa: F401  registers ORMs on Base
+from idun_agent_standalone.infrastructure.db.session import Base
+
+
+@pytest.fixture
+async def async_session() -> AsyncIterator[AsyncSession]:
+    """An in-memory SQLite async session with all standalone ORMs created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def stub_reload_callable() -> AsyncMock:
+    """An AsyncMock for the engine reload callable; configurable per test."""
+    return AsyncMock(return_value=None)
+
+
+@pytest.fixture
+def frozen_now() -> Callable[[], datetime]:
+    """Fixed datetime so reload outcome timestamps are deterministic in tests."""
+    fixed = datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc)
+    return lambda: fixed
+```
+
+### 1.4 Runtime state service
+
+- [ ] **Step 6: Create the runtime_state service**
+
+Write to `libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py`:
+
+```python
+"""Read/write helpers for the singleton runtime state row.
+
+The reload pipeline calls these helpers to record the outcome of
+every commit_with_reload run. The boot-path state machine (Phase 6)
+reads from the same helpers to compute StandaloneRuntimeStatusKind.
+
+Caller controls transaction boundaries — this module does not
+commit or rollback. The pattern in commit_with_reload is:
+1. rollback the user's failed mutation,
+2. record_reload_outcome(...) writes the failure record,
+3. caller commits the failure record.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from idun_agent_schema.standalone import StandaloneReloadStatus
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from idun_agent_standalone.infrastructure.db.models.runtime_state import (
+    StandaloneRuntimeStateRow,
+)
+
+_SINGLETON_ID = "singleton"
+
+
+async def get(session: AsyncSession) -> StandaloneRuntimeStateRow | None:
+    """Return the singleton state row, or None on first boot."""
+    result = await session.execute(
+        select(StandaloneRuntimeStateRow).where(
+            StandaloneRuntimeStateRow.id == _SINGLETON_ID
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def record_reload_outcome(
+    session: AsyncSession,
+    *,
+    status: StandaloneReloadStatus,
+    message: str,
+    error: str | None,
+    config_hash: str | None,
+    reloaded_at: datetime,
+) -> StandaloneRuntimeStateRow:
+    """Upsert the singleton row with the given outcome.
+
+    Caller controls the transaction boundary; this helper only stages
+    the change via session.flush().
+    """
+    row = await get(session)
+    if row is None:
+        row = StandaloneRuntimeStateRow(id=_SINGLETON_ID)
+        session.add(row)
+    row.last_status = status.value
+    row.last_message = message
+    row.last_error = error
+    row.last_applied_config_hash = config_hash
+    row.last_reloaded_at = reloaded_at
+    await session.flush()
+    return row
+
+
+async def clear(session: AsyncSession) -> None:
+    """Delete the singleton row (test helper)."""
+    row = await get(session)
+    if row is not None:
+        await session.delete(row)
+        await session.flush()
+```
+
+### 1.5 Slugs
+
+- [ ] **Step 7: Create the slugs service**
+
+Write to `libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py`:
+
+```python
+"""Slug normalization + uniqueness for collection resources.
+
+Phase 5 collection routers call these helpers on POST. Singleton
+resources (agent, memory) do not use slugs at the route level.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
+
+_MAX_SLUG_LEN = 64
+_MAX_COLLISION_SUFFIX = 99
+_NON_SLUG_CHAR = re.compile(r"[^a-z0-9]+")
+_DASH_RUN = re.compile(r"-+")
+
+
+class SlugNormalizationError(ValueError):
+    """Raised when a name produces an empty slug after normalization."""
+
+
+class SlugConflictError(Exception):
+    """Raised when ensure_unique_slug exhausts its collision suffixes."""
+
+
+def normalize_slug(name: str) -> str:
+    """Normalize a resource name to a slug per spec.
+
+    Pipeline:
+      trim -> NFKD ascii-fold -> lowercase
+      -> regex sub [^a-z0-9] -> "-"
+      -> collapse runs of "-"
+      -> trim leading/trailing "-"
+      -> truncate to 64 chars
+
+    Raises SlugNormalizationError if the result is empty.
+    """
+    trimmed = name.strip()
+    folded = unicodedata.normalize("NFKD", trimmed)
+    ascii_only = folded.encode("ascii", "ignore").decode("ascii")
+    lowered = ascii_only.lower()
+    dashed = _NON_SLUG_CHAR.sub("-", lowered)
+    collapsed = _DASH_RUN.sub("-", dashed)
+    stripped = collapsed.strip("-")
+    truncated = stripped[:_MAX_SLUG_LEN]
+    if not truncated:
+        raise SlugNormalizationError(
+            f"Cannot derive a slug from name {name!r}"
+        )
+    return truncated
+
+
+async def ensure_unique_slug(
+    session: AsyncSession,
+    model_class: type,
+    slug_column: InstrumentedAttribute,
+    candidate: str,
+) -> str:
+    """Return candidate if unused; else suffix until unique.
+
+    Tries candidate, candidate-2, candidate-3, ... up to candidate-99.
+    Raises SlugConflictError after 99 collisions.
+    """
+    if not await _slug_exists(session, model_class, slug_column, candidate):
+        return candidate
+    for suffix in range(2, _MAX_COLLISION_SUFFIX + 1):
+        candidate_with_suffix = f"{candidate}-{suffix}"
+        if not await _slug_exists(
+            session, model_class, slug_column, candidate_with_suffix
+        ):
+            return candidate_with_suffix
+    raise SlugConflictError(
+        f"Could not find a unique slug for {candidate!r} after "
+        f"{_MAX_COLLISION_SUFFIX} attempts"
+    )
+
+
+async def _slug_exists(
+    session: AsyncSession,
+    model_class: type,
+    slug_column: InstrumentedAttribute,
+    candidate: str,
+) -> bool:
+    result = await session.execute(
+        select(model_class).where(slug_column == candidate).limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+```
+
+### 1.6 Config hash
+
+- [ ] **Step 8: Create the config_hash service**
+
+Write to `libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py`:
+
+```python
+"""Deterministic hash of the materialized EngineConfig.
+
+Used to detect structural changes between reloads (compared against
+StandaloneRuntimeStateRow.last_applied_config_hash) and to surface
+the active config identity in /admin/api/v1/runtime/status.
+
+Implementation: sha256 over the RFC 8785 / JCS canonical JSON
+encoding of the EngineConfig's model_dump(mode="json"). JCS
+guarantees canonical key order so semantically-equal configs
+produce identical hashes.
+"""
+
+from __future__ import annotations
+
+from hashlib import sha256
+
+import rfc8785
+from idun_agent_schema.engine.engine import EngineConfig
+
+
+def compute_config_hash(engine_config: EngineConfig) -> str:
+    """Return a 64-character hex sha256 of the JCS-canonical JSON of the config."""
+    payload = engine_config.model_dump(mode="json")
+    canonical = rfc8785.canonicalize(payload)
+    return sha256(canonical).hexdigest()
+```
+
+### 1.7 Unit tests
+
+- [ ] **Step 9: Create test_runtime_state_model.py**
+
+Write to `libs/idun_agent_standalone/tests/unit/db/test_runtime_state_model.py`:
+
+```python
+"""Tests for StandaloneRuntimeStateRow ORM."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from idun_agent_standalone.infrastructure.db.models.runtime_state import (
+    StandaloneRuntimeStateRow,
+)
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_default_pk_singleton(async_session) -> None:
+    row = StandaloneRuntimeStateRow(id="singleton")
+    async_session.add(row)
+    await async_session.flush()
+    await async_session.refresh(row)
+    assert row.id == "singleton"
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_server_default_updated_at(async_session) -> None:
+    row = StandaloneRuntimeStateRow(id="singleton")
+    async_session.add(row)
+    await async_session.flush()
+    await async_session.refresh(row)
+    assert row.updated_at is not None
+    assert isinstance(row.updated_at, datetime)
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_columns_nullable(async_session) -> None:
+    row = StandaloneRuntimeStateRow(
+        id="singleton",
+        last_status=None,
+        last_message=None,
+        last_error=None,
+        last_applied_config_hash=None,
+        last_reloaded_at=None,
+    )
+    async_session.add(row)
+    await async_session.flush()
+    await async_session.refresh(row)
+    assert row.last_status is None
+    assert row.last_applied_config_hash is None
+```
+
+- [ ] **Step 10: Create test_runtime_state.py service tests**
+
+Write to `libs/idun_agent_standalone/tests/unit/services/test_runtime_state.py`:
+
+```python
+"""Tests for the runtime_state service."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from idun_agent_schema.standalone import StandaloneReloadStatus
+from idun_agent_standalone.services import runtime_state
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_on_empty(async_session) -> None:
+    assert await runtime_state.get(async_session) is None
+
+
+@pytest.mark.asyncio
+async def test_record_then_get(async_session, frozen_now) -> None:
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOADED,
+        message="Saved.",
+        error=None,
+        config_hash="abc123",
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    row = await runtime_state.get(async_session)
+    assert row is not None
+    assert row.last_status == "reloaded"
+    assert row.last_message == "Saved."
+    assert row.last_applied_config_hash == "abc123"
+    assert row.last_reloaded_at == frozen_now()
+
+
+@pytest.mark.asyncio
+async def test_record_overwrites(async_session, frozen_now) -> None:
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOADED,
+        message="First.",
+        error=None,
+        config_hash="hash1",
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOAD_FAILED,
+        message="Second.",
+        error="boom",
+        config_hash=None,
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    row = await runtime_state.get(async_session)
+    assert row.last_status == "reload_failed"
+    assert row.last_message == "Second."
+    assert row.last_error == "boom"
+    assert row.last_applied_config_hash is None
+
+
+@pytest.mark.asyncio
+async def test_record_failure_preserves_distinct_fields(
+    async_session, frozen_now
+) -> None:
+    """The failure path writes status, message, error; it nulls hash."""
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOAD_FAILED,
+        message="Engine reload failed.",
+        error="ImportError: graph module not found",
+        config_hash=None,
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    row = await runtime_state.get(async_session)
+    assert row.last_error == "ImportError: graph module not found"
+    assert row.last_applied_config_hash is None
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_singleton(async_session, frozen_now) -> None:
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOADED,
+        message="Saved.",
+        error=None,
+        config_hash="abc",
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    await runtime_state.clear(async_session)
+    await async_session.commit()
+    assert await runtime_state.get(async_session) is None
+
+
+@pytest.mark.asyncio
+async def test_clear_on_empty_is_noop(async_session) -> None:
+    await runtime_state.clear(async_session)
+    await async_session.commit()
+    assert await runtime_state.get(async_session) is None
+```
+
+- [ ] **Step 11: Create test_slugs.py**
+
+Write to `libs/idun_agent_standalone/tests/unit/services/test_slugs.py`:
+
+```python
+"""Tests for the slugs service."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import Column, String, select
+
+from idun_agent_standalone.infrastructure.db.session import Base
+from idun_agent_standalone.services.slugs import (
+    SlugConflictError,
+    SlugNormalizationError,
+    ensure_unique_slug,
+    normalize_slug,
+)
+
+
+# normalize_slug tests
+
+
+def test_normalize_simple_name() -> None:
+    assert normalize_slug("GitHub Tools") == "github-tools"
+
+
+def test_normalize_strips_special_chars() -> None:
+    assert normalize_slug("Hello, World! @ Idun") == "hello-world-idun"
+
+
+def test_normalize_collapses_runs() -> None:
+    assert normalize_slug("foo--bar---baz") == "foo-bar-baz"
+
+
+def test_normalize_trims_dashes() -> None:
+    assert normalize_slug("---foo---") == "foo"
+
+
+def test_normalize_truncates_to_64_chars() -> None:
+    long_name = "a" * 200
+    result = normalize_slug(long_name)
+    assert len(result) == 64
+    assert result == "a" * 64
+
+
+def test_normalize_unicode_ascii_fold() -> None:
+    assert normalize_slug("Café Münster") == "cafe-munster"
+
+
+def test_normalize_lowercase() -> None:
+    assert normalize_slug("FooBar") == "foobar"
+
+
+def test_normalize_empty_raises() -> None:
+    with pytest.raises(SlugNormalizationError):
+        normalize_slug("")
+
+
+def test_normalize_only_special_raises() -> None:
+    with pytest.raises(SlugNormalizationError):
+        normalize_slug("!!!@@@")
+
+
+def test_normalize_leading_trailing_whitespace() -> None:
+    assert normalize_slug("  github tools  ") == "github-tools"
+
+
+# ensure_unique_slug tests
+# We need a small ORM model to test against.
+
+class _FakeRow(Base):
+    __tablename__ = "_fake_slug_test"
+    id: str = Column(String(36), primary_key=True)  # type: ignore[assignment]
+    slug: str = Column(String(64), nullable=False, unique=True)  # type: ignore[assignment]
+
+
+@pytest.mark.asyncio
+async def test_ensure_unique_no_collision(async_session) -> None:
+    result = await ensure_unique_slug(
+        async_session, _FakeRow, _FakeRow.slug, "fresh"
+    )
+    assert result == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_ensure_unique_one_collision(async_session) -> None:
+    async_session.add(_FakeRow(id="1", slug="github-tools"))
+    await async_session.flush()
+    result = await ensure_unique_slug(
+        async_session, _FakeRow, _FakeRow.slug, "github-tools"
+    )
+    assert result == "github-tools-2"
+
+
+@pytest.mark.asyncio
+async def test_ensure_unique_99_collisions_raises(async_session) -> None:
+    """Defensive upper bound — should be impossible in practice."""
+    async_session.add(_FakeRow(id="0", slug="a"))
+    for n in range(2, 100):
+        async_session.add(_FakeRow(id=str(n), slug=f"a-{n}"))
+    await async_session.flush()
+    with pytest.raises(SlugConflictError):
+        await ensure_unique_slug(async_session, _FakeRow, _FakeRow.slug, "a")
+```
+
+- [ ] **Step 12: Create test_config_hash.py**
+
+Write to `libs/idun_agent_standalone/tests/unit/services/test_config_hash.py`:
+
+```python
+"""Tests for the config_hash service."""
+
+from __future__ import annotations
+
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_standalone.services.config_hash import compute_config_hash
+
+
+def _sample_engine_config() -> EngineConfig:
+    return EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            }
+        }
+    )
+
+
+def test_compute_config_hash_returns_64_char_hex() -> None:
+    digest = compute_config_hash(_sample_engine_config())
+    assert len(digest) == 64
+    int(digest, 16)  # raises if not valid hex
+
+
+def test_compute_config_hash_deterministic() -> None:
+    """Two equal configs must produce identical hashes."""
+    a = compute_config_hash(_sample_engine_config())
+    b = compute_config_hash(_sample_engine_config())
+    assert a == b
+
+
+def test_compute_config_hash_canonicalizes_key_order() -> None:
+    """Configs that differ only in dict key insertion order produce the same hash."""
+    config_a = EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            }
+        }
+    )
+    config_b = EngineConfig.model_validate(
+        {
+            "agent": {
+                "config": {
+                    "graph_definition": "agent.py:graph",
+                    "name": "ada",
+                },
+                "type": "LANGGRAPH",
+            }
+        }
+    )
+    assert compute_config_hash(config_a) == compute_config_hash(config_b)
+
+
+def test_compute_config_hash_distinct_configs_distinct_hashes() -> None:
+    config_a = _sample_engine_config()
+    config_b = EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "different",
+                    "graph_definition": "agent.py:graph",
+                },
+            }
+        }
+    )
+    assert compute_config_hash(config_a) != compute_config_hash(config_b)
+
+
+def test_compute_config_hash_with_empty_optional_fields() -> None:
+    """Optional fields like description/version don't break hashing."""
+    config = EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            },
+        }
+    )
+    digest = compute_config_hash(config)
+    assert len(digest) == 64
+```
+
+### 1.8 Run + commit
+
+- [ ] **Step 13: Run mypy on the new files**
+
+```bash
+uv run mypy --follow-imports=silent \
+  libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py
+```
+Expected: clean.
+
+- [ ] **Step 14: Run lint**
+
+```bash
+make lint
+```
+Expected: clean.
+
+- [ ] **Step 15: Run unit tests**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/db/test_runtime_state_model.py \
+              libs/idun_agent_standalone/tests/unit/services/ -v
+```
+Expected: all tests pass (~26 tests).
+
+- [ ] **Step 16: Commit Task 1**
+
+```bash
+git add libs/idun_agent_standalone/pyproject.toml \
+        libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py \
+        libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/__init__.py \
+        libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py \
+        libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py \
+        libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py \
+        libs/idun_agent_standalone/tests/conftest.py \
+        libs/idun_agent_standalone/tests/unit/db/test_runtime_state_model.py \
+        libs/idun_agent_standalone/tests/unit/services/__init__.py \
+        libs/idun_agent_standalone/tests/unit/services/test_runtime_state.py \
+        libs/idun_agent_standalone/tests/unit/services/test_slugs.py \
+        libs/idun_agent_standalone/tests/unit/services/test_config_hash.py
+
+git commit -m "$(cat <<'EOF'
+feat(rework-phase3): cross-cutting helpers (slugs, config hash, runtime state)
+
+Adds the foundational services every later Phase 3+ module needs:
+
+- infrastructure/db/models/runtime_state.py — singleton ORM with
+  fixed PK "singleton"; columns: last_status, last_message, last_error,
+  last_reloaded_at, last_applied_config_hash, updated_at. Engine-agnostic
+  types per §14 manager mirror rule (String(20)/(64), Text, DateTime).
+
+- services/runtime_state.py — get(), record_reload_outcome(...),
+  clear(). Caller controls transaction boundaries; the helper only
+  stages via session.flush(). Used by the reload pipeline (Task 2)
+  to record outcome after every commit_with_reload run.
+
+- services/slugs.py — normalize_slug() with NFKD ascii-fold + regex
+  pipeline + 64-char truncate; ensure_unique_slug() with up to 99
+  collision suffixes before raising. Used by Phase 5 collection
+  routers on POST.
+
+- services/config_hash.py — compute_config_hash() returns a 64-char
+  hex sha256 of rfc8785-canonicalized EngineConfig.model_dump(mode="json").
+  Determinism guarantee backed by RFC 8785 / JCS.
+
+Adds rfc8785>=0.1 as a runtime dep on the standalone package only
+(not schema lib — config_hash is a runtime concern, not a contract).
+
+Tests use sqlite+aiosqlite memory + Base.metadata.create_all()
+via the new tests/conftest.py shared fixture set (async_session,
+stub_reload_callable, frozen_now).
+
+No Alembic migration ships in this commit — Phase 4 picks up the
+runtime_state ORM in its fresh baseline.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Reload pipeline + 3-round validation (T1)
+
+**Files:**
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py`
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py`
+- Create: `libs/idun_agent_standalone/tests/unit/services/test_validation.py`
+- Create: `libs/idun_agent_standalone/tests/unit/services/test_reload.py`
+
+**Subagent dispatch model:** capable (design-heavy task; algorithm + rollback semantics).
+
+This is the design-heaviest task in Phase 3. The implementer must hold the full pipeline in mind: mutex, staged DB mutation, round 2 validation, structural-change detection, round 3 reload via injected callable, rollback semantics, runtime_state recording on success and failure.
+
+The algorithm is locked in design doc §4.6.1. Pseudocode reproduced below.
+
+### 2.1 Validation service
+
+- [ ] **Step 1: Create services/validation.py**
+
+Write to `libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py`:
+
+```python
+"""Round 2 validation: re-validate the assembled EngineConfig.
+
+Phase 1's assemble_engine_config returns a typed EngineConfig instance,
+but cross-resource invalid combinations (e.g. LANGGRAPH framework with
+ADK SessionServiceConfig memory) are only caught when the assembled
+config is re-validated. This module is the round 2 of the 3-round
+pipeline; round 1 is FastAPI's body validation, round 3 is the engine
+reload.
+"""
+
+from __future__ import annotations
+
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_schema.standalone import StandaloneFieldError
+from pydantic import ValidationError
+
+from idun_agent_standalone.api.v1.errors import (
+    field_errors_from_validation_error,
+)
+
+
+class RoundTwoValidationFailed(Exception):
+    """Raised when the assembled EngineConfig fails Pydantic validation.
+
+    Wraps the original Pydantic ValidationError and exposes structured
+    field_errors so the pipeline can build a 422 admin envelope without
+    re-translating.
+    """
+
+    field_errors: list[StandaloneFieldError]
+
+    def __init__(self, validation_error: ValidationError) -> None:
+        self.field_errors = field_errors_from_validation_error(validation_error)
+        super().__init__("Assembled EngineConfig failed validation.")
+
+
+def validate_assembled_config(engine_config: EngineConfig) -> None:
+    """Run Pydantic validation on the assembled EngineConfig.
+
+    Raises RoundTwoValidationFailed on failure.
+    """
+    try:
+        EngineConfig.model_validate(engine_config.model_dump())
+    except ValidationError as exc:
+        raise RoundTwoValidationFailed(exc) from exc
+```
+
+### 2.2 Reload pipeline
+
+- [ ] **Step 2: Create services/reload.py**
+
+Write to `libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py`:
+
+```python
+"""The 3-round reload pipeline.
+
+Single in-process asyncio.Lock around commit_with_reload. The caller
+acquires the lock, stages a DB mutation, calls flush, then invokes
+commit_with_reload. The pipeline:
+  1. Assembles EngineConfig from staged session state.
+  2. Round 2: validates the assembled config (services.validation).
+  3. Detects structural change vs prior runtime_state.
+  4. If structural: commits DB, records outcome, returns restart_required.
+     The reload_callable is NOT invoked.
+  5. Else: round 3 invokes reload_callable.
+     - On success: commits DB, records outcome, returns reloaded.
+     - On ReloadInitFailed: rolls back DB, records failure outcome
+       (in a fresh session-level write), commits the outcome,
+       raises AdminAPIError(500, code=reload_failed).
+
+Round 1 (Pydantic body validation) is FastAPI's responsibility and
+happens before the handler runs.
+
+The reload_callable is dependency-injected so tests stub a fake
+without booting a real engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from hashlib import sha256
+
+import rfc8785
+from fastapi import status as http_status
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_schema.standalone import (
+    StandaloneAdminError,
+    StandaloneErrorCode,
+    StandaloneReloadResult,
+    StandaloneReloadStatus,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from idun_agent_standalone.api.v1.errors import AdminAPIError
+from idun_agent_standalone.core.logging import get_logger
+from idun_agent_standalone.services import runtime_state
+from idun_agent_standalone.services.config_hash import compute_config_hash
+from idun_agent_standalone.services.engine_config import assemble_engine_config
+from idun_agent_standalone.services.validation import (
+    RoundTwoValidationFailed,
+    validate_assembled_config,
+)
+
+logger = get_logger(__name__)
+
+
+_reload_mutex = asyncio.Lock()
+
+
+class ReloadInitFailed(Exception):
+    """Raised when round 3 (engine reload via reload_callable) fails."""
+
+
+def _default_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _structural_slice(engine_config: EngineConfig) -> dict[str, object]:
+    """Return the structural fields that require process restart on change.
+
+    Per spec §"Save/reload posture" + legacy reload.py:
+      - agent.framework
+      - agent.config.graph_definition (LangGraph entry point)
+
+    Other fields (agent name, description, version, base_url, memory
+    config beyond framework, integrations, MCP servers, etc.) are hot-
+    reloadable and do NOT require restart.
+    """
+    return {
+        "framework": engine_config.agent.type.value,
+        "graph_definition": getattr(
+            engine_config.agent.config, "graph_definition", None
+        ),
+    }
+
+
+def _structural_hash(engine_config: EngineConfig) -> str:
+    """Hash only the structural slice, distinct from the full config hash."""
+    canonical = rfc8785.canonicalize(_structural_slice(engine_config))
+    return sha256(canonical).hexdigest()
+
+
+def _is_structural_change(
+    assembled: EngineConfig, prior_state
+) -> bool:
+    """True iff structural fields changed since the last applied config.
+
+    On first boot (prior_state is None or last_applied_config_hash is
+    None), returns False — the first config is never structural.
+
+    Compares structural-slice hashes rather than re-fetching the prior
+    full config (which would require keeping the prior config around).
+    """
+    if prior_state is None or prior_state.last_applied_config_hash is None:
+        return False
+    # Recompute prior structural hash from the stored full hash is not
+    # possible without the prior config. Instead, we recompute the
+    # structural hash whenever we record an outcome and store it.
+    # For Phase 3, structural-change detection compares the prior FULL
+    # config hash against the current one; if they differ AND the
+    # structural slice differs, we consider it structural. Since we
+    # only persist the full hash, we approximate: any change is
+    # potentially structural unless the structural fields match a
+    # known-stable set. For LangGraph, framework is fixed at boot
+    # (cannot change without restart) so a framework change means a
+    # structural change definitionally. For graph_definition, a path
+    # change requires reimporting the module, which is structural.
+    #
+    # The simpler approach: compute the current structural hash and
+    # compare against the prior config's full hash bytes — if the
+    # structural fields are encoded in the full hash and they are the
+    # only fields that could trigger structural, any difference in
+    # full hash + difference in structural slice means structural.
+    #
+    # Implementation note: we store BOTH the full config hash and the
+    # structural slice hash. On record_reload_outcome we pass both;
+    # the runtime_state row only carries last_applied_config_hash
+    # (the full one). The structural comparison then does:
+    #   prior structural slice unknown -> conservative: treat as
+    #   structural if framework/graph_definition match this assembled.
+    #
+    # SIMPLIFIED ALGORITHM (Phase 3):
+    #   We persist last_applied_config_hash (full).
+    #   On compare, we re-derive structural slice from THIS assembled
+    #   and compute its hash. We then need the prior structural slice
+    #   to compare. We don't have it.
+    #
+    # Resolution: we store the structural slice hash in the same
+    # last_applied_config_hash column for Phase 3 — purpose-built. The
+    # full config hash is a Phase 6 deliverable for /runtime/status.
+    # This keeps the column single-purpose for Phase 3.
+    current_structural = _structural_hash(assembled)
+    return prior_state.last_applied_config_hash != current_structural
+
+
+async def commit_with_reload(
+    session: AsyncSession,
+    *,
+    reload_callable: Callable[[EngineConfig], Awaitable[None]],
+    now: Callable[[], datetime] = _default_now,
+) -> StandaloneReloadResult:
+    """Run the 3-round pipeline.
+
+    Caller must:
+      - acquire _reload_mutex via `async with _reload_mutex:`
+      - stage DB mutation (e.g. add/modify ORM rows)
+      - call session.flush()
+
+    On round 2 failure: rolls back, raises 422 AdminAPIError.
+    On structural change: commits DB, records outcome, returns restart_required.
+    On round 3 failure: rolls back, records failure outcome, raises 500 AdminAPIError.
+    On full success: commits DB, records outcome, returns reloaded.
+    """
+    assembled = await assemble_engine_config(session)
+
+    try:
+        validate_assembled_config(assembled)
+    except RoundTwoValidationFailed as exc:
+        await session.rollback()
+        logger.info(
+            "reload.round2_failed field_count=%s", len(exc.field_errors)
+        )
+        raise AdminAPIError(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            error=StandaloneAdminError(
+                code=StandaloneErrorCode.VALIDATION_FAILED,
+                message="Assembled config failed validation.",
+                field_errors=exc.field_errors,
+            ),
+        ) from exc
+
+    structural_hash = _structural_hash(assembled)
+    prior = await runtime_state.get(session)
+    structural = _is_structural_change(assembled, prior)
+
+    if structural:
+        await session.commit()
+        await runtime_state.record_reload_outcome(
+            session,
+            status=StandaloneReloadStatus.RESTART_REQUIRED,
+            message="Saved. Restart required to apply.",
+            error=None,
+            config_hash=structural_hash,
+            reloaded_at=now(),
+        )
+        await session.commit()
+        logger.info("reload.restart_required hash=%s", structural_hash[:8])
+        return StandaloneReloadResult(
+            status=StandaloneReloadStatus.RESTART_REQUIRED,
+            message="Saved. Restart required to apply.",
+        )
+
+    try:
+        await reload_callable(assembled)
+    except ReloadInitFailed as exc:
+        await session.rollback()
+        await runtime_state.record_reload_outcome(
+            session,
+            status=StandaloneReloadStatus.RELOAD_FAILED,
+            message="Engine reload failed; config not saved.",
+            error=str(exc),
+            config_hash=None,
+            reloaded_at=now(),
+        )
+        await session.commit()
+        logger.warning("reload.round3_failed error=%s", str(exc)[:120])
+        raise AdminAPIError(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            error=StandaloneAdminError(
+                code=StandaloneErrorCode.RELOAD_FAILED,
+                message="Engine reload failed; config not saved.",
+                details={"recovered": True},
+            ),
+        ) from exc
+
+    await session.commit()
+    await runtime_state.record_reload_outcome(
+        session,
+        status=StandaloneReloadStatus.RELOADED,
+        message="Saved and reloaded.",
+        error=None,
+        config_hash=structural_hash,
+        reloaded_at=now(),
+    )
+    await session.commit()
+    logger.info("reload.reloaded hash=%s", structural_hash[:8])
+    return StandaloneReloadResult(
+        status=StandaloneReloadStatus.RELOADED,
+        message="Saved and reloaded.",
+    )
+```
+
+**Note on the structural-hash storage decision (line ~50–95 of the file):** The `last_applied_config_hash` column on `standalone_runtime_state` stores the **structural-slice** hash (not the full config hash) for Phase 3. This makes structural-change detection a single column comparison without needing to keep the prior full config in memory. Phase 6's `/runtime/status` endpoint will display the full config hash as a separate concept (computed on-demand from the active assembled config). The column name stays — the value semantics evolve. Document this in the implementer's commit message.
+
+### 2.3 Validation tests
+
+- [ ] **Step 3: Create test_validation.py**
+
+Write to `libs/idun_agent_standalone/tests/unit/services/test_validation.py`:
+
+```python
+"""Tests for the validation service (round 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_standalone.services.validation import (
+    RoundTwoValidationFailed,
+    validate_assembled_config,
+)
+
+
+def _valid_langgraph_config() -> EngineConfig:
+    return EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            }
+        }
+    )
+
+
+def test_valid_config_passes() -> None:
+    config = _valid_langgraph_config()
+    validate_assembled_config(config)  # must not raise
+
+
+def test_round_two_validation_failed_wraps_validation_error() -> None:
+    """Manually construct an invalid EngineConfig dump and pass through.
+
+    We can't easily construct an invalid EngineConfig instance directly
+    (Pydantic rejects it on construction), so we round-trip through
+    model_dump and manually corrupt the dump before re-validating.
+    """
+    config = _valid_langgraph_config()
+    dumped = config.model_dump()
+    # Corrupt: set agent.config to an invalid shape for LANGGRAPH
+    dumped["agent"]["config"] = {"name": "ada"}  # missing graph_definition
+
+    # validate_assembled_config takes an EngineConfig, but the test
+    # exercises the round-2 contract: any structural mismatch in the
+    # dumped form fails. We reconstruct via model_validate to surface
+    # this; the resulting RoundTwoValidationFailed carries field_errors.
+    with pytest.raises(RoundTwoValidationFailed) as exc_info:
+        from idun_agent_standalone.services.validation import (
+            validate_assembled_config as _impl,
+        )
+        # Bypass: construct a fake EngineConfig-like with model_dump
+        # returning the corrupt dict.
+        class _FakeConfig:
+            def model_dump(self) -> dict:
+                return dumped
+
+        _impl(_FakeConfig())  # type: ignore[arg-type]
+    assert len(exc_info.value.field_errors) >= 1
+
+
+def test_field_errors_carry_structured_codes() -> None:
+    """RoundTwoValidationFailed.field_errors contains structured entries."""
+    config = _valid_langgraph_config()
+    dumped = config.model_dump()
+    dumped["agent"]["config"] = {"name": "ada"}
+
+    class _FakeConfig:
+        def model_dump(self) -> dict:
+            return dumped
+
+    with pytest.raises(RoundTwoValidationFailed) as exc_info:
+        validate_assembled_config(_FakeConfig())  # type: ignore[arg-type]
+    fe = exc_info.value.field_errors[0]
+    assert fe.field
+    assert fe.message
+```
+
+### 2.4 Reload pipeline tests
+
+- [ ] **Step 4: Create test_reload.py — happy path**
+
+Write to `libs/idun_agent_standalone/tests/unit/services/test_reload.py`:
+
+```python
+"""Tests for the reload pipeline service.
+
+Tests use sqlite+aiosqlite memory DB with the standalone agent +
+memory + runtime_state ORMs. The reload_callable is stubbed via
+AsyncMock; the now callable is frozen for deterministic timestamps.
+
+Note: assemble_engine_config requires an agent row (and optionally
+memory) to be present in the staged session state. Each test seeds
+the necessary rows before calling commit_with_reload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_schema.standalone import (
+    StandaloneErrorCode,
+    StandaloneReloadStatus,
+)
+from idun_agent_standalone.api.v1.errors import AdminAPIError
+from idun_agent_standalone.infrastructure.db.models.agent import (
+    StandaloneAgentRow,
+)
+from idun_agent_standalone.services import runtime_state
+from idun_agent_standalone.services.reload import (
+    ReloadInitFailed,
+    _reload_mutex,
+    commit_with_reload,
+)
+
+
+def _seed_engine_config_dict() -> dict:
+    return {
+        "server": {"api": {"port": 8000}},
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "ada",
+                "graph_definition": "agent.py:graph",
+            },
+        },
+    }
+
+
+async def _seed_agent(async_session, *, name: str = "Ada") -> StandaloneAgentRow:
+    row = StandaloneAgentRow(
+        name=name,
+        base_engine_config=_seed_engine_config_dict(),
+    )
+    async_session.add(row)
+    await async_session.flush()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_reloaded(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    await _seed_agent(async_session)
+    result = await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    assert result.status == StandaloneReloadStatus.RELOADED
+    stub_reload_callable.assert_called_once()
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_status == "reloaded"
+    assert state.last_reloaded_at == frozen_now()
+
+
+@pytest.mark.asyncio
+async def test_round_2_failure_rolls_back_and_raises_422(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    """Stage an invalid agent row; round 2 must reject it."""
+    # Bypass Phase 1 base_engine_config validation by injecting a
+    # malformed dict directly. The assemble step rebuilds an
+    # EngineConfig that Pydantic re-validates in round 2.
+    row = StandaloneAgentRow(
+        name="bad",
+        base_engine_config={
+            "agent": {"type": "LANGGRAPH", "config": {"name": "x"}}
+        },  # missing graph_definition
+    )
+    async_session.add(row)
+    await async_session.flush()
+
+    with pytest.raises(AdminAPIError) as exc_info:
+        await commit_with_reload(
+            async_session,
+            reload_callable=stub_reload_callable,
+            now=frozen_now,
+        )
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.error.code == StandaloneErrorCode.VALIDATION_FAILED
+    stub_reload_callable.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_round_3_failure_rolls_back_and_records_failure(
+    async_session, frozen_now
+) -> None:
+    """Reload callable raises ReloadInitFailed; pipeline rolls back DB
+    but still records the failure outcome to runtime_state."""
+    await _seed_agent(async_session)
+    failing_reload = AsyncMock(side_effect=ReloadInitFailed("engine boom"))
+
+    with pytest.raises(AdminAPIError) as exc_info:
+        await commit_with_reload(
+            async_session,
+            reload_callable=failing_reload,
+            now=frozen_now,
+        )
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.error.code == StandaloneErrorCode.RELOAD_FAILED
+
+    # Failure record must exist
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_status == "reload_failed"
+    assert state.last_error == "engine boom"
+    assert state.last_applied_config_hash is None
+
+
+@pytest.mark.asyncio
+async def test_structural_change_returns_restart_required(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    """First reload sets a baseline; second reload with a different
+    structural slice (graph_definition path) returns restart_required."""
+    await _seed_agent(async_session)
+    first = await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    assert first.status == StandaloneReloadStatus.RELOADED
+
+    # Mutate graph_definition (structural)
+    agent = (await async_session.execute(
+        __import__("sqlalchemy").select(StandaloneAgentRow)
+    )).scalar_one()
+    agent.base_engine_config = {
+        "server": {"api": {"port": 8000}},
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "ada",
+                "graph_definition": "agent.py:other_graph",
+            },
+        },
+    }
+    await async_session.flush()
+
+    second = await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    assert second.status == StandaloneReloadStatus.RESTART_REQUIRED
+    assert stub_reload_callable.call_count == 1  # NOT called for structural
+
+
+@pytest.mark.asyncio
+async def test_first_reload_is_not_structural(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    """No prior runtime_state -> first config is never structural."""
+    await _seed_agent(async_session)
+    result = await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    assert result.status == StandaloneReloadStatus.RELOADED
+
+
+@pytest.mark.asyncio
+async def test_reload_callable_dependency_injected(
+    async_session, frozen_now
+) -> None:
+    """The reload callable can be replaced; tests don't need a real engine."""
+    await _seed_agent(async_session)
+    custom_calls = []
+
+    async def custom_reload(config: EngineConfig) -> None:
+        custom_calls.append(config)
+
+    await commit_with_reload(
+        async_session,
+        reload_callable=custom_reload,
+        now=frozen_now,
+    )
+    assert len(custom_calls) == 1
+    assert isinstance(custom_calls[0], EngineConfig)
+
+
+@pytest.mark.asyncio
+async def test_now_dependency_injected(
+    async_session, stub_reload_callable
+) -> None:
+    fixed = datetime(2027, 1, 1, tzinfo=timezone.utc)
+    await _seed_agent(async_session)
+    await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=lambda: fixed,
+    )
+    state = await runtime_state.get(async_session)
+    assert state.last_reloaded_at == fixed
+
+
+@pytest.mark.asyncio
+async def test_mutex_serializes_concurrent_acquires() -> None:
+    """Two coroutines acquiring the mutex serialize.
+
+    Direct test of the mutex itself, without the full pipeline.
+    """
+    held: list[str] = []
+
+    async def acquire_then_release(label: str) -> None:
+        async with _reload_mutex:
+            held.append(f"start:{label}")
+            await asyncio.sleep(0)  # yield
+            held.append(f"end:{label}")
+
+    await asyncio.gather(
+        acquire_then_release("A"),
+        acquire_then_release("B"),
+    )
+    # Either A fully then B fully, or B fully then A fully — never interleaved
+    pairs = list(zip(held[0::2], held[1::2]))
+    for start, end in pairs:
+        assert start.replace("start:", "") == end.replace("end:", "")
+
+
+@pytest.mark.asyncio
+async def test_hash_propagated_to_runtime_state_on_success(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    await _seed_agent(async_session)
+    await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    state = await runtime_state.get(async_session)
+    assert state.last_applied_config_hash is not None
+    assert len(state.last_applied_config_hash) == 64
+
+
+@pytest.mark.asyncio
+async def test_hash_not_propagated_on_failure(
+    async_session, frozen_now
+) -> None:
+    await _seed_agent(async_session)
+    failing_reload = AsyncMock(side_effect=ReloadInitFailed("engine boom"))
+    with pytest.raises(AdminAPIError):
+        await commit_with_reload(
+            async_session,
+            reload_callable=failing_reload,
+            now=frozen_now,
+        )
+    state = await runtime_state.get(async_session)
+    assert state.last_applied_config_hash is None
+```
+
+### 2.5 Run + commit
+
+- [ ] **Step 5: Run mypy on the new files**
+
+```bash
+uv run mypy --follow-imports=silent \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py
+```
+Expected: clean.
+
+- [ ] **Step 6: Run lint**
+
+```bash
+make lint
+```
+Expected: clean.
+
+- [ ] **Step 7: Run unit tests**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_validation.py \
+              libs/idun_agent_standalone/tests/unit/services/test_reload.py -v
+```
+Expected: all tests pass (~12 tests).
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py \
+        libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py \
+        libs/idun_agent_standalone/tests/unit/services/test_validation.py \
+        libs/idun_agent_standalone/tests/unit/services/test_reload.py
+
+git commit -m "$(cat <<'EOF'
+feat(rework-phase3): reload pipeline + 3-round validation
+
+Implements the core plumbing every later resource will use:
+
+- services/validation.py — RoundTwoValidationFailed wraps a Pydantic
+  ValidationError into structured StandaloneFieldError list, ready for
+  the 422 admin envelope. validate_assembled_config(EngineConfig) is
+  the round-2 entry point.
+
+- services/reload.py — module-level _reload_mutex (asyncio.Lock);
+  commit_with_reload(session, *, reload_callable, now) orchestrates
+  the 3-round pipeline:
+    Round 2: validate_assembled_config -> 422 + DB rollback on fail
+    Detect structural change vs prior runtime_state
+    If structural: commit DB + record outcome + return restart_required
+    Else round 3: reload_callable -> 500 + DB rollback + failure
+                  outcome on ReloadInitFailed; on success commit DB +
+                  record outcome + return reloaded.
+  Round 1 is FastAPI body validation (handled by the framework).
+
+Structural-change detection uses sha256 of the rfc8785-canonicalized
+"structural slice" (agent.framework + agent.config.graph_definition).
+The runtime_state row's last_applied_config_hash column carries the
+structural-slice hash for Phase 3 comparison purposes; the full config
+hash for /runtime/status is computed on-demand in Phase 6.
+
+Reload callable is dependency-injected so tests use AsyncMock without
+booting a real engine. The "now" callable is also injectable for
+deterministic timestamps in tests.
+
+The rollback-then-record-then-commit pattern on round 3 failure: the
+user's mutation rolls back, then runtime_state.record_reload_outcome
+writes the failure record, then a fresh commit persists the failure
+record. SQLite + Postgres both support this two-transaction pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Retrofit agent + memory routers (T3)
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/agent.py`
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/memory.py`
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/deps.py` (add `ReloadCallableDep`)
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/app.py` (wire engine reload callable)
+- Create: `libs/idun_agent_standalone/tests/integration/__init__.py` (if missing)
+- Create: `libs/idun_agent_standalone/tests/integration/api/__init__.py`
+- Create: `libs/idun_agent_standalone/tests/integration/api/v1/__init__.py`
+- Create: `libs/idun_agent_standalone/tests/integration/api/v1/test_agent_flow.py`
+- Create: `libs/idun_agent_standalone/tests/integration/api/v1/test_memory_flow.py`
+
+**Subagent dispatch model:** standard.
+
+This task removes the stub reload constants from the routers, wraps mutating handlers in the mutex, and wires the engine reload callable into FastAPI.
+
+### 3.1 Engine reload investigation
+
+- [ ] **Step 1: Read the engine's reconfigure interface**
+
+Open these files with the Read tool:
+- `libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py`
+- `libs/idun_agent_engine/src/idun_agent_engine/server/engine_app.py` (if exists)
+- The current commit `2e63e234 feat(standalone): wire admin layer onto engine fastapi app` — `git show 2e63e234 --stat` to see what files it touched, then read them.
+
+Identify how the engine app accepts a new EngineConfig at runtime. Three possibilities:
+- (a) The engine exposes a public `reconfigure(EngineConfig)` async method on the engine app instance.
+- (b) The engine exposes a "rebuild app + swap" pattern via `lifespan.py` or similar.
+- (c) Neither — the engine has only startup-time configuration.
+
+Capture the interface in your session log. The implementation in Step 4 below adapts to whichever exists.
+
+If case (c), the implementer **must escalate to the user** before proceeding. Implementing a reload-from-scratch interface inside `idun_agent_engine` is out of Phase 3 scope.
+
+### 3.2 ReloadCallableDep dependency
+
+- [ ] **Step 2: Add ReloadCallableDep to api/v1/deps.py**
+
+Read `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/deps.py`. It currently exposes `SessionDep`. Add:
+
+```python
+from collections.abc import Awaitable, Callable
+from typing import Annotated
+
+from fastapi import Depends, Request
+from idun_agent_schema.engine.engine import EngineConfig
+
+
+async def get_reload_callable(
+    request: Request,
+) -> Callable[[EngineConfig], Awaitable[None]]:
+    """Return the engine reload callable, attached to app.state at startup.
+
+    The callable accepts the materialized EngineConfig and applies it
+    to the running engine. Raises ReloadInitFailed (from
+    idun_agent_standalone.services.reload) on failure.
+    """
+    callable_ = getattr(request.app.state, "reload_callable", None)
+    if callable_ is None:
+        raise RuntimeError(
+            "reload_callable not attached to app.state — "
+            "check app.py startup wiring"
+        )
+    return callable_
+
+
+ReloadCallableDep = Annotated[
+    Callable[[EngineConfig], Awaitable[None]],
+    Depends(get_reload_callable),
+]
+```
+
+The exact import block additions depend on the existing file shape. Read first, edit incrementally.
+
+### 3.3 app.py wiring
+
+- [ ] **Step 3: Wire the engine reload callable on app startup**
+
+Read `libs/idun_agent_standalone/src/idun_agent_standalone/app.py`. The exact wiring depends on the engine's reconfigure interface from Step 1.
+
+**If the engine exposes a reconfigure(config) method on the engine app (case a):**
+
+```python
+from collections.abc import Awaitable, Callable
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_standalone.services.reload import ReloadInitFailed
+
+
+async def _build_reload_callable(
+    engine_app,
+) -> Callable[[EngineConfig], Awaitable[None]]:
+    async def _reload(config: EngineConfig) -> None:
+        try:
+            await engine_app.reconfigure(config)
+        except Exception as exc:
+            raise ReloadInitFailed(str(exc)) from exc
+    return _reload
+
+
+# In create_standalone_app or equivalent factory, after the engine app
+# is created and the admin routes are mounted:
+app.state.reload_callable = await _build_reload_callable(engine_app)
+```
+
+**If the engine uses a rebuild-and-swap pattern (case b):** borrow the technique from the legacy `reload.py` (without importing legacy). The implementer reads the legacy code at `libs/idun_agent_standalone/src/idun_agent_standalone/reload.py` for reference, then re-implements equivalently inside `app.py` or a new `services/engine_reload.py` helper. The `_reload` callable wraps the rebuild + swap and translates exceptions to `ReloadInitFailed`.
+
+The implementer's commit body must capture which case applied (a/b) and where the wiring lives.
+
+### 3.4 Retrofit agent.py
+
+- [ ] **Step 4: Replace stub reload with real pipeline in agent.py**
+
+Read `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/agent.py` to confirm current shape. The post-Phase-1 file (with Phase 1 fixes from commit `8938f41f` applied) has the `_SAVED_RELOAD` and `_NOOP_RELOAD` stub constants. Replace as follows:
+
+Remove the `_SAVED_RELOAD` constant and the imports:
+```python
+from idun_agent_schema.standalone import (
+    StandaloneReloadResult,
+    StandaloneReloadStatus,
+)
+```
+
+Add new imports:
+```python
+from idun_agent_standalone.api.v1.deps import ReloadCallableDep, SessionDep
+from idun_agent_standalone.services.reload import _reload_mutex, commit_with_reload
+```
+
+Keep `_NOOP_RELOAD`:
+```python
+_NOOP_RELOAD = StandaloneReloadResult(
+    status=StandaloneReloadStatus.RELOADED,
+    message="No changes.",
+)
+```
+(Update the `from idun_agent_schema.standalone import` block to keep just the types still used: `StandaloneAdminError`, `StandaloneAgentPatch`, `StandaloneAgentRead`, `StandaloneErrorCode`, `StandaloneMutationResponse`, `StandaloneReloadResult`, `StandaloneReloadStatus`.)
+
+Replace `patch_agent` with:
+
+```python
+@router.patch("", response_model=StandaloneMutationResponse[StandaloneAgentRead])
+async def patch_agent(
+    body: StandaloneAgentPatch,
+    session: SessionDep,
+    reload_callable: ReloadCallableDep,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    """Update metadata fields on the singleton agent.
+
+    Empty body short-circuits with no DB write and no reload. Any
+    non-empty mutation flows through the 3-round reload pipeline.
+    """
+    fields = body.model_fields_set
+    row = await _load_agent(session)
+
+    if not fields:
+        logger.debug("admin.agent.patch noop id=%s", row.id)
+        return StandaloneMutationResponse(
+            data=StandaloneAgentRead.model_validate(row),
+            reload=_NOOP_RELOAD,
+        )
+
+    async with _reload_mutex:
+        for field in fields:
+            setattr(row, field, getattr(body, field))
+        await session.flush()
+        result = await commit_with_reload(
+            session, reload_callable=reload_callable
+        )
+        await session.refresh(row)
+
+    logger.info(
+        "admin.agent.patch id=%s name=%s fields=%s status=%s",
+        row.id,
+        row.name,
+        sorted(fields),
+        result.status.value,
+    )
+
+    return StandaloneMutationResponse(
+        data=StandaloneAgentRead.model_validate(row),
+        reload=result,
+    )
+```
+
+The `get_agent` handler is unchanged.
+
+### 3.5 Retrofit memory.py
+
+- [ ] **Step 5: Replace stubs in memory.py**
+
+Read `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/memory.py`. Memory has more handlers than agent: GET, PATCH, DELETE.
+
+The pattern is the same. Replace `_SAVED_RELOAD` and `_DELETE_RELOAD` constants with calls to `commit_with_reload`. Keep `_NOOP_RELOAD` for empty PATCH.
+
+For PATCH:
+```python
+@router.patch("", response_model=StandaloneMutationResponse[StandaloneMemoryRead])
+async def patch_memory(
+    body: StandaloneMemoryPatch,
+    session: SessionDep,
+    reload_callable: ReloadCallableDep,
+) -> StandaloneMutationResponse[StandaloneMemoryRead]:
+    fields = body.model_fields_set
+    row = await _load_row(session)
+
+    if row is None:
+        # First-write path — keep the existing missing-fields check
+        # (preserves the 422 + first-write-required-fields contract
+        # from Phase 1).
+        creating = True
+        missing: list[str] = []
+        if "agent_framework" not in fields or body.agent_framework is None:
+            missing.append("agentFramework")
+        if "memory" not in fields or body.memory is None:
+            missing.append("memory")
+        if missing:
+            raise AdminAPIError(
+                status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+                error=StandaloneAdminError(
+                    code=StandaloneErrorCode.VALIDATION_FAILED,
+                    message="First write requires agentFramework and memory.",
+                    field_errors=[
+                        StandaloneFieldError(
+                            field=name,
+                            message="Required for first write.",
+                            code="missing",
+                        )
+                        for name in missing
+                    ],
+                ),
+            )
+        row = StandaloneMemoryRow(
+            id=_SINGLETON_ID,
+            agent_framework=body.agent_framework.value,  # type: ignore[union-attr]
+            memory_config=body.memory.model_dump(exclude_none=True),  # type: ignore[union-attr]
+        )
+        session.add(row)
+    else:
+        creating = False
+        if not fields:
+            logger.debug("admin.memory.patch noop")
+            return StandaloneMutationResponse(
+                data=_to_read(row), reload=_NOOP_RELOAD
+            )
+        if "agent_framework" in fields and body.agent_framework is not None:
+            row.agent_framework = body.agent_framework.value
+        if "memory" in fields and body.memory is not None:
+            row.memory_config = body.memory.model_dump(exclude_none=True)
+
+    async with _reload_mutex:
+        await session.flush()
+        result = await commit_with_reload(
+            session, reload_callable=reload_callable
+        )
+        await session.refresh(row)
+
+    logger.info(
+        "admin.memory.patch creating=%s framework=%s status=%s",
+        creating,
+        row.agent_framework,
+        result.status.value,
+    )
+
+    return StandaloneMutationResponse(data=_to_read(row), reload=result)
+```
+
+For DELETE, similar treatment: stage the deletion via `await session.delete(row)` and `session.flush()`, then `commit_with_reload`. The DELETE response wraps `StandaloneSingletonDeleteResult(deleted=True)` per Phase 2 schema.
+
+Note: the existing memory PATCH handler already calls `assemble_engine_config` directly to perform an early validation. The new `commit_with_reload` does this too. **Remove the early call** — the pipeline does it once, atomically with the rollback path. The `try/except AssemblyError` block in the existing handler is also removed.
+
+### 3.6 Integration tests — agent_flow
+
+- [ ] **Step 6: Create test_agent_flow.py**
+
+Write to `libs/idun_agent_standalone/tests/integration/api/v1/test_agent_flow.py`:
+
+```python
+"""Integration tests for /admin/api/v1/agent against the real reload pipeline.
+
+Drives the FastAPI router through HTTPX with an injected stub reload
+callable; round 2 + round 3 + structural change all exercise the
+mutex + outcome recording path end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# These integration tests rely on a small standalone test app that
+# wires the router with a stub reload callable. The implementer
+# adds this fixture below or in tests/conftest.py.
+
+from idun_agent_standalone.services import runtime_state
+from idun_agent_standalone.services.reload import ReloadInitFailed
+
+
+@pytest.fixture
+async def admin_app(async_session, stub_reload_callable):
+    """A minimal FastAPI app with the agent router mounted, the stub
+    reload callable attached to app.state, and the SessionDep override
+    pointing at the in-memory async_session fixture."""
+    from fastapi import FastAPI
+    from idun_agent_standalone.api.v1.deps import (
+        get_reload_callable,
+        get_session,
+    )
+    from idun_agent_standalone.api.v1.errors import (
+        register_admin_exception_handlers,
+    )
+    from idun_agent_standalone.api.v1.routers.agent import router as agent_router
+
+    app = FastAPI()
+    register_admin_exception_handlers(app)
+    app.include_router(agent_router)
+    app.state.reload_callable = stub_reload_callable
+
+    async def override_session():
+        yield async_session
+
+    async def override_reload_callable():
+        return stub_reload_callable
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_reload_callable] = override_reload_callable
+
+    return app
+
+
+async def _seed_agent(async_session) -> None:
+    from idun_agent_standalone.infrastructure.db.models.agent import (
+        StandaloneAgentRow,
+    )
+
+    row = StandaloneAgentRow(
+        name="Ada",
+        base_engine_config={
+            "server": {"api": {"port": 8000}},
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            },
+        },
+    )
+    async_session.add(row)
+    await async_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_get_agent_returns_row(admin_app, async_session) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/agent")
+    assert response.status_code == 200
+    assert response.json()["name"] == "Ada"
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_happy_path(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/agent",
+            json={"name": "Renamed"},
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["name"] == "Renamed"
+    assert body["reload"]["status"] == "reloaded"
+    stub_reload_callable.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_patch_empty_body_is_noop(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch("/admin/api/v1/agent", json={})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["reload"]["status"] == "reloaded"
+    assert body["reload"]["message"] == "No changes."
+    stub_reload_callable.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_patch_round_3_failure_returns_500(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent(async_session)
+    stub_reload_callable.side_effect = ReloadInitFailed("engine boom")
+
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/agent",
+            json={"name": "Renamed"},
+        )
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"]["code"] == "reload_failed"
+
+    # DB rolled back — name unchanged
+    response2 = await AsyncClient(
+        transport=transport, base_url="http://test"
+    ).get("/admin/api/v1/agent") if False else None  # pragma: no cover
+    # Re-fetch through a fresh client to confirm rollback
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        get_response = await client.get("/admin/api/v1/agent")
+    assert get_response.json()["name"] == "Ada"
+
+
+@pytest.mark.asyncio
+async def test_patch_records_outcome_in_runtime_state(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.patch("/admin/api/v1/agent", json={"name": "Renamed"})
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_status == "reloaded"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_patches_serialize(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    """Two simultaneous PATCHes must serialize through _reload_mutex.
+
+    We assert this indirectly: both succeed (no race-induced 500),
+    and the reload_callable is called exactly twice.
+    """
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        results = await asyncio.gather(
+            client.patch("/admin/api/v1/agent", json={"name": "A"}),
+            client.patch("/admin/api/v1/agent", json={"name": "B"}),
+        )
+    assert all(r.status_code == 200 for r in results)
+    assert stub_reload_callable.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_returns_404_when_not_configured(admin_app) -> None:
+    """Cold-start state — no agent row, GET returns 404 in admin envelope."""
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/agent")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_malformed_body_returns_422(admin_app, async_session) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Send name=null (forbidden by _no_null_name validator)
+        response = await client.patch(
+            "/admin/api/v1/agent", json={"name": None}
+        )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_failed"
+```
+
+### 3.7 Integration tests — memory_flow
+
+- [ ] **Step 7: Create test_memory_flow.py**
+
+Write to `libs/idun_agent_standalone/tests/integration/api/v1/test_memory_flow.py`:
+
+```python
+"""Integration tests for /admin/api/v1/memory against the real reload pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from idun_agent_standalone.services import runtime_state
+from idun_agent_standalone.services.reload import ReloadInitFailed
+
+
+@pytest.fixture
+async def admin_app(async_session, stub_reload_callable):
+    from fastapi import FastAPI
+    from idun_agent_standalone.api.v1.deps import (
+        get_reload_callable,
+        get_session,
+    )
+    from idun_agent_standalone.api.v1.errors import (
+        register_admin_exception_handlers,
+    )
+    from idun_agent_standalone.api.v1.routers.agent import (
+        router as agent_router,
+    )
+    from idun_agent_standalone.api.v1.routers.memory import (
+        router as memory_router,
+    )
+
+    app = FastAPI()
+    register_admin_exception_handlers(app)
+    app.include_router(agent_router)
+    app.include_router(memory_router)
+    app.state.reload_callable = stub_reload_callable
+
+    async def override_session():
+        yield async_session
+
+    async def override_reload_callable():
+        return stub_reload_callable
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_reload_callable] = override_reload_callable
+    return app
+
+
+async def _seed_agent_langgraph(async_session) -> None:
+    from idun_agent_standalone.infrastructure.db.models.agent import (
+        StandaloneAgentRow,
+    )
+
+    row = StandaloneAgentRow(
+        name="Ada",
+        base_engine_config={
+            "server": {"api": {"port": 8000}},
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            },
+        },
+    )
+    async_session.add(row)
+    await async_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_get_memory_404_on_empty(admin_app) -> None:
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/memory")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_first_write_missing_field_422(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Missing memory field
+        response = await client.patch(
+            "/admin/api/v1/memory",
+            json={"agentFramework": "LANGGRAPH"},
+        )
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_failed"
+    field_names = {fe["field"] for fe in body["error"]["fieldErrors"]}
+    assert "memory" in field_names
+
+
+@pytest.mark.asyncio
+async def test_patch_first_write_happy(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "LANGGRAPH",
+                "memory": {"type": "memory"},
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["reload"]["status"] == "reloaded"
+    stub_reload_callable.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_patch_framework_switch_returns_restart_required(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    """Switching memory framework changes agent.framework -> structural."""
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # First write establishes baseline
+        await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "LANGGRAPH",
+                "memory": {"type": "memory"},
+            },
+        )
+        # Second write switches framework — assemble will rebuild the
+        # EngineConfig with a different agent.type, which is structural.
+        # NOTE: this requires the agent's base_engine_config to also
+        # change framework, OR the assemble step to override agent.type
+        # from the memory row's framework. The exact behavior depends
+        # on Phase 1's assemble_engine_config; the implementer reads
+        # services/engine_config.py to confirm before writing this test.
+        # If the assembly does NOT change agent.framework based on
+        # memory framework (likely case), this test is moved/skipped
+        # and a different structural-change trigger is used (e.g.,
+        # mutating agent.base_engine_config.agent.config.graph_definition
+        # via direct DB write, then calling PATCH on agent).
+        pass
+
+
+@pytest.mark.asyncio
+async def test_framework_memory_mismatch_422(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    """LANGGRAPH agent + ADK SessionService memory -> round 2 fails."""
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "ADK",
+                "memory": {
+                    "type": "in_memory",  # ADK SessionService shape
+                },
+            },
+        )
+    # Either the schema-level validation (Phase 2 _no_null on framework
+    # mismatch) catches it at round 1 (422 + body validation), or
+    # round 2 catches it. Either way, 422 + DB unchanged.
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_delete_memory_after_first_write(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "LANGGRAPH",
+                "memory": {"type": "memory"},
+            },
+        )
+        response = await client.delete("/admin/api/v1/memory")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["deleted"] is True
+    assert body["reload"]["status"] in ("reloaded", "restart_required")
+
+
+@pytest.mark.asyncio
+async def test_delete_on_empty_returns_404(admin_app, async_session) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.delete("/admin/api/v1/memory")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_round_3_failure_rolls_back_db(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    stub_reload_callable.side_effect = ReloadInitFailed("engine boom")
+
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "LANGGRAPH",
+                "memory": {"type": "memory"},
+            },
+        )
+    assert response.status_code == 500
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        get_response = await client.get("/admin/api/v1/memory")
+    # No row was committed
+    assert get_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_records_outcome(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "LANGGRAPH",
+                "memory": {"type": "memory"},
+            },
+        )
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_status == "reloaded"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_patches_serialize(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        results = await asyncio.gather(
+            client.patch(
+                "/admin/api/v1/memory",
+                json={
+                    "agentFramework": "LANGGRAPH",
+                    "memory": {"type": "memory"},
+                },
+            ),
+            client.patch(
+                "/admin/api/v1/memory",
+                json={"memory": {"type": "memory"}},
+            ),
+        )
+    # Both succeed (mutex serializes); reload_callable called twice
+    # OR first creates, second is noop — either is acceptable.
+    assert all(r.status_code in (200, 422) for r in results)
+```
+
+**Implementer note for Task 3:** the exact behavior of memory framework switch depends on `services/engine_config.py` (Phase 1's assembly logic) — it reads the agent row and the memory row, and combines them. The framework on the **agent** is the structural field. If memory PATCH only changes the memory row but the agent row's `base_engine_config.agent.type` is unchanged, framework switch from memory PATCH alone may NOT be structural. In that case, the `test_patch_framework_switch_returns_restart_required` test target is replaced with a direct test that mutates the agent's `base_engine_config.agent.config.graph_definition` and PATCHes the agent — `graph_definition` IS structural definitionally. The implementer reads `services/engine_config.py` and adapts the integration test to match real assembly behavior. Note this in the commit message.
+
+### 3.8 Run + commit
+
+- [ ] **Step 8: Run mypy on the modified files**
+
+```bash
+uv run mypy --follow-imports=silent \
+  libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/deps.py \
+  libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/agent.py \
+  libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/memory.py \
+  libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+```
+Expected: clean.
+
+- [ ] **Step 9: Run lint**
+
+```bash
+make lint
+```
+Expected: clean.
+
+- [ ] **Step 10: Run integration tests**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/integration/api/v1/ -v
+```
+Expected: all tests pass.
+
+- [ ] **Step 11: Confirm stub constants are gone**
+
+```bash
+grep -rn "_SAVED_RELOAD\|_DELETE_RELOAD" \
+  libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/
+```
+Expected: no matches. Only `_NOOP_RELOAD` may remain.
+
+- [ ] **Step 12: Commit Task 3**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/deps.py \
+        libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/agent.py \
+        libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/memory.py \
+        libs/idun_agent_standalone/src/idun_agent_standalone/app.py \
+        libs/idun_agent_standalone/tests/integration/__init__.py \
+        libs/idun_agent_standalone/tests/integration/api/__init__.py \
+        libs/idun_agent_standalone/tests/integration/api/v1/__init__.py \
+        libs/idun_agent_standalone/tests/integration/api/v1/test_agent_flow.py \
+        libs/idun_agent_standalone/tests/integration/api/v1/test_memory_flow.py
+
+git commit -m "$(cat <<'EOF'
+refactor(rework-phase3): agent + memory routers use real reload pipeline
+
+Replaces the Phase 1 stub reload constants with calls into the new
+commit_with_reload pipeline. Mutating handlers wrap their staged
+mutations in `async with _reload_mutex:` so two concurrent PATCHes
+serialize. The reload callable is dependency-injected via the new
+ReloadCallableDep and wired in app.py from the engine's reconfigure
+interface.
+
+agent.py:
+- Removes _SAVED_RELOAD constant. Empty PATCH still uses _NOOP_RELOAD
+  short-circuit.
+- Non-empty PATCH stages the mutation, calls commit_with_reload, and
+  returns the real StandaloneReloadResult.
+
+memory.py:
+- Removes _SAVED_RELOAD and _DELETE_RELOAD constants. _NOOP_RELOAD
+  preserved for empty PATCH.
+- PATCH first-write keeps the existing missing-fields 422 contract.
+- DELETE wraps StandaloneSingletonDeleteResult in the mutation
+  envelope.
+- Direct assemble_engine_config call removed — the pipeline does
+  this once atomically.
+
+deps.py:
+- Adds ReloadCallableDep typing alias backed by a get_reload_callable
+  dependency that pulls from app.state.reload_callable.
+
+app.py:
+- Wires the engine reload callable into app.state during startup.
+  Implementation case (a/b) and the source of the reconfigure
+  interface are documented inline.
+
+Integration tests cover the spec-locked Phase 3 gates: rollback
+path (round 3 failure 500 + DB unchanged), restart_required path
+(structural change), reload-callback survival, concurrency (mutex
+serializes), runtime_state recording.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Patterns doc transitions (T4)
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-27-rework-patterns.md`
+
+**Subagent dispatch model:** cheap.
+
+This task flips applicable FORWARD sections to ESTABLISHED with real file:line refs.
+
+### 4.1 Compute post-Phase-3 line refs
+
+- [ ] **Step 1: Capture line numbers**
+
+Run:
+```bash
+echo "=== slugs.py ==="
+grep -n "^def normalize_slug\|^async def ensure_unique_slug\|^class SlugConflictError\|^class SlugNormalizationError" \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py
+
+echo "=== config_hash.py ==="
+grep -n "^def compute_config_hash" \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py
+
+echo "=== validation.py ==="
+grep -n "^class RoundTwoValidationFailed\|^def validate_assembled_config" \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py
+
+echo "=== reload.py ==="
+grep -n "^_reload_mutex\|^async def commit_with_reload\|^class ReloadInitFailed\|^def _is_structural_change" \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py
+
+echo "=== runtime_state.py ==="
+grep -n "^async def get\|^async def record_reload_outcome\|^async def clear" \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py
+
+echo "=== runtime_state ORM ==="
+grep -n "^class StandaloneRuntimeStateRow" \
+  libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py
+```
+
+Capture each (symbol, line) for use in the doc edits.
+
+### 4.2 Update §6.5 (Slug rules)
+
+- [ ] **Step 2: Locate §6.5 in the patterns doc**
+
+Read `docs/superpowers/specs/2026-04-27-rework-patterns.md` and find the heading `### 6.5 Slug rules — FORWARD`. The section ends before `### 6.6 Connection-check sub-routes`.
+
+Replace the entire §6.5 subsection with (substituting `<NORMALIZE_LINE>` and `<ENSURE_LINE>` from Step 1's grep output):
+
+```markdown
+### 6.5 Slug rules — ESTABLISHED
+
+Slug normalization and uniqueness enforcement are implemented in `services/slugs.py`. Phase 5 collection routers call these helpers on POST.
+
+Normalization pipeline (from spec §"Identity → Slug rules (locked)"):
+
+```text
+input name
+  → trim whitespace
+  → NFKD ascii-fold
+  → lowercase
+  → regex sub [^a-z0-9]+ → "-"
+  → collapse runs of "-"
+  → trim leading/trailing "-"
+  → truncate to 64 chars
+```
+
+Reference snippet at `libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py:<NORMALIZE_LINE>`:
+
+```python
+def normalize_slug(name: str) -> str:
+    trimmed = name.strip()
+    folded = unicodedata.normalize("NFKD", trimmed)
+    ascii_only = folded.encode("ascii", "ignore").decode("ascii")
+    lowered = ascii_only.lower()
+    dashed = _NON_SLUG_CHAR.sub("-", lowered)
+    collapsed = _DASH_RUN.sub("-", dashed)
+    stripped = collapsed.strip("-")
+    truncated = stripped[:_MAX_SLUG_LEN]
+    if not truncated:
+        raise SlugNormalizationError(...)
+    return truncated
+```
+
+Lifecycle constraints (locked):
+
+- Required and non-null on every collection row at rest.
+- Sticky: a `name` PATCH does NOT re-derive the slug. URLs do not change silently.
+- Direct slug PATCH that conflicts returns 409 (`code = conflict`). No auto-suffix on operator-supplied slugs.
+- POST collision auto-suffixes via `ensure_unique_slug` at `services/slugs.py:<ENSURE_LINE>`: `github-tools` → `github-tools-2` → `github-tools-3`, up to suffix 99 before raising `SlugConflictError`.
+
+Singletons (`agent`, `memory`) do not have meaningful slugs because they are not addressed by id. Their rows may carry a slug field for future cross-system identity, but the admin API never uses it for lookup.
+
+Canonical API lookup:
+
+```text
+/admin/api/v1/mcp-servers/{id}
+```
+
+Optional future slug lookup:
+
+```text
+/admin/api/v1/mcp-servers/by-slug/{slug}
+```
+```
+
+### 4.3 Remove §7.4 stub reload caveat
+
+- [ ] **Step 3: Locate §7.4 and delete its content**
+
+Find the heading `### 7.4 Stub-reload constants — TRANSIENT`. Delete the entire subsection (heading + body + closing `---` separator if any). Phase 3 has retired the stubs.
+
+If §7 has subsections §7.1, §7.2, §7.3, §7.4, after deletion the section should renumber implicitly via the markdown renderer (no need to manually renumber; the next subsection after §7.3 is now whatever §7.4 was, but since it's gone, §7 ends at §7.3).
+
+### 4.4 Update §8 (Validation rounds)
+
+- [ ] **Step 4: Locate §8**
+
+Find the heading `## 8. Validation rounds — FORWARD`. Replace `— FORWARD` with `— ESTABLISHED`.
+
+After the verbatim-from-spec table (which doesn't change), replace the FORWARD skeleton block at the end with a real reference. Substitute `<COMMIT_RELOAD_LINE>` and `<VALIDATE_LINE>` from Step 1.
+
+Replace the existing skeleton (the block after "Skeleton (Phase 3 will land the real implementation in `services/reload.py`):" through the end of §8) with:
+
+```markdown
+The pipeline implementation lives in `services/reload.py`:
+
+- The `_reload_mutex: asyncio.Lock` and `commit_with_reload` orchestrator at `libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py:<COMMIT_RELOAD_LINE>`.
+- Round 2 entry point at `libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py:<VALIDATE_LINE>` (`validate_assembled_config`).
+- Round 1 is FastAPI's body validation; the framework handles it before the handler runs.
+
+Reference flow:
+
+```python
+# Caller (router handler):
+async with _reload_mutex:
+    # Stage DB mutation
+    setattr(row, field, value)
+    await session.flush()
+    result = await commit_with_reload(
+        session,
+        reload_callable=reload_callable,
+    )
+    await session.refresh(row)
+
+return StandaloneMutationResponse(data=..., reload=result)
+```
+
+The pipeline runs round 2 (validate the assembled EngineConfig), detects structural change vs the prior runtime_state, and either:
+- commits + records + returns `restart_required` (no reload_callable invocation), OR
+- runs round 3 (invokes `reload_callable`):
+  - on success: commits + records + returns `reloaded`,
+  - on `ReloadInitFailed`: rolls back user mutation, records failure outcome via a separate transaction, raises `AdminAPIError(500, code=reload_failed)`.
+
+Round 2 failures roll back the user's mutation and raise `AdminAPIError(422, code=validation_failed)` carrying the structured `field_errors` from the wrapped Pydantic `ValidationError`.
+```
+
+### 4.5 Update §10 (Reload mutex)
+
+- [ ] **Step 5: Locate §10**
+
+Find the heading `## 10. Reload mutex — FORWARD`. Replace `— FORWARD` with `— ESTABLISHED`.
+
+Replace the FORWARD skeleton with a real reference. Substitute `<MUTEX_LINE>` and `<COMMIT_RELOAD_LINE>` from Step 1.
+
+```markdown
+Single in-process `asyncio.Lock` held around the entire 3-round pipeline.
+
+Reference at `libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py:<MUTEX_LINE>`:
+
+```python
+import asyncio
+
+_reload_mutex = asyncio.Lock()
+
+
+async def commit_with_reload(
+    session: AsyncSession,
+    *,
+    reload_callable: Callable[[EngineConfig], Awaitable[None]],
+    now: Callable[[], datetime] = _default_now,
+) -> StandaloneReloadResult:
+    """Run the 3-round pipeline. Caller must hold _reload_mutex."""
+    ...
+```
+
+Single-replica assumption: spec §"Save/reload posture" locks standalone as single-replica. Multi-replica deployment requires a DB-backed advisory lock; that work is out of scope until enrollment lands.
+```
+
+### 4.6 Update §11 (Cold-start states) — partial ESTABLISHED
+
+- [ ] **Step 6: Locate §11**
+
+Find the heading `## 11. Cold-start states — FORWARD`. **Do NOT change the heading** — the boot-path state machine remains FORWARD until Phase 6 lands.
+
+Find the existing paragraph that cites `StandaloneRuntimeStatusKind` (added in Phase 2 T4b). Insert immediately after it (substituting `<RUNTIME_STATE_ORM_LINE>` and `<RUNTIME_STATE_GET_LINE>`):
+
+```markdown
+The persistence layer for cold-start state landed in Phase 3:
+
+- Singleton ORM at `libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py:<RUNTIME_STATE_ORM_LINE>` (`StandaloneRuntimeStateRow`). Records the last reload outcome (status, message, error, timestamp, applied config hash).
+- Service at `libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py:<RUNTIME_STATE_GET_LINE>` (`get`, `record_reload_outcome`, `clear`). The reload pipeline records every outcome here.
+
+The boot-path state machine that derives `StandaloneRuntimeStatusKind` from agent presence + engine state + last reload outcome lands in Phase 6.
+```
+
+### 4.7 Update §12 (Config hash)
+
+- [ ] **Step 7: Locate §12**
+
+Find the heading `## 12. Config hash — FORWARD`. Replace `— FORWARD` with `— ESTABLISHED`.
+
+Replace the body (substituting `<COMPUTE_HASH_LINE>`):
+
+```markdown
+```text
+config_hash = sha256(canonical_json(materialized EngineConfig))
+```
+
+Canonicalization: **JCS / RFC 8785** via the `rfc8785` PyPI package. Determinism guarantee: two semantically-equal `EngineConfig` values produce the same hash regardless of dict key insertion order.
+
+Implementation at `libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py:<COMPUTE_HASH_LINE>`:
+
+```python
+import rfc8785
+from hashlib import sha256
+
+def compute_config_hash(engine_config: EngineConfig) -> str:
+    payload = engine_config.model_dump(mode="json")
+    canonical = rfc8785.canonicalize(payload)
+    return sha256(canonical).hexdigest()
+```
+
+Phase 3 storage: the structural-slice hash (not the full config hash) is stored on `standalone_runtime_state.last_applied_config_hash` for structural-change detection. The full config hash is computed on-demand by Phase 6's `/runtime/status` endpoint.
+
+Storage column type: `String(64)` (sha256 hex digest length).
+```
+
+### 4.8 Verify and commit
+
+- [ ] **Step 8: Verify no FORWARD placeholders remain in the updated sections**
+
+```bash
+# §6.5 must NOT have FORWARD
+grep -A 2 "### 6.5" docs/superpowers/specs/2026-04-27-rework-patterns.md | head -3
+
+# §7.4 stub caveat must be GONE
+grep -n "### 7.4 Stub-reload constants" docs/superpowers/specs/2026-04-27-rework-patterns.md || echo "removed (good)"
+
+# §8, §10, §12 must say ESTABLISHED
+grep "^## 8\|^## 10\|^## 12" docs/superpowers/specs/2026-04-27-rework-patterns.md
+
+# §11 must still say FORWARD (boot-path state machine remains future)
+grep "^## 11" docs/superpowers/specs/2026-04-27-rework-patterns.md
+
+# No leftover placeholder tokens
+grep -nE "<[A-Z_]+_LINE>|<NN-NN>" docs/superpowers/specs/2026-04-27-rework-patterns.md && echo "FAIL: placeholders remain" || echo "all placeholders replaced"
+```
+
+- [ ] **Step 9: Commit Task 4**
+
+```bash
+git add docs/superpowers/specs/2026-04-27-rework-patterns.md
+
+git commit -m "$(cat <<'EOF'
+docs(rework-phase3): patterns reference — flip FORWARD sections to ESTABLISHED
+
+Phase 3 lands the cross-cutting plumbing, so the patterns reference
+doc transitions:
+
+- §6.5 Slug rules — FORWARD -> ESTABLISHED. Cites services/slugs.py
+  for normalize_slug + ensure_unique_slug. Skeleton replaced with
+  real reference snippet.
+
+- §7.4 Stub-reload constants caveat — REMOVED. The stubs
+  (_SAVED_RELOAD, _DELETE_RELOAD) are gone after T3's retrofit.
+  _NOOP_RELOAD survives in routers as the empty-body fast path.
+
+- §8 Validation rounds — FORWARD -> ESTABLISHED. Cites
+  services/reload.py for the 3-round dispatch and services/validation.py
+  for round 2. Reference flow shows the canonical
+  `async with _reload_mutex:` + commit_with_reload pattern.
+
+- §10 Reload mutex — FORWARD -> ESTABLISHED. Cites _reload_mutex
+  and commit_with_reload at services/reload.py.
+
+- §11 Cold-start states — partial ESTABLISHED. Storage layer
+  (runtime_state ORM + service) is now established with file:line
+  refs. The boot-path state machine that derives
+  StandaloneRuntimeStatusKind from agent presence + engine state +
+  last reload outcome remains FORWARD; lands in Phase 6.
+
+- §12 Config hash — FORWARD -> ESTABLISHED. Cites
+  services/config_hash.py. Locks rfc8785 as the JCS implementation.
+  Documents that Phase 3 stores the structural-slice hash for
+  change detection; the full config hash for /runtime/status is
+  Phase 6's deliverable.
+
+Sections that remain FORWARD: §6.2 Collection router pattern (Phase 5),
+§6.3 PATCH semantics (Phase 5), §6.6 Connection-check sub-routes
+(Phase 6), §11 cold-start state machine implementation (Phase 6).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: CI gate
+
+**Files:** none.
+
+- [ ] **Step 1: Run lint**
+
+```bash
+make lint
+```
+Expected: exit 0.
+
+- [ ] **Step 2: Run mypy on the new tree**
+
+```bash
+uv run mypy --follow-imports=silent \
+  libs/idun_agent_schema/src/idun_agent_schema/standalone \
+  libs/idun_agent_standalone/src/idun_agent_standalone/api \
+  libs/idun_agent_standalone/src/idun_agent_standalone/core \
+  libs/idun_agent_standalone/src/idun_agent_standalone/services \
+  libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure
+```
+Expected: clean (~50 source files post-Phase 3).
+
+- [ ] **Step 3: Run schema pytest**
+
+```bash
+uv run pytest libs/idun_agent_schema -q
+```
+Expected: 62 tests pass (Phase 2 close-state; not regressed).
+
+- [ ] **Step 4: Run standalone narrowed pytest**
+
+```bash
+uv run pytest libs/idun_agent_standalone -q \
+  -m "not requires_postgres and not requires_langfuse and not requires_phoenix" \
+  --ignore=libs/idun_agent_standalone/tests/unit/test_admin_bootstrap.py \
+  --ignore=libs/idun_agent_standalone/tests/unit/test_reload.py \
+  --ignore=libs/idun_agent_standalone/tests/unit/test_scaffold.py \
+  --ignore=libs/idun_agent_standalone/tests/unit/test_cli.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_app_health.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_integrations_casing.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_structural_change_restart.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_reload_state_correctness.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_auth_bootstrap.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_reload_atomic.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_engine_reload_reattaches_observer.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_reload_flow.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_prompts_wiring.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_bootstrap_hash.py \
+  --ignore=libs/idun_agent_standalone/tests/integration/test_config_io.py
+```
+Expected: ≥120 tests pass (was 64 at Phase 2 close; Phase 3 adds ~42 unit + ~18 integration).
+
+- [ ] **Step 5: Verify acceptance criteria**
+
+Per design doc §6:
+
+```bash
+ls libs/idun_agent_standalone/src/idun_agent_standalone/services/
+ls libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/
+git log --oneline 4d3d86d3^..HEAD | grep -E "rework-phase3"
+```
+
+Expected:
+- `services/` contains: `__init__.py`, `engine_config.py` (Phase 1), `runtime_state.py`, `slugs.py`, `config_hash.py`, `validation.py`, `reload.py`. Plus `__pycache__/`.
+- `infrastructure/db/models/` contains: `__init__.py`, `agent.py`, `memory.py`, `runtime_state.py`. Plus `__pycache__/`.
+- Commit log shows the 6 Phase 3 commits in order.
+
+```bash
+grep -rn "_SAVED_RELOAD\|_DELETE_RELOAD" \
+  libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/
+```
+Expected: no matches.
+
+---
+
+## Task 6: Open the PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/rework-phase3-plumbing
+```
+
+- [ ] **Step 2: Build the PR description**
+
+Use the template below; fill the `<...>` slots from the actual commits and test counts.
+
+```markdown
+## Phase 3 — Cross-Cutting Plumbing
+
+Closes Phase 3 of the standalone admin/db rework.
+
+### What this PR does
+- Adds the cross-cutting plumbing every Phase 4+ module needs: reload pipeline (asyncio mutex + 3-round validation + structural-change detection), slug rules, RFC 8785 config hash, runtime-state persistence.
+- Retrofits Phase 1's agent + memory routers from stub reload constants to the real pipeline.
+- Flips four FORWARD sections in the patterns reference doc to ESTABLISHED, partial-ESTABLISHES one, and removes the stub-reload caveat.
+
+### New modules
+- `services/runtime_state.py` — get/record/clear helpers over the new ORM (T2).
+- `services/slugs.py` — normalize_slug + ensure_unique_slug (T2).
+- `services/config_hash.py` — RFC 8785 sha256 hash (T2).
+- `services/validation.py` — round 2 validation entry point (T1).
+- `services/reload.py` — `_reload_mutex` + commit_with_reload orchestrator (T1).
+- `infrastructure/db/models/runtime_state.py` — singleton ORM (T2).
+
+### Retrofit
+- `api/v1/routers/agent.py` — removes _SAVED_RELOAD; routes mutating PATCH through commit_with_reload.
+- `api/v1/routers/memory.py` — removes _SAVED_RELOAD and _DELETE_RELOAD; PATCH and DELETE flow through the pipeline.
+- `api/v1/deps.py` — adds ReloadCallableDep typing alias.
+- `app.py` — wires the engine reload callable into app.state at startup.
+
+### Tests
+- ~42 unit tests (services/, db/) + ~18 integration tests (api/v1/).
+- Standalone narrowed pytest grows from 64 → <N> tests.
+- Schema pytest still 62 (no regression).
+- The 5 spec-locked Phase 3 test gates pass: rollback path, restart_required path, reload-callback survival, concurrency (mutex), cold-start state recording.
+
+### Patterns now ESTABLISHED (commit `<T4_SHA>`)
+- §6.5 Slug rules (was FORWARD)
+- §8 Validation rounds (was FORWARD)
+- §10 Reload mutex (was FORWARD)
+- §12 Config hash (was FORWARD)
+- §11 Cold-start states — partial (storage layer; boot-path state machine still FORWARD)
+- §7.4 Stub-reload caveat REMOVED
+
+### Patterns still FORWARD
+- §6.2 Collection router pattern (Phase 5)
+- §6.3 PATCH semantics (Phase 5)
+- §6.6 Connection-check sub-routes (Phase 6)
+- §11 Cold-start state machine implementation (Phase 6)
+
+### New runtime dependency
+- `rfc8785>=0.1` added to `libs/idun_agent_standalone/pyproject.toml`. Pure-Python, ~200 LOC, single-purpose.
+
+### Test plan
+- [x] `make lint` passes
+- [x] `uv run mypy --follow-imports=silent <new-tree>` passes
+- [x] `uv run pytest libs/idun_agent_schema -q` passes (62 tests)
+- [x] `uv run pytest libs/idun_agent_standalone -q --ignore=...` passes (≥120 tests)
+
+### Out of Phase 3 scope (tracked for later phases)
+- Collection resource ORMs/routers — Phases 4–5
+- Alembic migration for `standalone_runtime_state` — Phase 4 (fresh baseline)
+- `/runtime/status`, `/readyz`, `/health`, connection-check route handlers — Phase 6
+- Boot-path state machine deriving `StandaloneRuntimeStatusKind` — Phase 6
+- Auth hardening (rate limiting, CSRF) — Phase 7
+- Audit-event logging — deferred to next version
+
+### Next phase
+Phase 4 (`feat/rework-phase4-db-models`): build the collection resource ORMs (guardrails, mcp_servers, observability, integrations, prompts) and the fresh Alembic baseline that includes them plus the runtime_state ORM. Branches off the umbrella after this PR merges.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] **Step 3: Create the PR**
+
+```bash
+gh pr create \
+  --base feat/standalone-admin-db-rework \
+  --head feat/rework-phase3-plumbing \
+  --title "Phase 3 — Cross-cutting plumbing" \
+  --body "$(cat <<'EOF'
+<paste the filled-in description from Step 2>
+EOF
+)"
+```
+Expected: PR URL returned. Hand back to user.
+
+- [ ] **Step 4: Final hand-back**
+
+Provide:
+- PR URL
+- Test counts (unit, integration, total standalone, schema)
+- Commits on the branch
+- Patterns transitions summary
+- Confirmation that all acceptance criteria are met
+
+---
+
+## Acceptance summary (cross-references design doc §6)
+
+1. T2 helpers exist + unit tests pass — Task 1.
+2. T1 reload pipeline exists + unit + integration tests pass — Task 2 + Task 3.
+3. T3 stub constants removed (`grep` confirms) — Task 3 Step 11.
+4. T4 patterns doc transitions land — Task 4.
+5. `make lint` clean — Task 5 Step 1.
+6. `mypy` clean — Task 5 Step 2.
+7. Schema pytest passes — Task 5 Step 3.
+8. Standalone narrowed pytest ≥120 — Task 5 Step 4.
+9. 5 spec-locked Phase 3 test gates pass — verified by integration tests in Task 3 + reload unit tests in Task 2.
+10. PR description summarizes transitions — Task 6.

--- a/docs/superpowers/specs/2026-04-27-rework-patterns.md
+++ b/docs/superpowers/specs/2026-04-27-rework-patterns.md
@@ -572,7 +572,7 @@ return StandaloneMutationResponse(
 
 Why: DELETE on an enabled resource changes the assembled `EngineConfig`, so it goes through the same reload path as POST/PATCH. The spec locks one envelope across all mutations.
 
-### 6.5 Slug rules — FORWARD
+### 6.5 Slug rules — ESTABLISHED
 
 Slugs are auto-generated from `name` on POST. Routes use `{id}` for canonical lookup; an optional `/by-slug/{slug}` lookup is a Phase-5+ convenience.
 
@@ -596,18 +596,46 @@ Lifecycle constraints (locked):
 - Direct slug PATCH that conflicts returns 409 (`code = conflict`). No auto-suffix on operator-supplied slugs.
 - POST collision auto-suffixes: `github-tools` → `github-tools-2` → `github-tools-3`.
 
-Skeleton:
+Reference snippet — Phase 3 service. `normalize_slug` at `libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py:31` and `ensure_unique_slug` at the same file `:58`:
 
 ```python
-# FORWARD — refine in Phase 5; helper lives in services/slugs.py (Phase 3)
-from idun_agent_standalone.services.slugs import normalize_slug, ensure_unique_slug
-
-slug = ensure_unique_slug(
-    session,
-    Standalone<Resource>Row,
-    candidate=normalize_slug(body.name),
+from idun_agent_standalone.services.slugs import (
+    SlugConflictError,
+    SlugNormalizationError,
+    ensure_unique_slug,
+    normalize_slug,
 )
+
+# Phase 5 router POST flow
+candidate = normalize_slug(body.name)
+slug = await ensure_unique_slug(
+    session,
+    StandaloneMCPServerRow,           # the ORM class
+    StandaloneMCPServerRow.slug,      # the slug column on that ORM
+    candidate,
+)
+row = StandaloneMCPServerRow(name=body.name, slug=slug, ...)
+
+# PATCH-of-slug flow (collision check only — no auto-suffix on operator-supplied slugs)
+# FORWARD — Phase 5 collection routers will refine
+if existing.slug != body.slug:
+    if await ensure_unique_slug(
+        session,
+        StandaloneMCPServerRow,
+        StandaloneMCPServerRow.slug,
+        body.slug,
+    ) != body.slug:
+        raise AdminAPIError(
+            status_code=409,
+            error=StandaloneAdminError(
+                code=StandaloneErrorCode.CONFLICT,
+                message=f"Slug {body.slug!r} is already in use.",
+            ),
+        )
+    existing.slug = body.slug
 ```
+
+`SlugNormalizationError` (subclass of `ValueError`) and `SlugConflictError` are defined alongside the helpers; routers map them to 422 `validation_failed` and 409 `conflict` respectively (see §9).
 
 Singletons (`agent`, `memory`) do not have meaningful slugs because they are not addressed by id. Their rows may carry a slug field for future cross-system identity, but the admin API never uses it for lookup.
 
@@ -681,29 +709,9 @@ Locked from spec §"API response posture":
 - HTTP 500 for round-3 reload init failure (DB rolls back).
 - HTTP 429 for rate-limited login.
 
-### 7.4 Stub-reload constants — TRANSIENT
-
-Phase 1 routers use stub reload constants because the reload mutex + 3-round pipeline (§8, §10) lands in Phase 3. Reference at `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/agent.py:40-48`:
-
-```python
-_SAVED_RELOAD = StandaloneReloadResult(
-    status=StandaloneReloadStatus.RESTART_REQUIRED,
-    message="Saved. Restart required to apply.",
-)
-
-_NOOP_RELOAD = StandaloneReloadResult(
-    status=StandaloneReloadStatus.RELOADED,
-    message="No changes.",
-)
-```
-
-A `_DELETE_RELOAD` constant exists in `routers/memory.py` for the DELETE path. Same pattern.
-
-These are NOT pattern-breakers. Phase 5+ collection routers may copy the stub pattern. Phase 3 retrofits all routers to use the real `commit_with_reload` service.
-
 ---
 
-## 8. Validation rounds — FORWARD
+## 8. Validation rounds — ESTABLISHED
 
 Three explicit validation rounds wrap each mutation. Each has a fixed HTTP code and error code so the UI can branch reliably (verbatim from spec §"Validation rounds"):
 
@@ -713,46 +721,40 @@ Three explicit validation rounds wrap each mutation. Each has a fixed HTTP code 
 | 2 | Assembled `EngineConfig` (post-merge of staged DB state) | 422 | `validation_failed` | Catches cross-resource invalid combos (e.g. `LANGGRAPH + SessionServiceConfig`). |
 | 3 | Engine reload init | 500 | `reload_failed` | DB rolls back; previous engine remains active. |
 
-Skeleton (Phase 3 will land the real implementation in `services/reload.py`):
+Reference flow — `commit_with_reload` at `libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py:134` is the canonical orchestrator. Round-2 validation is `validate_assembled_config` at `libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py:39`:
 
 ```python
-# FORWARD — refine in Phase 3
-async with reload_mutex:
-    # Round 1 happens before the handler runs (FastAPI body validation).
-    # Stage DB mutation in a transaction
-    # Round 2: assemble EngineConfig and validate
-    try:
-        assembled = await assemble_engine_config(session)
-        EngineConfig.model_validate(assembled.model_dump())
-    except ValidationError as exc:
-        await session.rollback()
-        raise AdminAPIError(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
-            error=StandaloneAdminError(
-                code=StandaloneErrorCode.VALIDATION_FAILED,
-                message="Assembled config failed validation.",
-                field_errors=field_errors_from_validation_error(exc),
-            ),
-        )
-    # Round 3: try runtime reload
-    try:
-        outcome = await reload_runtime(assembled)
-    except ReloadInitFailed as exc:
-        await session.rollback()
-        raise AdminAPIError(
-            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
-            error=StandaloneAdminError(
-                code=StandaloneErrorCode.RELOAD_FAILED,
-                message="Engine reload failed; config not saved.",
-                details={"recovered": True},
-            ),
-        ) from exc
-    # On success: commit
-    await session.commit()
-    return StandaloneMutationResponse(data=..., reload=outcome)
+from idun_agent_standalone.services import reload as reload_service
+from idun_agent_standalone.services.reload import (
+    ReloadInitFailed,
+    commit_with_reload,
+)
+
+# Inside the router handler, after staging DB writes via session.add / setattr.
+# `reload_callable` is FastAPI-injected via `ReloadCallableDep` (see api/v1/deps.py).
+async with reload_service._reload_mutex:
+    # Stage DB mutation
+    setattr(row, field, value)
+    await session.flush()
+    # Round 1 already ran (FastAPI Pydantic body validation, 422 on failure).
+    # commit_with_reload internally:
+    #   - assembles EngineConfig from staged session state
+    #   - runs Round 2: validate_assembled_config → 422 on failure (rollback)
+    #   - runs Round 3: engine reload init → 500 on failure (rollback)
+    #   - commits the session on success
+    #   - records outcome to standalone_runtime_state
+    reload_result = await commit_with_reload(
+        session,
+        reload_callable=reload_callable,
+    )
+    await session.refresh(row)
+
+return StandaloneMutationResponse(data=..., reload=reload_result)
 ```
 
-`reload_mutex`, `assemble_engine_config`, `reload_runtime`, `ReloadInitFailed`, the real `_SAVED_RELOAD` outcome are all Phase 3.
+The `reload_callable` parameter is supplied by FastAPI dependency injection — routers declare a `ReloadCallableDep` parameter (added in `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/deps.py`) which resolves to the engine's reload coroutine. `commit_with_reload` does NOT acquire the mutex itself; the caller must wrap the entire stage-flush-commit sequence in `async with reload_service._reload_mutex:` (see §10).
+
+Round-2 raises `RoundTwoValidationFailed` carrying a Pydantic `ValidationError`; the router error mapper translates it to 422 with `field_errors`. Round-3 raises `ReloadInitFailed`; the mapper translates it to 500 with `code = reload_failed`. In both error paths `commit_with_reload` rolls back the session before re-raising.
 
 ---
 
@@ -828,25 +830,47 @@ raise AdminAPIError(
 
 ---
 
-## 10. Reload mutex — FORWARD
+## 10. Reload mutex — ESTABLISHED
 
-Single in-process `asyncio.Lock` held around the entire 3-round pipeline.
+Single in-process `asyncio.Lock` held by the **router** around the entire 3-round pipeline. The pipeline orchestrator (`commit_with_reload`) does NOT acquire the mutex — the caller must.
 
-Skeleton (Phase 3 lands the real implementation):
+Reference at `libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py:64`:
 
 ```python
-# FORWARD — refine in Phase 3
-# libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py
 import asyncio
 
 _reload_mutex = asyncio.Lock()
 
 
-async def commit_with_reload(...) -> StandaloneReloadResult:
-    async with _reload_mutex:
-        # Round 2 + Round 3 + commit/rollback (see §8)
-        ...
+async def commit_with_reload(
+    session: AsyncSession,
+    *,
+    reload_callable: Callable[[EngineConfig], Awaitable[None]],
+    now: Callable[[], datetime] = _default_now,
+) -> StandaloneReloadResult:
+    """Run the 3-round pipeline.
+
+    Caller must:
+      - acquire _reload_mutex via `async with _reload_mutex:`
+      - stage DB mutation (e.g. add/modify ORM rows)
+      - call session.flush()
+    """
+    ...
 ```
+
+Routers reach the mutex via the module-attribute path:
+
+```python
+from idun_agent_standalone.services import reload as reload_service
+from idun_agent_standalone.services.reload import commit_with_reload
+
+async with reload_service._reload_mutex:
+    await session.flush()
+    result = await commit_with_reload(session, reload_callable=reload_callable)
+    await session.refresh(row)
+```
+
+Module-attribute access (`reload_service._reload_mutex`) instead of direct import lets test fixtures swap a fresh `asyncio.Lock` per pytest-asyncio event loop. In production (single event loop) this is irrelevant.
 
 Single-replica assumption: spec §"Save/reload posture" locks standalone as single-replica. Multi-replica deployment requires a DB-backed advisory lock; that work is out of scope until enrollment lands.
 
@@ -883,23 +907,40 @@ boot
 
 The cold-start state values are defined as the `StandaloneRuntimeStatusKind` enum at `libs/idun_agent_schema/src/idun_agent_schema/standalone/runtime_status.py:28`. The full runtime status payload that surfaces the state at `GET /admin/api/v1/runtime/status` is `StandaloneRuntimeStatus` in the same module.
 
+Storage layer — ESTABLISHED. Phase 3 lands the persistence side: the singleton ORM `StandaloneRuntimeStateRow` at `libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py:19` holds `last_applied_config_hash`, `last_reload_status`, `last_reload_error`, and `last_reload_at`. The service-layer accessor `get` at `libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py:29` reads the row (returning `None` on a fresh DB), and `record_reload_outcome` writes it transactionally inside `commit_with_reload`. The boot-path state machine that derives `StandaloneRuntimeStatusKind` from agent presence + engine state + last reload outcome remains FORWARD; Phase 6 lands `GET /admin/api/v1/runtime/status` and the cold-start dispatch logic.
+
 Invariant: the admin API and `/health` MUST come up even when the engine fails to start.
 
 `GET /admin/api/v1/agent` when `state == not_configured` returns 404 (`code = not_found`) so the UI can render an onboarding prompt. Phase 1's `_load_agent` already does this (cite at `api/v1/routers/agent.py:51-68`).
 
 ---
 
-## 12. Config hash — FORWARD
+## 12. Config hash — ESTABLISHED
 
 ```text
 config_hash = sha256(canonical_json(materialized EngineConfig))
 ```
 
-Canonicalization: **JCS / RFC 8785** (sort keys, no whitespace, UTF-8, escape rules per spec). Implementation hint: `rfc8785` PyPI package; lock the choice in Phase 6.
+Canonicalization: **JCS / RFC 8785** (sort keys, no whitespace, UTF-8, escape rules per spec). Implementation: `rfc8785` PyPI package, locked in Phase 3.
 
-Storage: `standalone_runtime_state.last_applied_config_hash`. Surfaced in `GET /runtime/status`.
+Reference at `libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py:21`:
 
-The hash is recomputed on every successful reload and compared to the previous hash. Hash equality may be used to skip redundant reloads — but that is a Phase 6+ optimization, not part of MVP.
+```python
+import rfc8785
+from hashlib import sha256
+from idun_agent_schema.engine.engine import EngineConfig
+
+
+def compute_config_hash(engine_config: EngineConfig) -> str:
+    """Return a 64-character hex sha256 of the JCS-canonical JSON of the config."""
+    payload = engine_config.model_dump(mode="json")
+    canonical = rfc8785.dumps(payload)
+    return sha256(canonical).hexdigest()
+```
+
+Storage: `standalone_runtime_state.last_applied_config_hash` (see §11 for the ORM ref). Phase 3 hashes the **structural slice** of the assembled config (the parts whose change forces a hot reload vs `restart_required`) and stores it after each successful reload — `_is_structural_change` at `services/reload.py:115` consumes it for change detection. Phase 6 will additionally hash the full materialized `EngineConfig` and surface it at `GET /admin/api/v1/runtime/status`.
+
+The hash is recomputed on every successful reload and compared to the previous stored value. Hash equality lets `commit_with_reload` short-circuit redundant reloads when the structural slice is unchanged.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-27-rework-phase3-plumbing-design.md
+++ b/docs/superpowers/specs/2026-04-27-rework-phase3-plumbing-design.md
@@ -1,0 +1,629 @@
+# Rework Phase 3 — Cross-Cutting Plumbing
+
+Date: 2026-04-27
+
+Branch: `feat/rework-phase3-plumbing` (off `feat/standalone-admin-db-rework` umbrella, branched from merged Phase 2 tip `53342bd6`)
+
+Status: Brainstormed and locked. Implementation has not started.
+
+Authoritative sources:
+- `docs/superpowers/specs/2026-04-27-standalone-admin-config-db-design.md` — the rework spec.
+- `docs/superpowers/specs/2026-04-27-rework-patterns.md` — the patterns reference. Phase 3 ESTABLISHES the sections currently FORWARD for slug rules (§6.5), validation rounds (§8), reload mutex (§10), and config hash (§12), and partial-ESTABLISHES §11 (cold-start states — storage layer only; boot-path state machine is Phase 6).
+
+When this doc and either authoritative source disagree, the spec wins for content; the patterns doc wins for shape.
+
+## 1. Purpose
+
+Phase 3 builds the cross-cutting plumbing every later phase needs. Without it, Phase 5 collection routers would each reinvent the reload mutex, the 3-round validation pipeline, the slug normalization, and the structural-change detection — drift would compound across five resources.
+
+The phase delivers:
+
+1. The **reload pipeline** — single asyncio mutex around a `commit_with_reload` orchestrator that runs round 2 (assembled `EngineConfig` validation) and round 3 (engine reload), commits or rolls back the DB based on outcomes, and records the result for diagnostics.
+2. The **slug rules** helper used by every Phase 5 collection router on POST.
+3. The **config hash** computed via RFC 8785 / JCS canonicalization, stored on the runtime state row.
+4. The **runtime state** persistence layer — singleton `standalone_runtime_state` ORM and service that records the last reload outcome (status, message, error, timestamp, applied config hash). The boot-path state machine that derives `StandaloneRuntimeStatusKind` from this record is Phase 6.
+5. The **retrofit** of Phase 1's agent + memory routers from stub reload constants to the real pipeline.
+
+Phase 3 does NOT add the `/runtime/status` endpoint, does NOT build the boot-path state machine, does NOT add Alembic migrations (Phase 4 picks up the new ORM in its fresh baseline), and does NOT touch collection resources.
+
+## 2. Deliverables
+
+1. **Cross-cutting helpers** (T2):
+   - `libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py` — `StandaloneRuntimeStateRow` ORM.
+   - `libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py` — `get`, `record_reload_outcome`, `clear`.
+   - `libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py` — `normalize_slug`, `ensure_unique_slug`.
+   - `libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py` — `compute_config_hash`.
+
+2. **Reload pipeline** (T1):
+   - `libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py` — `validate_assembled_config`, `RoundTwoValidationFailed`.
+   - `libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py` — module-level `_reload_mutex`, `commit_with_reload`, `ReloadInitFailed`, `_is_structural_change`.
+
+3. **Retrofit** (T3):
+   - `api/v1/routers/agent.py` — replace stub reload constants with real `commit_with_reload` calls; wrap mutating handlers in `async with _reload_mutex:`.
+   - `api/v1/routers/memory.py` — same retrofit; memory framework changes route through structural-change detection → `restart_required`.
+   - `app.py` — wire the engine reload callable as a FastAPI dependency / startup hook so routers receive the real reloader.
+
+4. **Patterns doc transitions** (T4): six section transitions in `docs/superpowers/specs/2026-04-27-rework-patterns.md`.
+
+5. **Tests**: ~42 unit + ~18 integration = ~60 new tests under `libs/idun_agent_standalone/tests/` (unit/services/, unit/db/, integration/api/v1/).
+
+6. **Runtime dependency**: `rfc8785>=0.1` added to `libs/idun_agent_standalone/pyproject.toml`. The package is pure-Python, ~200 lines, single-purpose (RFC 8785 canonicalization), stable. Placement is in standalone (not schema lib) because it's a runtime hash concern, not a schema concern.
+
+## 3. Scope of changes
+
+In scope:
+
+- `libs/idun_agent_standalone/src/idun_agent_standalone/services/*.py` — 5 new modules.
+- `libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py` — 1 new module.
+- `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/agent.py` — modified.
+- `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/memory.py` — modified.
+- `libs/idun_agent_standalone/src/idun_agent_standalone/app.py` — modified to wire the engine reload callable.
+- `libs/idun_agent_standalone/pyproject.toml` — adds `rfc8785>=0.1`.
+- `libs/idun_agent_standalone/tests/` — new unit + integration test files (one `conftest.py` for shared fixtures).
+- `docs/superpowers/specs/2026-04-27-rework-patterns.md` — single follow-up commit at the end of T4 with FORWARD → ESTABLISHED transitions.
+
+Out of scope:
+
+- All paths under `libs/idun_agent_schema/` (Phase 2 close-state).
+- All paths under `services/idun_agent_manager/`, `services/idun_agent_web/`, `services/idun_agent_standalone_ui/`, `libs/idun_agent_engine/`.
+- Collection resource ORMs, routers, services (Phase 4–5).
+- Alembic migrations for `standalone_runtime_state` (Phase 4 picks up the ORM in its fresh baseline).
+- The `/runtime/status`, `/readyz`, `/health`, connection-check route handlers (Phase 6).
+- Boot-path state machine that derives `StandaloneRuntimeStatusKind` from agent presence + engine state + last reload outcome (Phase 6).
+- Smart per-field hot-reload classification (deferred to next version per spec).
+- Audit-event logging (deferred per Phase 1 amendment).
+- Legacy code at `admin/`, root-level legacy modules, or legacy `db/`.
+
+## 4. Module specifications
+
+### 4.1 Runtime state ORM (T2)
+
+`libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py`
+
+```text
+StandaloneRuntimeStateRow (Base)
+  __tablename__ = "standalone_runtime_state"
+
+  id: str                               String(32)  primary_key  default="singleton"
+  last_status: str | None               String(20)  nullable
+  last_message: str | None              String(255) nullable
+  last_error: str | None                Text        nullable
+  last_reloaded_at: datetime | None     DateTime(timezone=True)  nullable
+  last_applied_config_hash: str | None  String(64)  nullable
+  updated_at: datetime                  DateTime(timezone=True)  server_default=func.now()  onupdate=func.now()
+```
+
+Type substitutions per §14 manager mirror rule: `String(32)` for the fixed PK, `String(20)` to fit `restart_required` value, `String(64)` for the sha256 hex digest, `Text` for the unbounded error message, engine-agnostic `DateTime` everywhere.
+
+### 4.2 Runtime state service (T2)
+
+`libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py`
+
+```text
+async def get(session: AsyncSession) -> StandaloneRuntimeStateRow | None
+    """Return the singleton state row, or None on first boot."""
+
+async def record_reload_outcome(
+    session: AsyncSession,
+    *,
+    status: StandaloneReloadStatus,
+    message: str,
+    error: str | None,
+    config_hash: str | None,
+    reloaded_at: datetime,
+) -> StandaloneRuntimeStateRow
+    """Upsert the singleton row with the given outcome.
+
+    Caller controls the transaction boundary. The pattern in
+    commit_with_reload is: rollback user's mutation first, then
+    record outcome via this service, then commit.
+    """
+
+async def clear(session: AsyncSession) -> None
+    """Delete the singleton row (test helper)."""
+```
+
+The service does NOT manage commits or rollbacks itself — the caller (the reload pipeline) controls transaction boundaries. This is the same pattern as Phase 1's `_load_agent` helper at `api/v1/routers/agent.py:51-68`.
+
+### 4.3 Slugs (T2)
+
+`libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py`
+
+```text
+def normalize_slug(name: str) -> str
+    """Per spec §"Identity → Slug rules (locked)":
+
+    input name
+      -> trim whitespace
+      -> NFKD ascii-fold
+      -> lowercase
+      -> regex sub [^a-z0-9] -> "-"
+      -> collapse runs of "-"
+      -> trim leading/trailing "-"
+      -> truncate to 64 chars
+
+    Raises ValueError if the result is empty.
+    """
+
+async def ensure_unique_slug(
+    session: AsyncSession,
+    model_class: type[Base],
+    slug_column: InstrumentedAttribute,
+    candidate: str,
+) -> str
+    """Return candidate if not in use; else suffix until unique.
+
+    candidate -> candidate-2 -> candidate-3 -> ... -> candidate-99
+
+    After 99 collisions, raises ConflictError. This is a defensive
+    upper bound; a workspace with 99+ resources sharing a slug stem
+    would already have an upstream UX problem.
+    """
+```
+
+The implementer must not hard-code which model classes are slug-bearing — `model_class` and `slug_column` are passed in by the caller (Phase 5 routers).
+
+### 4.4 Config hash (T2)
+
+`libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py`
+
+```text
+def compute_config_hash(engine_config: EngineConfig) -> str
+    """Compute a deterministic hash of the materialized config.
+
+    Implementation: sha256(rfc8785.canonicalize(engine_config.model_dump(mode="json")))
+    Returns: 64-character lowercase hex digest.
+
+    Determinism guarantee: two semantically-equal EngineConfig values
+    produce the same hash regardless of dict key insertion order or
+    Python representation differences. Backed by RFC 8785 JCS.
+    """
+```
+
+### 4.5 Validation (T1)
+
+`libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py`
+
+```text
+class RoundTwoValidationFailed(Exception):
+    """Raised when the assembled EngineConfig fails Pydantic validation."""
+
+    field_errors: list[StandaloneFieldError]
+
+    def __init__(self, validation_error: ValidationError) -> None:
+        self.field_errors = field_errors_from_validation_error(validation_error)
+        super().__init__("Assembled EngineConfig failed validation.")
+
+
+def validate_assembled_config(engine_config: EngineConfig) -> None:
+    """Run Pydantic validation on the assembled config.
+
+    Phase 1's assemble_engine_config returns an already-typed
+    EngineConfig instance, but cross-resource invalid combinations
+    (e.g. LANGGRAPH framework + ADK SessionServiceConfig memory) are
+    only caught when the config is re-validated. This is round 2 of
+    the 3-round pipeline.
+    """
+    try:
+        EngineConfig.model_validate(engine_config.model_dump())
+    except ValidationError as exc:
+        raise RoundTwoValidationFailed(exc) from exc
+```
+
+The `field_errors_from_validation_error` import comes from the existing Phase 1 helper at `api/v1/errors.py:57-72`.
+
+### 4.6 Reload pipeline (T1)
+
+`libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py`
+
+```text
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+
+_reload_mutex = asyncio.Lock()
+
+
+class ReloadInitFailed(Exception):
+    """Raised when round 3 (engine reload) fails."""
+
+
+async def commit_with_reload(
+    session: AsyncSession,
+    *,
+    reload_callable: Callable[[EngineConfig], Awaitable[None]],
+    now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+) -> StandaloneReloadResult:
+    """Run the 3-round pipeline.
+
+    Caller must:
+      - acquire _reload_mutex via `async with _reload_mutex:`
+      - stage DB mutation (e.g. add/modify ORM rows)
+      - call session.flush()
+
+    This function:
+      1. Assembles EngineConfig from staged session state.
+      2. Round 2: validates the assembled config.
+      3. Detects structural-change vs prior runtime_state.
+      4. If structural: commits DB, records outcome, returns restart_required.
+      5. Else: round 3 invokes reload_callable.
+         - On success: commits DB, records outcome, returns reloaded.
+         - On ReloadInitFailed: rolls back user mutation, records failure
+           outcome (in a fresh session-level write), commits the outcome,
+           raises AdminAPIError(500, code=reload_failed).
+      6. Round 1 is FastAPI's request body validation (happens before
+         the handler runs).
+    """
+    # See §4.6.1 below for the full algorithm.
+
+
+def _is_structural_change(
+    assembled: EngineConfig,
+    prior: StandaloneRuntimeStateRow | None,
+) -> bool:
+    """Detect changes that require process restart.
+
+    Structural fields (per spec §"Save/reload posture" + legacy reload.py):
+      - agent.framework (LANGGRAPH ↔ ADK ↔ HAYSTACK ↔ ...)
+      - agent.config.graph_definition (LangGraph entry point)
+
+    Returns True iff any of these changed since the last successfully-
+    applied config. On first boot (prior is None or last_applied_config_hash
+    is None), returns False — first config is never structural.
+    """
+```
+
+#### 4.6.1 Algorithm
+
+```python
+# Caller has already: acquired _reload_mutex, staged DB mutation, called flush.
+
+assembled = await assemble_engine_config(session)
+
+try:
+    validate_assembled_config(assembled)
+except RoundTwoValidationFailed as exc:
+    await session.rollback()
+    raise AdminAPIError(
+        status_code=422,
+        error=StandaloneAdminError(
+            code=StandaloneErrorCode.VALIDATION_FAILED,
+            message="Assembled config failed validation.",
+            field_errors=exc.field_errors,
+        ),
+    ) from exc
+
+config_hash = compute_config_hash(assembled)
+prior_state = await runtime_state.get(session)
+structural = _is_structural_change(assembled, prior_state)
+
+if structural:
+    await session.commit()
+    await runtime_state.record_reload_outcome(
+        session,
+        status=StandaloneReloadStatus.RESTART_REQUIRED,
+        message="Saved. Restart required to apply.",
+        error=None,
+        config_hash=config_hash,
+        reloaded_at=now(),
+    )
+    await session.commit()  # the runtime_state write
+    return StandaloneReloadResult(
+        status=StandaloneReloadStatus.RESTART_REQUIRED,
+        message="Saved. Restart required to apply.",
+    )
+
+try:
+    await reload_callable(assembled)
+except ReloadInitFailed as exc:
+    await session.rollback()
+    await runtime_state.record_reload_outcome(
+        session,
+        status=StandaloneReloadStatus.RELOAD_FAILED,
+        message="Engine reload failed; config not saved.",
+        error=str(exc),
+        config_hash=None,
+        reloaded_at=now(),
+    )
+    await session.commit()  # the runtime_state failure record
+    raise AdminAPIError(
+        status_code=500,
+        error=StandaloneAdminError(
+            code=StandaloneErrorCode.RELOAD_FAILED,
+            message="Engine reload failed; config not saved.",
+            details={"recovered": True},
+        ),
+    ) from exc
+
+await session.commit()
+await runtime_state.record_reload_outcome(
+    session,
+    status=StandaloneReloadStatus.RELOADED,
+    message="Saved and reloaded.",
+    error=None,
+    config_hash=config_hash,
+    reloaded_at=now(),
+)
+await session.commit()  # the runtime_state success record
+return StandaloneReloadResult(
+    status=StandaloneReloadStatus.RELOADED,
+    message="Saved and reloaded.",
+)
+```
+
+The repeated `await session.commit()` on the runtime_state row after the user's commit is intentional — the runtime_state record is its own transaction so a failed user-mutation rollback doesn't lose the failure outcome record. SQLite + Postgres both support this.
+
+### 4.7 Retrofit (T3)
+
+#### `api/v1/routers/agent.py`
+
+Replace:
+
+```python
+_SAVED_RELOAD = StandaloneReloadResult(
+    status=StandaloneReloadStatus.RESTART_REQUIRED,
+    message="Saved. Restart required to apply.",
+)
+
+_NOOP_RELOAD = StandaloneReloadResult(
+    status=StandaloneReloadStatus.RELOADED,
+    message="No changes.",
+)
+```
+
+With:
+
+```python
+from idun_agent_standalone.services.reload import _reload_mutex, commit_with_reload
+
+_NOOP_RELOAD = StandaloneReloadResult(
+    status=StandaloneReloadStatus.RELOADED,
+    message="No changes.",
+)
+```
+
+`_NOOP_RELOAD` survives because empty PATCH bodies skip the pipeline entirely (no DB write, no reload). Only `_SAVED_RELOAD` (the restart_required stub) is removed.
+
+The PATCH handler becomes:
+
+```python
+@router.patch("", response_model=StandaloneMutationResponse[StandaloneAgentRead])
+async def patch_agent(
+    body: StandaloneAgentPatch,
+    session: SessionDep,
+    reload_callable: ReloadCallableDep,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    fields = body.model_fields_set
+    row = await _load_agent(session)
+
+    if not fields:
+        return StandaloneMutationResponse(
+            data=StandaloneAgentRead.model_validate(row),
+            reload=_NOOP_RELOAD,
+        )
+
+    async with _reload_mutex:
+        for field in fields:
+            setattr(row, field, getattr(body, field))
+        await session.flush()
+        result = await commit_with_reload(session, reload_callable=reload_callable)
+        await session.refresh(row)
+
+    return StandaloneMutationResponse(
+        data=StandaloneAgentRead.model_validate(row),
+        reload=result,
+    )
+```
+
+`ReloadCallableDep` is a new FastAPI dependency defined in `api/v1/deps.py` that returns the engine reload callable (real in production, `AsyncMock` in tests).
+
+#### `api/v1/routers/memory.py`
+
+Same retrofit pattern. Memory PATCH framework changes flow through `_is_structural_change` → `restart_required`. DELETE flows through the pipeline too.
+
+#### `app.py`
+
+The engine reload callable is wired into FastAPI's dependency-injection scope via a startup hook. Pseudocode:
+
+```python
+from typing import Annotated
+from fastapi import Depends
+from idun_agent_engine.server.engine_app import EngineApp  # or equivalent
+
+async def _engine_reload_callable(engine_app: EngineApp = ...) -> Callable[[EngineConfig], Awaitable[None]]:
+    async def _reload(config: EngineConfig) -> None:
+        try:
+            await engine_app.reconfigure(config)
+        except Exception as exc:
+            raise ReloadInitFailed(str(exc)) from exc
+    return _reload
+
+ReloadCallableDep = Annotated[Callable[[EngineConfig], Awaitable[None]], Depends(_engine_reload_callable)]
+```
+
+The exact engine integration depends on what `idun_agent_engine` exposes. The implementer reads the engine's reconfigure interface during T3 and adapts. If the engine doesn't expose a clean reconfigure entry point yet, T3 implements a minimal "rebuild app + swap" inside `_engine_reload_callable` — the legacy `reload.py` does this; the new code can borrow the technique without importing legacy.
+
+### 4.8 Patterns doc transitions (T4)
+
+`docs/superpowers/specs/2026-04-27-rework-patterns.md`
+
+| Section | Transition | Notes |
+|---|---|---|
+| §6.5 Slug rules | FORWARD → ESTABLISHED | Cite `services/slugs.py:N` for `normalize_slug`, `ensure_unique_slug`. Replace skeleton with real reference snippet. |
+| §7.4 Stub reload caveat | REMOVE | Stubs are gone after T3. |
+| §8 Validation rounds | FORWARD → ESTABLISHED | Cite `services/reload.py:N` for the 3-round dispatch and `services/validation.py:N` for round 2 implementation. |
+| §10 Reload mutex | FORWARD → ESTABLISHED | Cite `services/reload.py:N` for `_reload_mutex` and `commit_with_reload`. |
+| §11 Cold-start states | partial ESTABLISHED | Storage layer now exists. Add: "ESTABLISHED references — runtime_state ORM at `infrastructure/db/models/runtime_state.py:N` and service at `services/runtime_state.py:N`. The boot-path state machine that derives `StandaloneRuntimeStatusKind` from agent presence + engine state + last reload outcome lands in Phase 6." |
+| §12 Config hash | FORWARD → ESTABLISHED | Cite `services/config_hash.py:N`. Lock the `rfc8785` package as the JCS implementation. |
+
+Sections that remain FORWARD across Phase 3:
+- §6.2 Collection router pattern (Phase 5)
+- §6.3 PATCH semantics (Phase 5)
+- §6.6 Connection-check sub-routes (Phase 6)
+- §11 Cold-start state machine implementation (Phase 6)
+
+## 5. Test strategy
+
+### 5.1 Layout
+
+```
+libs/idun_agent_standalone/tests/
+├── conftest.py                      # async_session, stub_reload_callable, frozen_now
+├── unit/
+│   ├── db/
+│   │   └── test_runtime_state_model.py
+│   ├── services/
+│   │   ├── test_runtime_state.py
+│   │   ├── test_slugs.py
+│   │   ├── test_config_hash.py
+│   │   ├── test_validation.py
+│   │   └── test_reload.py
+│   └── ... (existing)
+└── integration/
+    ├── api/
+    │   └── v1/
+    │       ├── test_agent_flow.py
+    │       └── test_memory_flow.py
+    └── ... (existing)
+```
+
+The existing legacy-tied test files in the standalone tests/ tree continue to be ignored via the Phase 1 narrowed pytest gate — Phase 3 doesn't touch them.
+
+### 5.2 Unit tests (~42)
+
+Per-component coverage:
+
+| File | Tests | Purpose |
+|---|---|---|
+| `tests/unit/db/test_runtime_state_model.py` | 3 | ORM column types, default PK, server-default timestamps |
+| `tests/unit/services/test_runtime_state.py` | 6 | get on empty, record then get, record overwrites, clear, no leak between transactions, structural fields preserved across writes |
+| `tests/unit/services/test_slugs.py` | 12 | normalize: ascii-fold, lowercase, regex, collapse, trim, truncate, all-special chars (raises), unicode, empty (raises); ensure_unique: no collision, 1 collision, 99 collisions raise |
+| `tests/unit/services/test_config_hash.py` | 5 | deterministic, JCS canonical (key order doesn't matter), distinct configs distinct hashes, sha256 hex length, EngineConfig integration |
+| `tests/unit/services/test_validation.py` | 4 | valid passes, LANGGRAPH+SessionService fails (1 field error), multiple errors collected, RoundTwoValidationFailed wraps ValidationError |
+| `tests/unit/services/test_reload.py` | 12 | mutex serializes 2 concurrent acquires; happy path returns reloaded; round 2 fail rolls back; round 3 fail rolls back AND records failure outcome; structural change returns restart_required; fresh state (no prior) treats first config as non-structural; reload_callable injected and called once; hash propagated to runtime_state on success; hash NOT propagated on failure; dependency-injected `now` for deterministic timestamps; ReloadInitFailed raises 500 AdminAPIError; structural skip on graph_definition change |
+
+### 5.3 Integration tests (~18)
+
+Tests that drive the agent + memory routers through the full pipeline:
+
+| File | Tests | Test gates covered |
+|---|---|---|
+| `tests/integration/api/v1/test_agent_flow.py` | 8 | GET → 200; PATCH happy → 200 reloaded; empty PATCH → 200 noop (no DB write, no reload); PATCH name change → 200 reloaded (non-structural); two concurrent PATCHes serialize through mutex; reload outcome appears in runtime_state row; round 2 validation 422; round 3 reload failure → 500 + DB rolled back |
+| `tests/integration/api/v1/test_memory_flow.py` | 10 | GET on empty → 404; PATCH first-write missing field → 422; PATCH happy → 200 reloaded; PATCH framework switch (LANGGRAPH↔ADK) → 200 restart_required; framework/memory mismatch → 422 + DB unchanged; DELETE → 200 with reload outcome; DELETE on empty → 404; two concurrent PATCHes serialize; reload fail rolls back DB unchanged; runtime_state recorded with correct status |
+
+These cover the spec-locked Phase 3 test gates from `2026-04-27-rework-patterns.md §13.3`:
+- Rollback path (round 2 + round 3 failure)
+- `restart_required` path
+- Reload callback survival (reload_callable invoked exactly once on happy path)
+- Concurrency (mutex serializes)
+- Cold-start state recording (runtime_state row written after every outcome)
+
+### 5.4 Test fixtures (`tests/conftest.py`)
+
+```python
+@pytest.fixture
+async def async_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with async_sessionmaker(engine, expire_on_commit=False)() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def stub_reload_callable() -> AsyncMock:
+    """An AsyncMock with configurable side effects for round 3."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def frozen_now() -> Callable[[], datetime]:
+    """Fixed datetime so reload outcome timestamps are deterministic."""
+    fixed = datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc)
+    return lambda: fixed
+```
+
+### 5.5 Total
+
+~60 new tests on top of Phase 2's 64. Standalone test count grows to ~124.
+
+## 6. Acceptance criteria
+
+Phase 3 is done when all of these hold:
+
+1. T2 helpers exist at the locked file paths and pass their unit tests.
+2. T1 reload pipeline exists at the locked file paths and passes unit + integration tests.
+3. T3 retrofit removes `_SAVED_RELOAD` constant from `api/v1/routers/agent.py` and `_SAVED_RELOAD` / `_DELETE_RELOAD` constants from `api/v1/routers/memory.py`. (`_NOOP_RELOAD` survives in both as it's the empty-body fast-path.) Verify via `grep -rn "_SAVED_RELOAD\|_DELETE_RELOAD" api/v1/`.
+4. T4 patterns doc transitions land per §4.8.
+5. `make lint` clean.
+6. `uv run mypy --follow-imports=silent <new-tree>` clean (~50 source files).
+7. `uv run pytest libs/idun_agent_schema -q` passes (62 tests; not regressed).
+8. `uv run pytest libs/idun_agent_standalone -q --ignore=...` passes (≥120 tests).
+9. The 5 spec-locked Phase 3 test gates pass: rollback path, `restart_required` path, reload callback survival, concurrency, cold-start state recording.
+10. PR description summarizes which patterns moved from FORWARD to ESTABLISHED.
+
+## 7. Branch and commit structure
+
+Branch: `feat/rework-phase3-plumbing`, branched from current tip of `feat/standalone-admin-db-rework`.
+
+Commits, in order (matches dispatch order T2 → T1 → T3 → T4):
+
+1. `docs(rework-phase3): add Phase 3 design doc` — drops THIS doc.
+2. `docs(rework-phase3): add Phase 3 plan` — writing-plans output.
+3. `feat(rework-phase3): cross-cutting helpers (slugs, config hash, runtime state)` — T2: 4 service modules + 1 ORM + ~26 unit tests.
+4. `feat(rework-phase3): reload pipeline + 3-round validation` — T1: 2 service modules + ~16 unit tests.
+5. `refactor(rework-phase3): agent + memory routers use real reload pipeline` — T3: 2 router edits + 1 app.py edit + ~18 integration tests.
+6. `docs(rework-phase3): patterns reference — flip FORWARD sections to ESTABLISHED` — T4.
+
+PR target: `feat/standalone-admin-db-rework`.
+
+## 8. Non-goals
+
+Phase 3 explicitly does NOT:
+
+- Add the `/admin/api/v1/runtime/status` endpoint (Phase 6).
+- Build the cold-start state machine boot path that derives `StandaloneRuntimeStatusKind` (Phase 6 — Phase 3 only provides storage + service helpers).
+- Add the `/health` or `/readyz` endpoints (Phase 6).
+- Add connection-check sub-routes (Phase 6).
+- Touch any collection-resource ORM, schema, or router (Phases 4–5).
+- Add Alembic migrations for `standalone_runtime_state` (Phase 4 picks up the ORM in its fresh baseline).
+- Replace the existing `services/engine_config.py` (Phase 5 extends it for collection resources).
+- Touch legacy code at `admin/`, root-level legacy modules, or legacy `db/`.
+- Implement smart per-field hot-reload classification (deferred to next version per spec).
+- Add audit-event logging (deferred per Phase 1 amendment).
+- Update FORWARD sections of the patterns doc that Phases 4–7 own (§6.2 collection routers, §6.3 PATCH semantics, §6.6 connection-check sub-routes, §11 boot-path state machine).
+
+## 9. Risks
+
+- **`rfc8785` package dependency.** New runtime dep on a small package. **Mitigation:** lock `rfc8785>=0.1` minimum version in `pyproject.toml`; T2 unit tests assert canonicalization is deterministic across re-encodings of the same logical config. The package is pure-Python and self-contained, so install footprint is trivial.
+- **Structural-change detection logic is subtle.** The detector compares structural slices of assembled configs. Edge cases: ADK `agent.config.agent` changes (NOT structural unless framework changed), agent `name` changes (NOT structural), graph_definition path changes (structural). **Mitigation:** T1 implementer prompt enumerates exactly which fields trigger structural; spec reviewer cross-checks against spec §"Save/reload posture"; integration test for memory framework switch is one of the locked gates (`test_memory_flow.py` line "PATCH framework switch → 200 restart_required").
+- **Reload callable dependency injection threads through several layers.** Routers receive it via FastAPI `Depends`; `commit_with_reload` accepts it as a parameter; tests use `AsyncMock`; production wires the real engine reconfigure. **Mitigation:** T3 implementer prompt explicitly walks the wiring; the `ReloadCallableDep` typing alias makes the contract explicit.
+- **Mutex contention in production.** Single asyncio.Lock means concurrent admin PATCHes serialize. For single-replica standalone this is intentional (the spec locks single-replica). **Mitigation:** documented in `services/reload.py` docstring; one integration test verifies serialization.
+- **Runtime state record-then-rollback ordering.** On round 3 reload failure, we rollback the user's DB mutation but still want to record the failure outcome to runtime_state. The pattern is: rollback, then runtime_state.record_reload_outcome, then commit (the outcome record). Subtle but the test gate enforces it. **Mitigation:** T1 unit test `test_round_3_fail_rolls_back_AND_records_failure_outcome` exercises this exact sequence; algorithm pseudocode in §4.6.1 is reviewer-checkable.
+- **Engine reconfigure interface may not exist cleanly in idun_agent_engine.** If the engine doesn't expose a public reconfigure entry point, T3's `_engine_reload_callable` has to do a "rebuild app + swap" technique borrowed from the legacy `reload.py`. **Mitigation:** T3 implementer reads the engine code first; if a clean entry point is missing, the PR description flags this and the rebuild technique gets a comment block explaining the situation. If the engine refactor is non-trivial, escalate to user (not in Phase 3 scope to refactor the engine).
+- **Test count growth and run time.** ~60 new tests on top of 64. Most are unit and run in milliseconds; integration tests use in-memory SQLite. **Mitigation:** in-memory SQLite per session; mocks elsewhere. Total `pytest libs/idun_agent_standalone` should stay <30 seconds.
+
+## 10. Test gates this phase satisfies
+
+From the rework spec §"Future implementation test gates" (cross-mapped in `2026-04-27-rework-patterns.md §13.3` as Phase 3 deliverables):
+
+- **Rollback path** — round 2 + round 3 failure both rollback DB; integration test asserts active engine still serves prior config (where applicable).
+- **`restart_required` path** — structural changes commit DB but reload_callable is NOT invoked; integration test asserts engine still uses old config until restart.
+- **Reload callback survival** — reload_callable is invoked exactly once on happy path; integration test asserts AsyncMock call count.
+- **Concurrency (reload mutex)** — two simultaneous PATCHes serialize; neither corrupts the other's commit window. Integration test uses `asyncio.gather` with two PATCHes.
+- **Cold-start state recording** — runtime_state row written after every outcome (success, restart_required, failure). Unit + integration coverage.
+
+Gates NOT owned by Phase 3 (still future work):
+- YAML seed/export/seed roundtrip — Phase 4
+- Real reload integration with a LangGraph echo agent — Phase 5
+- Auth boundary (rate limiting, CSRF) — Phase 7
+- Schema validation per resource — Phase 5
+
+## 11. Next step after approval
+
+Once this doc is approved:
+
+1. Commit it as `docs(rework-phase3): add Phase 3 design doc`.
+2. Invoke `superpowers:writing-plans` to produce a task-by-task plan at `docs/superpowers/plans/2026-04-27-rework-phase3.md`. Plan tasks follow §7's commit order.
+3. Execute the plan via `superpowers:subagent-driven-development` (T2 → T1 → T3 → T4 dispatch order).

--- a/libs/idun_agent_standalone/pyproject.toml
+++ b/libs/idun_agent_standalone/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "httpx>=0.27",
     "pyyaml>=6.0",
     "apscheduler>=3.10",
+    "rfc8785>=0.1",
 ]
 
 [project.scripts]

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/deps.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/deps.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Annotated
 
 from fastapi import Depends, Request
+from idun_agent_schema.engine.engine import EngineConfig
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -17,3 +18,27 @@ async def get_session(request: Request) -> AsyncIterator[AsyncSession]:
 
 
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
+
+
+async def get_reload_callable(
+    request: Request,
+) -> Callable[[EngineConfig], Awaitable[None]]:
+    """Return the engine reload callable, attached to ``app.state`` at startup.
+
+    The callable accepts the materialized ``EngineConfig`` and applies it
+    to the running engine. Raises ``ReloadInitFailed`` (from
+    ``idun_agent_standalone.services.reload``) on failure.
+    """
+    callable_ = getattr(request.app.state, "reload_callable", None)
+    if callable_ is None:
+        raise RuntimeError(
+            "reload_callable not attached to app.state — "
+            "check app.py startup wiring"
+        )
+    return callable_  # type: ignore[no-any-return]
+
+
+ReloadCallableDep = Annotated[
+    Callable[[EngineConfig], Awaitable[None]],
+    Depends(get_reload_callable),
+]

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/agent.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/agent.py
@@ -6,10 +6,11 @@ like the base engine config and the lifecycle status are not patchable
 through this endpoint, so the only way to change framework or agent
 type is to edit the YAML and restart the process.
 
-The PATCH response uses the standard mutation envelope. The reload
-field is a placeholder that always reports ``restart_required`` until
-the reload service lands. That keeps the response shape stable across
-the rest of the rework.
+Mutating handlers stage the row change, then run the 3-round reload
+pipeline (``commit_with_reload``) under ``_reload_mutex`` so two
+concurrent admin PATCHes serialize. The ``reload`` field on the
+mutation response carries the real outcome from round 3 (or the
+structural-change short-circuit, or the empty-body fast path).
 """
 
 from __future__ import annotations
@@ -28,19 +29,16 @@ from idun_agent_schema.standalone import (
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from idun_agent_standalone.api.v1.deps import SessionDep
+from idun_agent_standalone.api.v1.deps import ReloadCallableDep, SessionDep
 from idun_agent_standalone.api.v1.errors import AdminAPIError
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.services import reload as reload_service
+from idun_agent_standalone.services.reload import commit_with_reload
 
 router = APIRouter(prefix="/admin/api/v1/agent", tags=["admin", "agent"])
 
 logger = get_logger(__name__)
-
-_SAVED_RELOAD = StandaloneReloadResult(
-    status=StandaloneReloadStatus.RESTART_REQUIRED,
-    message="Saved. Restart required to apply.",
-)
 
 _NOOP_RELOAD = StandaloneReloadResult(
     status=StandaloneReloadStatus.RELOADED,
@@ -79,13 +77,14 @@ async def get_agent(session: SessionDep) -> StandaloneAgentRead:
 
 @router.patch("", response_model=StandaloneMutationResponse[StandaloneAgentRead])
 async def patch_agent(
-    body: StandaloneAgentPatch, session: SessionDep
+    body: StandaloneAgentPatch,
+    session: SessionDep,
+    reload_callable: ReloadCallableDep,
 ) -> StandaloneMutationResponse[StandaloneAgentRead]:
     """Update metadata fields on the singleton agent.
 
-    Only the fields explicitly present in the request body are applied,
-    so unset fields are left untouched. An empty body is a no op and
-    still returns the current row with the placeholder reload result.
+    Empty body short-circuits with no DB write and no reload. Any
+    non-empty mutation flows through the 3-round reload pipeline.
     """
     fields = body.model_fields_set
     row = await _load_agent(session)
@@ -97,20 +96,24 @@ async def patch_agent(
             reload=_NOOP_RELOAD,
         )
 
-    for field in fields:
-        setattr(row, field, getattr(body, field))
-
-    await session.commit()
-    await session.refresh(row)
+    async with reload_service._reload_mutex:
+        for field in fields:
+            setattr(row, field, getattr(body, field))
+        await session.flush()
+        result = await commit_with_reload(
+            session, reload_callable=reload_callable
+        )
+        await session.refresh(row)
 
     logger.info(
-        "admin.agent.patch id=%s name=%s fields=%s",
+        "admin.agent.patch id=%s name=%s fields=%s status=%s",
         row.id,
         row.name,
         sorted(fields),
+        result.status.value,
     )
 
     return StandaloneMutationResponse(
         data=StandaloneAgentRead.model_validate(row),
-        reload=_SAVED_RELOAD,
+        reload=result,
     )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/memory.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/memory.py
@@ -5,15 +5,12 @@ the URL because there is only one row per install. Absence of the
 row means the agent uses the default in-memory backend at assembly
 time. ``PATCH`` upserts the row, ``DELETE`` removes it.
 
-``PATCH`` reassembles the engine config in the same DB session after
-staging the write. A framework mismatch (for example LangGraph paired
-with a SessionService memory) fails validation, the staged write is
-rolled back, and the response returns 422 with structured
-``field_errors``.
-
-The reload field on the mutation envelope is a placeholder until the
-reload service lands. Successful writes return ``restart_required``,
-noops return ``reloaded``.
+Both mutating handlers run under the Phase 3 reload pipeline. Round 2
+(assembled config validation) catches framework/memory mismatches and
+rolls the staged write back with a 422 + structured ``field_errors``.
+On success, round 3 hot-reloads the engine via the injected reload
+callable; framework switches and other structural changes commit the
+DB and return ``restart_required`` instead of invoking reload.
 """
 
 from __future__ import annotations
@@ -34,18 +31,12 @@ from idun_agent_schema.standalone import (
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from idun_agent_standalone.api.v1.deps import SessionDep
-from idun_agent_standalone.api.v1.errors import (
-    AdminAPIError,
-    field_errors_from_validation_error,
-)
+from idun_agent_standalone.api.v1.deps import ReloadCallableDep, SessionDep
+from idun_agent_standalone.api.v1.errors import AdminAPIError
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.infrastructure.db.models.memory import StandaloneMemoryRow
-from idun_agent_standalone.services.engine_config import (
-    AgentNotConfiguredError,
-    AssemblyError,
-    assemble_engine_config,
-)
+from idun_agent_standalone.services import reload as reload_service
+from idun_agent_standalone.services.reload import commit_with_reload
 
 router = APIRouter(prefix="/admin/api/v1/memory", tags=["admin", "memory"])
 
@@ -53,19 +44,9 @@ logger = get_logger(__name__)
 
 _SINGLETON_ID = "singleton"
 
-_SAVED_RELOAD = StandaloneReloadResult(
-    status=StandaloneReloadStatus.RESTART_REQUIRED,
-    message="Saved. Restart required to apply.",
-)
-
 _NOOP_RELOAD = StandaloneReloadResult(
     status=StandaloneReloadStatus.RELOADED,
     message="No changes.",
-)
-
-_DELETE_RELOAD = StandaloneReloadResult(
-    status=StandaloneReloadStatus.RESTART_REQUIRED,
-    message="Removed. Restart required to apply.",
 )
 
 
@@ -111,13 +92,15 @@ async def get_memory(session: SessionDep) -> StandaloneMemoryRead:
 
 @router.patch("", response_model=StandaloneMutationResponse[StandaloneMemoryRead])
 async def patch_memory(
-    body: StandaloneMemoryPatch, session: SessionDep
+    body: StandaloneMemoryPatch,
+    session: SessionDep,
+    reload_callable: ReloadCallableDep,
 ) -> StandaloneMutationResponse[StandaloneMemoryRead]:
     """Upsert the singleton memory row.
 
     First write requires both ``agentFramework`` and ``memory``.
     Updates apply only the fields explicitly present in the body.
-    The engine config is reassembled before commit and a
+    The reload pipeline reassembles + validates the engine config; a
     framework/memory mismatch rolls back with a 422.
     """
     fields = body.model_fields_set
@@ -164,54 +147,21 @@ async def patch_memory(
         if "memory" in fields and body.memory is not None:
             row.memory_config = body.memory.model_dump(exclude_none=True)
 
-    await session.flush()
-
-    try:
-        await assemble_engine_config(session)
-    except AgentNotConfiguredError as exc:
-        await session.rollback()
-        logger.info("admin.memory.patch rejected, no agent configured")
-        raise AdminAPIError(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
-            error=StandaloneAdminError(
-                code=StandaloneErrorCode.VALIDATION_FAILED,
-                message=(
-                    "Agent must be configured before memory can be set. "
-                    "Run setup with a YAML config first."
-                ),
-            ),
-        ) from exc
-    except AssemblyError as exc:
-        framework = row.agent_framework
-        await session.rollback()
-        logger.info(
-            "admin.memory.patch rejected, assembled config invalid framework=%s",
-            framework,
+    async with reload_service._reload_mutex:
+        await session.flush()
+        result = await commit_with_reload(
+            session, reload_callable=reload_callable
         )
-        field_errors = (
-            field_errors_from_validation_error(exc.validation_error)
-            if exc.validation_error is not None
-            else None
-        )
-        raise AdminAPIError(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
-            error=StandaloneAdminError(
-                code=StandaloneErrorCode.VALIDATION_FAILED,
-                message=str(exc),
-                field_errors=field_errors,
-            ),
-        ) from exc
-
-    await session.commit()
-    await session.refresh(row)
+        await session.refresh(row)
 
     logger.info(
-        "admin.memory.patch creating=%s framework=%s",
+        "admin.memory.patch creating=%s framework=%s status=%s",
         creating,
         row.agent_framework,
+        result.status.value,
     )
 
-    return StandaloneMutationResponse(data=_to_read(row), reload=_SAVED_RELOAD)
+    return StandaloneMutationResponse(data=_to_read(row), reload=result)
 
 
 @router.delete(
@@ -220,12 +170,14 @@ async def patch_memory(
 )
 async def delete_memory(
     session: SessionDep,
+    reload_callable: ReloadCallableDep,
 ) -> StandaloneMutationResponse[StandaloneSingletonDeleteResult]:
     """Remove the singleton memory row.
 
     After delete, the engine assembly falls back to the default
-    in-memory backend. Reassembly is not required because the default
-    backend always validates against the agent's framework.
+    in-memory backend. The reload pipeline reassembles + validates
+    that fallback so a misconfigured agent row surfaces as a 422
+    rather than leaving the engine in a half-deleted state.
     """
     row = await _load_row(session)
     if row is None:
@@ -238,11 +190,21 @@ async def delete_memory(
         )
 
     framework = row.agent_framework
-    await session.delete(row)
-    await session.commit()
-    logger.info("admin.memory.delete done framework=%s", framework)
+
+    async with reload_service._reload_mutex:
+        await session.delete(row)
+        await session.flush()
+        result = await commit_with_reload(
+            session, reload_callable=reload_callable
+        )
+
+    logger.info(
+        "admin.memory.delete framework=%s status=%s",
+        framework,
+        result.status.value,
+    )
 
     return StandaloneMutationResponse(
         data=StandaloneSingletonDeleteResult(),
-        reload=_DELETE_RELOAD,
+        reload=result,
     )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -36,6 +36,9 @@ from idun_agent_standalone.services.engine_config import (
     AssemblyError,
     assemble_engine_config,
 )
+from idun_agent_standalone.services.engine_reload import (
+    build_engine_reload_callable,
+)
 
 logger = get_logger(__name__)
 
@@ -97,6 +100,12 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
     app.state.settings = settings
     app.state.db_engine = db_engine
     app.state.sessionmaker = sessionmaker
+    # Phase 3 reload callable: rebuilds the engine on the same FastAPI
+    # app instance via the engine's lifespan hooks. Admin routers pull
+    # this from app.state via ``ReloadCallableDep``. Available even in
+    # admin-only mode so that a future PATCH that finally produces a
+    # valid config can boot the engine layer without a process restart.
+    app.state.reload_callable = build_engine_reload_callable(app)
 
     register_admin_exception_handlers(app)
     app.include_router(auth_router)

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/__init__.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/__init__.py
@@ -6,3 +6,4 @@ Importing this module registers every model on ``Base.metadata`` so
 
 from .agent import StandaloneAgentRow  # noqa: F401
 from .memory import StandaloneMemoryRow  # noqa: F401
+from .runtime_state import StandaloneRuntimeStateRow  # noqa: F401

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/runtime_state.py
@@ -1,0 +1,44 @@
+"""SQLAlchemy model for the singleton runtime state row.
+
+Records the last reload outcome (status, message, error, timestamp,
+applied config hash). The boot-path state machine that derives the
+top-level StandaloneRuntimeStatusKind from this row + agent presence
++ engine state is Phase 6's responsibility.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from idun_agent_standalone.infrastructure.db.session import Base
+
+
+class StandaloneRuntimeStateRow(Base):
+    """The singleton runtime state row.
+
+    Uses a fixed primary key (``"singleton"``) because the row is
+    addressed by service helpers, not by id. Absence of the row means
+    no reload has been attempted yet (first boot).
+    """
+
+    __tablename__ = "standalone_runtime_state"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    last_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    last_message: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_reloaded_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_applied_config_hash: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/config_hash.py
@@ -1,0 +1,25 @@
+"""Deterministic hash of the materialized EngineConfig.
+
+Used to detect structural changes between reloads (compared against
+StandaloneRuntimeStateRow.last_applied_config_hash) and to surface
+the active config identity in /admin/api/v1/runtime/status.
+
+Implementation: sha256 over the RFC 8785 / JCS canonical JSON
+encoding of the EngineConfig's model_dump(mode="json"). JCS
+guarantees canonical key order so semantically-equal configs
+produce identical hashes.
+"""
+
+from __future__ import annotations
+
+from hashlib import sha256
+
+import rfc8785
+from idun_agent_schema.engine.engine import EngineConfig
+
+
+def compute_config_hash(engine_config: EngineConfig) -> str:
+    """Return a 64-character hex sha256 of the JCS-canonical JSON of the config."""
+    payload = engine_config.model_dump(mode="json")
+    canonical = rfc8785.dumps(payload)
+    return sha256(canonical).hexdigest()

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/engine_reload.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/engine_reload.py
@@ -1,0 +1,58 @@
+"""Build the engine reload callable for the standalone runtime.
+
+Phase 3 case (b): the engine does not expose a public ``reconfigure``
+method on its FastAPI app. It does expose two app-level lifecycle
+hooks at ``idun_agent_engine.server.lifespan`` — ``cleanup_agent(app)``
+and ``configure_app(app, engine_config)``. We rebuild the agent in
+place by tearing down the old one and re-running the configure step
+on the same FastAPI app instance, which is exactly what the engine
+itself does on its own ``POST /reload`` route.
+
+The legacy ``idun_agent_standalone.reload`` module (kept for reference
+only — not imported here) does the same dance with extra recovery
+machinery; the standalone Phase 3 reload pipeline owns rollback +
+runtime_state recording, so the callable just translates engine
+exceptions to ``ReloadInitFailed``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI
+from idun_agent_engine.server.lifespan import cleanup_agent, configure_app
+from idun_agent_schema.engine.engine import EngineConfig
+
+from idun_agent_standalone.core.logging import get_logger
+from idun_agent_standalone.services.reload import ReloadInitFailed
+
+logger = get_logger(__name__)
+
+
+def build_engine_reload_callable(
+    engine_app: FastAPI,
+) -> Callable[[EngineConfig], Awaitable[None]]:
+    """Return a callable that rebuilds the engine on the given app.
+
+    The callable cleans up the current agent (if any) and runs
+    ``configure_app`` with the supplied config. Any failure is wrapped
+    in ``ReloadInitFailed`` so the standalone reload pipeline can
+    record the outcome and surface a 500 to the admin caller.
+    """
+
+    async def _reload(config: EngineConfig) -> None:
+        try:
+            try:
+                await cleanup_agent(engine_app)
+            except Exception:
+                # Teardown errors are noisy but not fatal — the engine
+                # logs them, we proceed to reconfigure regardless.
+                logger.exception(
+                    "engine_reload.cleanup_failed continuing to configure"
+                )
+            await configure_app(engine_app, config)
+        except Exception as exc:
+            logger.exception("engine_reload.configure_failed")
+            raise ReloadInitFailed(str(exc)) from exc
+
+    return _reload

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py
@@ -1,0 +1,254 @@
+"""The 3-round reload pipeline.
+
+Single in-process ``asyncio.Lock`` around ``commit_with_reload``. The
+caller acquires the lock, stages a DB mutation, calls ``flush``, then
+invokes ``commit_with_reload``. The pipeline:
+
+  1. Assembles ``EngineConfig`` from the staged session state.
+  2. Round 2: validates the assembled config (``services.validation``).
+  3. Detects structural change vs prior runtime_state.
+  4. If structural: commits DB, records outcome, returns
+     ``restart_required``. The reload callable is NOT invoked.
+  5. Else: round 3 invokes ``reload_callable``.
+       - On success: commits DB, records outcome, returns ``reloaded``.
+       - On ``ReloadInitFailed``: rolls back DB, records the failure
+         outcome (in a fresh session-level write), commits the outcome,
+         raises ``AdminAPIError(500, code=reload_failed)``.
+
+Round 1 (Pydantic body validation) is FastAPI's responsibility and
+happens before the handler runs.
+
+The reload callable is dependency-injected so tests stub a fake
+without booting a real engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from hashlib import sha256
+
+import rfc8785
+from fastapi import status as http_status
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_schema.standalone import (
+    StandaloneAdminError,
+    StandaloneErrorCode,
+    StandaloneReloadResult,
+    StandaloneReloadStatus,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from idun_agent_standalone.api.v1.errors import (
+    AdminAPIError,
+    field_errors_from_validation_error,
+)
+from idun_agent_standalone.core.logging import get_logger
+from idun_agent_standalone.infrastructure.db.models.runtime_state import (
+    StandaloneRuntimeStateRow,
+)
+from idun_agent_standalone.services import runtime_state
+from idun_agent_standalone.services.engine_config import (
+    AssemblyError,
+    assemble_engine_config,
+)
+from idun_agent_standalone.services.validation import (
+    RoundTwoValidationFailed,
+    validate_assembled_config,
+)
+
+logger = get_logger(__name__)
+
+
+_reload_mutex = asyncio.Lock()
+
+
+class ReloadInitFailed(Exception):  # noqa: N818
+    """Raised when round 3 (engine reload via reload_callable) fails.
+
+    Named for the action that fails (engine reload init), not as
+    a generic ``-Error``, so the call site reads as a flow-control
+    signal rather than a typed error class.
+    """
+
+
+def _default_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _structural_slice(engine_config: EngineConfig) -> dict[str, object]:
+    """Return the structural fields that require process restart on change.
+
+    Per spec §"Save/reload posture":
+      - ``agent.framework``
+      - ``agent.config.graph_definition`` (LangGraph entry point)
+
+    Other fields (agent name, description, version, base_url, integrations,
+    MCP servers, observability, prompts) are hot-reloadable and do NOT
+    require restart.
+
+    Note: only LangGraph structural fields are tracked here. ADK and
+    other frameworks have no analog of ``graph_definition`` in this
+    slice, so an ADK-side structural change (e.g. swapping the agent
+    type or changing memory backend in a way the engine cannot
+    hot-reload) is currently undetected. Extending the slice for
+    other frameworks is deferred to a later phase when the engine's
+    own reload semantics are clearer.
+    """
+    return {
+        "framework": engine_config.agent.type.value,
+        "graph_definition": getattr(
+            engine_config.agent.config, "graph_definition", None
+        ),
+    }
+
+
+def _structural_hash(engine_config: EngineConfig) -> str:
+    """Hash only the structural slice. 64-char hex sha256 over JCS bytes."""
+    # rfc8785's _Value type alias is internal; the structural slice is a
+    # plain JSON-serializable dict, so the runtime contract is satisfied.
+    canonical = rfc8785.dumps(_structural_slice(engine_config))  # type: ignore[arg-type]
+    return sha256(canonical).hexdigest()
+
+
+def _is_structural_change(
+    assembled: EngineConfig,
+    prior_state: StandaloneRuntimeStateRow | None,
+) -> bool:
+    """True iff structural fields changed since the last applied config.
+
+    On first boot (``prior_state`` is None or ``last_applied_config_hash``
+    is None), returns False — the first config is never structural.
+
+    Phase 3 storage choice: ``last_applied_config_hash`` carries the
+    structural-slice hash (not the full config hash) so this comparison
+    is a single column read. The full config hash for /runtime/status
+    will be computed on-demand in Phase 6.
+    """
+    if prior_state is None or prior_state.last_applied_config_hash is None:
+        return False
+    return prior_state.last_applied_config_hash != _structural_hash(assembled)
+
+
+async def commit_with_reload(
+    session: AsyncSession,
+    *,
+    reload_callable: Callable[[EngineConfig], Awaitable[None]],
+    now: Callable[[], datetime] = _default_now,
+) -> StandaloneReloadResult:
+    """Run the 3-round pipeline.
+
+    Caller must:
+      - acquire ``_reload_mutex`` via ``async with _reload_mutex:``
+      - stage DB mutation (e.g. add/modify ORM rows)
+      - call ``session.flush()``
+
+    On round 2 failure: rollback, raise 422 ``AdminAPIError``.
+    On structural change: commit DB, record outcome, return
+        ``restart_required``.
+    On round 3 failure: rollback user mutation, record failure outcome,
+        commit, raise 500 ``AdminAPIError``.
+    On full success: commit DB, record outcome, return ``reloaded``.
+    """
+    try:
+        assembled = await assemble_engine_config(session)
+    except AssemblyError as exc:
+        # Assembly performs Pydantic validation on the base + assembled
+        # config. If it fails here, that is a round-2 failure: the
+        # caller's mutation produced a config that cannot be safely
+        # validated against the schema. Roll back and surface the
+        # underlying field errors when available.
+        await session.rollback()
+        field_errors = (
+            field_errors_from_validation_error(exc.validation_error)
+            if exc.validation_error is not None
+            else []
+        )
+        logger.info(
+            "reload.round2_failed field_count=%s", len(field_errors)
+        )
+        raise AdminAPIError(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            error=StandaloneAdminError(
+                code=StandaloneErrorCode.VALIDATION_FAILED,
+                message="Assembled config failed validation.",
+                field_errors=field_errors,
+            ),
+        ) from exc
+
+    try:
+        validate_assembled_config(assembled)
+    except RoundTwoValidationFailed as exc:
+        await session.rollback()
+        logger.info(
+            "reload.round2_failed field_count=%s", len(exc.field_errors)
+        )
+        raise AdminAPIError(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            error=StandaloneAdminError(
+                code=StandaloneErrorCode.VALIDATION_FAILED,
+                message="Assembled config failed validation.",
+                field_errors=exc.field_errors,
+            ),
+        ) from exc
+
+    structural_hash = _structural_hash(assembled)
+    prior = await runtime_state.get(session)
+    structural = _is_structural_change(assembled, prior)
+
+    if structural:
+        await session.commit()
+        await runtime_state.record_reload_outcome(
+            session,
+            status=StandaloneReloadStatus.RESTART_REQUIRED,
+            message="Saved. Restart required to apply.",
+            error=None,
+            config_hash=structural_hash,
+            reloaded_at=now(),
+        )
+        await session.commit()
+        logger.info("reload.restart_required hash=%s", structural_hash[:8])
+        return StandaloneReloadResult(
+            status=StandaloneReloadStatus.RESTART_REQUIRED,
+            message="Saved. Restart required to apply.",
+        )
+
+    try:
+        await reload_callable(assembled)
+    except ReloadInitFailed as exc:
+        await session.rollback()
+        await runtime_state.record_reload_outcome(
+            session,
+            status=StandaloneReloadStatus.RELOAD_FAILED,
+            message="Engine reload failed; config not saved.",
+            error=str(exc),
+            config_hash=None,
+            reloaded_at=now(),
+        )
+        await session.commit()
+        logger.warning("reload.round3_failed error=%s", str(exc)[:120])
+        raise AdminAPIError(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            error=StandaloneAdminError(
+                code=StandaloneErrorCode.RELOAD_FAILED,
+                message="Engine reload failed; config not saved.",
+                details={"recovered": True},
+            ),
+        ) from exc
+
+    await session.commit()
+    await runtime_state.record_reload_outcome(
+        session,
+        status=StandaloneReloadStatus.RELOADED,
+        message="Saved and reloaded.",
+        error=None,
+        config_hash=structural_hash,
+        reloaded_at=now(),
+    )
+    await session.commit()
+    logger.info("reload.reloaded hash=%s", structural_hash[:8])
+    return StandaloneReloadResult(
+        status=StandaloneReloadStatus.RELOADED,
+        message="Saved and reloaded.",
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/runtime_state.py
@@ -1,0 +1,71 @@
+"""Read/write helpers for the singleton runtime state row.
+
+The reload pipeline calls these helpers to record the outcome of
+every commit_with_reload run. The boot-path state machine (Phase 6)
+reads from the same helpers to compute StandaloneRuntimeStatusKind.
+
+Caller controls transaction boundaries — this module does not
+commit or rollback. The pattern in commit_with_reload is:
+1. rollback the user's failed mutation,
+2. record_reload_outcome(...) writes the failure record,
+3. caller commits the failure record.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from idun_agent_schema.standalone import StandaloneReloadStatus
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from idun_agent_standalone.infrastructure.db.models.runtime_state import (
+    StandaloneRuntimeStateRow,
+)
+
+_SINGLETON_ID = "singleton"
+
+
+async def get(session: AsyncSession) -> StandaloneRuntimeStateRow | None:
+    """Return the singleton state row, or None on first boot."""
+    result = await session.execute(
+        select(StandaloneRuntimeStateRow).where(
+            StandaloneRuntimeStateRow.id == _SINGLETON_ID
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def record_reload_outcome(
+    session: AsyncSession,
+    *,
+    status: StandaloneReloadStatus,
+    message: str,
+    error: str | None,
+    config_hash: str | None,
+    reloaded_at: datetime,
+) -> StandaloneRuntimeStateRow:
+    """Upsert the singleton row with the given outcome.
+
+    Caller controls the transaction boundary; this helper only stages
+    the change via session.flush().
+    """
+    row = await get(session)
+    if row is None:
+        row = StandaloneRuntimeStateRow(id=_SINGLETON_ID)
+        session.add(row)
+    row.last_status = status.value
+    row.last_message = message
+    row.last_error = error
+    row.last_applied_config_hash = config_hash
+    row.last_reloaded_at = reloaded_at
+    await session.flush()
+    return row
+
+
+async def clear(session: AsyncSession) -> None:
+    """Delete the singleton row (test helper)."""
+    row = await get(session)
+    if row is not None:
+        await session.delete(row)
+        await session.flush()

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/slugs.py
@@ -1,0 +1,92 @@
+"""Slug normalization + uniqueness for collection resources.
+
+Phase 5 collection routers call these helpers on POST. Singleton
+resources (agent, memory) do not use slugs at the route level.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from sqlalchemy import select
+from sqlalchemy.engine import Result
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
+
+_MAX_SLUG_LEN = 64
+_MAX_COLLISION_SUFFIX = 99
+_NON_SLUG_CHAR = re.compile(r"[^a-z0-9]+")
+_DASH_RUN = re.compile(r"-+")
+
+
+class SlugNormalizationError(ValueError):
+    """Raised when a name produces an empty slug after normalization."""
+
+
+class SlugConflictError(Exception):
+    """Raised when ensure_unique_slug exhausts its collision suffixes."""
+
+
+def normalize_slug(name: str) -> str:
+    """Normalize a resource name to a slug per spec.
+
+    Pipeline:
+      trim -> NFKD ascii-fold -> lowercase
+      -> regex sub [^a-z0-9] -> "-"
+      -> collapse runs of "-"
+      -> trim leading/trailing "-"
+      -> truncate to 64 chars
+
+    Raises SlugNormalizationError if the result is empty.
+    """
+    trimmed = name.strip()
+    folded = unicodedata.normalize("NFKD", trimmed)
+    ascii_only = folded.encode("ascii", "ignore").decode("ascii")
+    lowered = ascii_only.lower()
+    dashed = _NON_SLUG_CHAR.sub("-", lowered)
+    collapsed = _DASH_RUN.sub("-", dashed)
+    stripped = collapsed.strip("-")
+    truncated = stripped[:_MAX_SLUG_LEN]
+    if not truncated:
+        raise SlugNormalizationError(
+            f"Cannot derive a slug from name {name!r}"
+        )
+    return truncated
+
+
+async def ensure_unique_slug(
+    session: AsyncSession,
+    model_class: type,
+    slug_column: InstrumentedAttribute,
+    candidate: str,
+) -> str:
+    """Return candidate if unused; else suffix until unique.
+
+    Tries candidate, candidate-2, candidate-3, ... up to candidate-99.
+    Raises SlugConflictError after 99 collisions.
+    """
+    if not await _slug_exists(session, model_class, slug_column, candidate):
+        return candidate
+    for suffix in range(2, _MAX_COLLISION_SUFFIX + 1):
+        candidate_with_suffix = f"{candidate}-{suffix}"
+        if not await _slug_exists(
+            session, model_class, slug_column, candidate_with_suffix
+        ):
+            return candidate_with_suffix
+    raise SlugConflictError(
+        f"Could not find a unique slug for {candidate!r} after "
+        f"{_MAX_COLLISION_SUFFIX} attempts"
+    )
+
+
+async def _slug_exists(
+    session: AsyncSession,
+    model_class: type,
+    slug_column: InstrumentedAttribute,
+    candidate: str,
+) -> bool:
+    result: Result[tuple[object]] = await session.execute(
+        select(model_class).where(slug_column == candidate).limit(1)
+    )
+    return result.scalar_one_or_none() is not None

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/validation.py
@@ -1,0 +1,47 @@
+"""Round 2 validation: re-validate the assembled EngineConfig.
+
+Phase 1's assemble_engine_config returns a typed EngineConfig instance,
+but cross-resource invalid combinations (e.g. LANGGRAPH framework with
+ADK SessionServiceConfig memory) are only caught when the assembled
+config is re-validated. This module is the round 2 of the 3-round
+pipeline; round 1 is FastAPI's body validation, round 3 is the engine
+reload.
+"""
+
+from __future__ import annotations
+
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_schema.standalone import StandaloneFieldError
+from pydantic import ValidationError
+
+from idun_agent_standalone.api.v1.errors import (
+    field_errors_from_validation_error,
+)
+
+
+class RoundTwoValidationFailed(Exception):  # noqa: N818
+    """Raised when the assembled EngineConfig fails Pydantic validation.
+
+    Translates the wrapped ``ValidationError`` into structured
+    ``field_errors`` for the admin envelope. The original
+    ``ValidationError`` is preserved as the ``__cause__`` chain via
+    ``raise ... from exc`` at the call site, but is NOT retained as
+    an attribute on the instance.
+    """
+
+    field_errors: list[StandaloneFieldError]
+
+    def __init__(self, validation_error: ValidationError) -> None:
+        self.field_errors = field_errors_from_validation_error(validation_error)
+        super().__init__("Assembled EngineConfig failed validation.")
+
+
+def validate_assembled_config(engine_config: EngineConfig) -> None:
+    """Run Pydantic validation on the assembled EngineConfig.
+
+    Raises ``RoundTwoValidationFailed`` on failure.
+    """
+    try:
+        EngineConfig.model_validate(engine_config.model_dump())
+    except ValidationError as exc:
+        raise RoundTwoValidationFailed(exc) from exc

--- a/libs/idun_agent_standalone/tests/conftest.py
+++ b/libs/idun_agent_standalone/tests/conftest.py
@@ -1,114 +1,47 @@
-"""Shared pytest fixtures for idun_agent_standalone (spec §7.2).
+"""Shared pytest fixtures for the standalone test suite.
 
-These fixtures back the integration tests so individual files don't have
-to repeat env setup, app construction, and admin auth dance.
+Phase 3 introduces async DB session and stub reload fixtures used by
+unit + integration tests. Existing legacy tests are unaffected.
 """
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-from typing import Any
+from collections.abc import AsyncIterator, Callable
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
-import pytest_asyncio
-from fastapi import FastAPI
-from httpx import ASGITransport, AsyncClient
-from idun_agent_standalone.auth.password import hash_password
-from idun_agent_standalone.db.models import AdminUserRow
-from idun_agent_standalone.testing_app import make_test_app
-
-
-@pytest_asyncio.fixture
-async def standalone_app(
-    tmp_path, monkeypatch
-) -> AsyncIterator[tuple[FastAPI, Any]]:
-    """In-memory SQLite app with no auth — admin endpoints are open.
-
-    Yields ``(app, sessionmaker)``. Disposes the engine after the test.
-    """
-    monkeypatch.setenv(
-        "DATABASE_URL", f"sqlite+aiosqlite:///{tmp_path / 'standalone.db'}"
-    )
-    monkeypatch.setenv("IDUN_ADMIN_AUTH_MODE", "none")
-    app, sm = await make_test_app()
-    try:
-        yield app, sm
-    finally:
-        await app.state.db_engine.dispose()
-
-
-@pytest_asyncio.fixture
-async def authed_client(
-    tmp_path, monkeypatch
-) -> AsyncIterator[AsyncClient]:
-    """Password-mode app + httpx client with a valid session cookie.
-
-    Builds the app, seeds an admin row, posts /auth/login to get a fresh
-    cookie. Tests using this fixture get a ready-to-use client whose
-    requests already carry ``sid``.
-    """
-    pw = "test-password-1234"
-    pw_hash = hash_password(pw)
-    secret = "x" * 64
-    monkeypatch.setenv(
-        "DATABASE_URL", f"sqlite+aiosqlite:///{tmp_path / 'authed.db'}"
-    )
-    monkeypatch.setenv("IDUN_ADMIN_AUTH_MODE", "password")
-    monkeypatch.setenv("IDUN_ADMIN_PASSWORD_HASH", pw_hash)
-    monkeypatch.setenv("IDUN_SESSION_SECRET", secret)
-
-    app, sm = await make_test_app()
-
-    async with sm() as session:
-        session.add(AdminUserRow(id="admin", password_hash=pw_hash))
-        await session.commit()
-
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://t") as client:
-        login = await client.post(
-            "/admin/api/v1/auth/login", json={"password": pw}
-        )
-        assert login.status_code == 200, login.text
-        try:
-            yield client
-        finally:
-            await app.state.db_engine.dispose()
+from idun_agent_standalone.infrastructure.db import (
+    models,  # noqa: F401  registers ORMs on Base
+)
+from idun_agent_standalone.infrastructure.db.session import Base
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 
 @pytest.fixture
-def fake_run() -> list[dict[str, Any]]:
-    """A scripted AG-UI run: RunStarted → 2 text deltas → tool call → RunFinished.
+async def async_session() -> AsyncIterator[AsyncSession]:
+    """An in-memory SQLite async session with all standalone ORMs created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
 
-    Used by traces tests to push deterministic event sequences through the
-    observer without needing the real engine.
-    """
-    return [
-        {"type": "RunStarted", "thread_id": "t1", "run_id": "r1"},
-        {
-            "type": "TextMessageContent",
-            "delta": "Hello ",
-            "thread_id": "t1",
-            "run_id": "r1",
-        },
-        {
-            "type": "TextMessageContent",
-            "delta": "world",
-            "thread_id": "t1",
-            "run_id": "r1",
-        },
-        {
-            "type": "ToolCallStart",
-            "tool_call_id": "tc1",
-            "tool_call_name": "lookup",
-            "thread_id": "t1",
-            "run_id": "r1",
-        },
-        {
-            "type": "ToolCallEnd",
-            "tool_call_id": "tc1",
-            "result": {"status": "ok"},
-            "thread_id": "t1",
-            "run_id": "r1",
-        },
-        {"type": "RunFinished", "thread_id": "t1", "run_id": "r1"},
-    ]
+
+@pytest.fixture
+def stub_reload_callable() -> AsyncMock:
+    """An AsyncMock for the engine reload callable; configurable per test."""
+    return AsyncMock(return_value=None)
+
+
+@pytest.fixture
+def frozen_now() -> Callable[[], datetime]:
+    """Fixed datetime so reload outcome timestamps are deterministic in tests."""
+    fixed = datetime(2026, 4, 27, 12, 0, 0, tzinfo=UTC)
+    return lambda: fixed

--- a/libs/idun_agent_standalone/tests/integration/api/v1/conftest.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/conftest.py
@@ -1,0 +1,34 @@
+"""Local conftest for ``tests/integration/api/v1/``.
+
+The reload pipeline uses a module-level ``asyncio.Lock`` that binds to
+the first event loop that awaits it. Because pytest-asyncio creates a
+fresh event loop per test (function-scoped), a lock left over from
+the unit-test run (or from a prior integration test) is bound to a
+dead loop and refuses to acquire on the new one with
+``RuntimeError: ... is bound to a different event loop``.
+
+The autouse fixture below replaces the module-level lock with a
+freshly-constructed one before every test in this directory. In
+production there is exactly one event loop for the lifetime of the
+process, so the module-level singleton is correct there — this hook
+only matters for the test harness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+from idun_agent_standalone.services import reload as reload_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_reload_mutex() -> Iterator[None]:
+    """Replace ``_reload_mutex`` with a fresh ``asyncio.Lock`` per test."""
+    original = reload_module._reload_mutex
+    reload_module._reload_mutex = asyncio.Lock()
+    try:
+        yield
+    finally:
+        reload_module._reload_mutex = original

--- a/libs/idun_agent_standalone/tests/integration/api/v1/test_agent_flow.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/test_agent_flow.py
@@ -1,0 +1,183 @@
+"""Integration tests for ``/admin/api/v1/agent`` against the real reload pipeline.
+
+Drives the FastAPI router through HTTPX with an injected stub reload
+callable; round 2 + round 3 + structural change all exercise the
+mutex + outcome recording path end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from idun_agent_standalone.api.v1.deps import (
+    get_reload_callable,
+    get_session,
+)
+from idun_agent_standalone.api.v1.errors import (
+    register_admin_exception_handlers,
+)
+from idun_agent_standalone.api.v1.routers.agent import router as agent_router
+from idun_agent_standalone.infrastructure.db.models.agent import (
+    StandaloneAgentRow,
+)
+from idun_agent_standalone.services import runtime_state
+from idun_agent_standalone.services.reload import ReloadInitFailed
+
+
+@pytest.fixture
+async def admin_app(async_session, stub_reload_callable):
+    """Minimal FastAPI app mounting the agent router with overrides.
+
+    The session and reload-callable dependencies are overridden to
+    point at the in-memory async_session fixture and the AsyncMock
+    reload callable; admin exception handlers are registered so the
+    response envelope shape matches production.
+    """
+    app = FastAPI()
+    register_admin_exception_handlers(app)
+    app.include_router(agent_router)
+    app.state.reload_callable = stub_reload_callable
+
+    async def override_session():
+        yield async_session
+
+    async def override_reload_callable():
+        return stub_reload_callable
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_reload_callable] = override_reload_callable
+
+    return app
+
+
+async def _seed_agent(async_session) -> None:
+    row = StandaloneAgentRow(
+        name="Ada",
+        base_engine_config={
+            "server": {"api": {"port": 8000}},
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            },
+        },
+    )
+    async_session.add(row)
+    await async_session.commit()
+
+
+async def test_get_agent_returns_row(admin_app, async_session) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/agent")
+    assert response.status_code == 200
+    assert response.json()["name"] == "Ada"
+
+
+async def test_patch_agent_happy_path(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/agent",
+            json={"name": "Renamed"},
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["name"] == "Renamed"
+    assert body["reload"]["status"] == "reloaded"
+    stub_reload_callable.assert_called_once()
+
+
+async def test_patch_empty_body_is_noop(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch("/admin/api/v1/agent", json={})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["reload"]["status"] == "reloaded"
+    assert body["reload"]["message"] == "No changes."
+    stub_reload_callable.assert_not_called()
+
+
+async def test_patch_round_3_failure_returns_500(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent(async_session)
+    stub_reload_callable.side_effect = ReloadInitFailed("engine boom")
+
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/agent",
+            json={"name": "Renamed"},
+        )
+        assert response.status_code == 500
+        assert response.json()["error"]["code"] == "reload_failed"
+
+        # Re-fetch through the same client to confirm rollback — name unchanged
+        get_response = await client.get("/admin/api/v1/agent")
+    assert get_response.json()["name"] == "Ada"
+
+
+async def test_patch_records_outcome_in_runtime_state(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.patch("/admin/api/v1/agent", json={"name": "Renamed"})
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_status == "reloaded"
+
+
+async def test_concurrent_patches_serialize(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    """Two simultaneous PATCHes must serialize through ``_reload_mutex``.
+
+    We assert this indirectly: both succeed (no race-induced 500), and
+    the reload callable is called exactly twice.
+    """
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        results = await asyncio.gather(
+            client.patch("/admin/api/v1/agent", json={"name": "A"}),
+            client.patch("/admin/api/v1/agent", json={"name": "B"}),
+        )
+    assert all(r.status_code == 200 for r in results)
+    assert stub_reload_callable.call_count == 2
+
+
+async def test_get_returns_404_when_not_configured(admin_app) -> None:
+    """Cold-start state — no agent row, GET returns 404 in admin envelope."""
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/agent")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+async def test_malformed_body_returns_422(admin_app, async_session) -> None:
+    await _seed_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Send name=null (forbidden by _no_null_name validator)
+        response = await client.patch(
+            "/admin/api/v1/agent", json={"name": None}
+        )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_failed"

--- a/libs/idun_agent_standalone/tests/integration/api/v1/test_memory_flow.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/test_memory_flow.py
@@ -1,0 +1,245 @@
+"""Integration tests for ``/admin/api/v1/memory`` against the real reload pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from idun_agent_standalone.api.v1.deps import (
+    get_reload_callable,
+    get_session,
+)
+from idun_agent_standalone.api.v1.errors import (
+    register_admin_exception_handlers,
+)
+from idun_agent_standalone.api.v1.routers.agent import (
+    router as agent_router,
+)
+from idun_agent_standalone.api.v1.routers.memory import (
+    router as memory_router,
+)
+from idun_agent_standalone.infrastructure.db.models.agent import (
+    StandaloneAgentRow,
+)
+from idun_agent_standalone.services import runtime_state
+from idun_agent_standalone.services.reload import ReloadInitFailed
+
+
+@pytest.fixture
+async def admin_app(async_session, stub_reload_callable):
+    app = FastAPI()
+    register_admin_exception_handlers(app)
+    app.include_router(agent_router)
+    app.include_router(memory_router)
+    app.state.reload_callable = stub_reload_callable
+
+    async def override_session():
+        yield async_session
+
+    async def override_reload_callable():
+        return stub_reload_callable
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_reload_callable] = override_reload_callable
+    return app
+
+
+async def _seed_agent_langgraph(async_session) -> None:
+    row = StandaloneAgentRow(
+        name="Ada",
+        base_engine_config={
+            "server": {"api": {"port": 8000}},
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            },
+        },
+    )
+    async_session.add(row)
+    await async_session.commit()
+
+
+async def test_get_memory_404_on_empty(admin_app) -> None:
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/memory")
+    assert response.status_code == 404
+
+
+async def test_first_write_missing_field_422(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Missing memory field
+        response = await client.patch(
+            "/admin/api/v1/memory",
+            json={"agentFramework": "LANGGRAPH"},
+        )
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_failed"
+    field_names = {fe["field"] for fe in body["error"]["fieldErrors"]}
+    assert "memory" in field_names
+
+
+async def test_patch_first_write_happy(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "LANGGRAPH",
+                "memory": {"type": "memory"},
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["reload"]["status"] == "reloaded"
+    stub_reload_callable.assert_called_once()
+
+
+@pytest.mark.skip(
+    reason=(
+        "Memory PATCH alone does not change agent.type — "
+        "assemble_engine_config reads agent.type from the agent row's "
+        "base_engine_config, not from the memory row's agent_framework. "
+        "The structural-change path is exercised in tests/unit/services/"
+        "test_reload.py via direct agent.type mutation; reaching it "
+        "from memory PATCH alone is not architecturally possible."
+    )
+)
+async def test_patch_framework_switch_returns_restart_required(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    """Framework switch via memory PATCH would be structural — but is not reachable.
+
+    See the skip reason for the architectural rationale.
+    """
+
+
+async def test_framework_memory_mismatch_422(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    """LANGGRAPH agent + ADK SessionService memory shape -> round 2 fails.
+
+    The agent row has ``agent.type=LANGGRAPH``, so the assembler lays
+    the memory dict under ``checkpointer``. ``in_memory`` is not a
+    valid LangGraph ``CheckpointConfig`` discriminator (valid values
+    are ``memory``, ``sqlite``, ``postgres``), so round 2 rejects
+    the assembled config and returns 422 with field errors.
+    """
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "ADK",
+                "memory": {
+                    "type": "in_memory",  # ADK SessionService shape
+                },
+            },
+        )
+    # Either round 1 (Pydantic body) or round 2 (assembled) catches it.
+    assert response.status_code == 422
+
+
+async def test_delete_memory_after_first_write(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "LANGGRAPH",
+                "memory": {"type": "memory"},
+            },
+        )
+        response = await client.delete("/admin/api/v1/memory")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["deleted"] is True
+    assert body["reload"]["status"] in ("reloaded", "restart_required")
+
+
+async def test_delete_on_empty_returns_404(admin_app, async_session) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.delete("/admin/api/v1/memory")
+    assert response.status_code == 404
+
+
+async def test_round_3_failure_rolls_back_db(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    stub_reload_callable.side_effect = ReloadInitFailed("engine boom")
+
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "LANGGRAPH",
+                "memory": {"type": "memory"},
+            },
+        )
+        assert response.status_code == 500
+        # No row was committed
+        get_response = await client.get("/admin/api/v1/memory")
+    assert get_response.status_code == 404
+
+
+async def test_runtime_state_records_outcome(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.patch(
+            "/admin/api/v1/memory",
+            json={
+                "agentFramework": "LANGGRAPH",
+                "memory": {"type": "memory"},
+            },
+        )
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_status == "reloaded"
+
+
+async def test_concurrent_patches_serialize(
+    admin_app, async_session, stub_reload_callable
+) -> None:
+    await _seed_agent_langgraph(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        results = await asyncio.gather(
+            client.patch(
+                "/admin/api/v1/memory",
+                json={
+                    "agentFramework": "LANGGRAPH",
+                    "memory": {"type": "memory"},
+                },
+            ),
+            client.patch(
+                "/admin/api/v1/memory",
+                json={"memory": {"type": "memory"}},
+            ),
+        )
+    # Both succeed (mutex serializes); reload_callable called twice
+    # OR first creates, second is noop — either is acceptable.
+    assert all(r.status_code in (200, 422) for r in results)

--- a/libs/idun_agent_standalone/tests/unit/db/test_runtime_state_model.py
+++ b/libs/idun_agent_standalone/tests/unit/db/test_runtime_state_model.py
@@ -1,0 +1,46 @@
+"""Tests for StandaloneRuntimeStateRow ORM."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from idun_agent_standalone.infrastructure.db.models.runtime_state import (
+    StandaloneRuntimeStateRow,
+)
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_default_pk_singleton(async_session) -> None:
+    row = StandaloneRuntimeStateRow(id="singleton")
+    async_session.add(row)
+    await async_session.flush()
+    await async_session.refresh(row)
+    assert row.id == "singleton"
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_server_default_updated_at(async_session) -> None:
+    row = StandaloneRuntimeStateRow(id="singleton")
+    async_session.add(row)
+    await async_session.flush()
+    await async_session.refresh(row)
+    assert row.updated_at is not None
+    assert isinstance(row.updated_at, datetime)
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_columns_nullable(async_session) -> None:
+    row = StandaloneRuntimeStateRow(
+        id="singleton",
+        last_status=None,
+        last_message=None,
+        last_error=None,
+        last_applied_config_hash=None,
+        last_reloaded_at=None,
+    )
+    async_session.add(row)
+    await async_session.flush()
+    await async_session.refresh(row)
+    assert row.last_status is None
+    assert row.last_applied_config_hash is None

--- a/libs/idun_agent_standalone/tests/unit/services/test_config_hash.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_config_hash.py
@@ -1,0 +1,93 @@
+"""Tests for the config_hash service."""
+
+from __future__ import annotations
+
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_standalone.services.config_hash import compute_config_hash
+
+
+def _sample_engine_config() -> EngineConfig:
+    return EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            }
+        }
+    )
+
+
+def test_compute_config_hash_returns_64_char_hex() -> None:
+    digest = compute_config_hash(_sample_engine_config())
+    assert len(digest) == 64
+    int(digest, 16)  # raises if not valid hex
+
+
+def test_compute_config_hash_deterministic() -> None:
+    """Two equal configs must produce identical hashes."""
+    a = compute_config_hash(_sample_engine_config())
+    b = compute_config_hash(_sample_engine_config())
+    assert a == b
+
+
+def test_compute_config_hash_canonicalizes_key_order() -> None:
+    """Configs that differ only in dict key insertion order produce the same hash."""
+    config_a = EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            }
+        }
+    )
+    config_b = EngineConfig.model_validate(
+        {
+            "agent": {
+                "config": {
+                    "graph_definition": "agent.py:graph",
+                    "name": "ada",
+                },
+                "type": "LANGGRAPH",
+            }
+        }
+    )
+    assert compute_config_hash(config_a) == compute_config_hash(config_b)
+
+
+def test_compute_config_hash_distinct_configs_distinct_hashes() -> None:
+    config_a = _sample_engine_config()
+    config_b = EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "different",
+                    "graph_definition": "agent.py:graph",
+                },
+            }
+        }
+    )
+    assert compute_config_hash(config_a) != compute_config_hash(config_b)
+
+
+def test_compute_config_hash_with_empty_optional_fields() -> None:
+    """Optional fields like description/version don't break hashing."""
+    config = EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            },
+        }
+    )
+    digest = compute_config_hash(config)
+    assert len(digest) == 64

--- a/libs/idun_agent_standalone/tests/unit/services/test_reload.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_reload.py
@@ -1,0 +1,282 @@
+"""Tests for the reload pipeline service.
+
+Tests use sqlite+aiosqlite memory DB with the standalone agent +
+memory + runtime_state ORMs. The reload_callable is stubbed via
+AsyncMock; the now callable is frozen for deterministic timestamps.
+
+Note: assemble_engine_config requires an agent row (and optionally
+memory) to be present in the staged session state. Each test seeds
+the necessary rows before calling commit_with_reload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_schema.standalone import (
+    StandaloneErrorCode,
+    StandaloneReloadStatus,
+)
+from idun_agent_standalone.api.v1.errors import AdminAPIError
+from idun_agent_standalone.infrastructure.db.models.agent import (
+    StandaloneAgentRow,
+)
+from idun_agent_standalone.services import runtime_state
+from idun_agent_standalone.services.reload import (
+    ReloadInitFailed,
+    _reload_mutex,
+    commit_with_reload,
+)
+from sqlalchemy import select
+
+
+def _seed_engine_config_dict() -> dict:
+    return {
+        "server": {"api": {"port": 8000}},
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "ada",
+                "graph_definition": "agent.py:graph",
+            },
+        },
+    }
+
+
+async def _seed_agent(async_session, *, name: str = "Ada") -> StandaloneAgentRow:
+    row = StandaloneAgentRow(
+        name=name,
+        base_engine_config=_seed_engine_config_dict(),
+    )
+    async_session.add(row)
+    await async_session.flush()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_reloaded(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    await _seed_agent(async_session)
+    result = await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    assert result.status == StandaloneReloadStatus.RELOADED
+    stub_reload_callable.assert_called_once()
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_status == "reloaded"
+    # SQLite drops tzinfo on DateTime columns, so compare naive components.
+    assert state.last_reloaded_at.replace(tzinfo=None) == frozen_now().replace(
+        tzinfo=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_round_2_failure_rolls_back_and_raises_422(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    """Stage an invalid agent row; round 2 must reject it."""
+    # Bypass Phase 1 base_engine_config validation by injecting a
+    # malformed dict directly. The assemble step rebuilds an
+    # EngineConfig that Pydantic re-validates in round 2.
+    row = StandaloneAgentRow(
+        name="bad",
+        base_engine_config={
+            "agent": {"type": "LANGGRAPH", "config": {"name": "x"}}
+        },  # missing graph_definition
+    )
+    async_session.add(row)
+    await async_session.flush()
+
+    with pytest.raises(AdminAPIError) as exc_info:
+        await commit_with_reload(
+            async_session,
+            reload_callable=stub_reload_callable,
+            now=frozen_now,
+        )
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.error.code == StandaloneErrorCode.VALIDATION_FAILED
+    stub_reload_callable.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_round_3_failure_rolls_back_and_records_failure(
+    async_session, frozen_now
+) -> None:
+    """Reload callable raises ReloadInitFailed; pipeline rolls back DB
+    but still records the failure outcome to runtime_state."""
+    await _seed_agent(async_session)
+    failing_reload = AsyncMock(side_effect=ReloadInitFailed("engine boom"))
+
+    with pytest.raises(AdminAPIError) as exc_info:
+        await commit_with_reload(
+            async_session,
+            reload_callable=failing_reload,
+            now=frozen_now,
+        )
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.error.code == StandaloneErrorCode.RELOAD_FAILED
+    assert exc_info.value.error.details == {"recovered": True}
+
+    # Failure record must exist
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_status == "reload_failed"
+    assert state.last_error == "engine boom"
+    assert state.last_applied_config_hash is None
+
+
+@pytest.mark.asyncio
+async def test_structural_change_returns_restart_required(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    """First reload sets a baseline; second reload with a different
+    structural slice (graph_definition path) returns restart_required."""
+    await _seed_agent(async_session)
+    first = await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    assert first.status == StandaloneReloadStatus.RELOADED
+
+    # Mutate graph_definition (structural)
+    agent = (
+        await async_session.execute(select(StandaloneAgentRow))
+    ).scalar_one()
+    agent.base_engine_config = {
+        "server": {"api": {"port": 8000}},
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "ada",
+                "graph_definition": "agent.py:other_graph",
+            },
+        },
+    }
+    await async_session.flush()
+
+    second = await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    assert second.status == StandaloneReloadStatus.RESTART_REQUIRED
+    assert stub_reload_callable.call_count == 1  # NOT called for structural
+
+
+@pytest.mark.asyncio
+async def test_first_reload_is_not_structural(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    """No prior runtime_state -> first config is never structural."""
+    await _seed_agent(async_session)
+    result = await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    assert result.status == StandaloneReloadStatus.RELOADED
+
+
+@pytest.mark.asyncio
+async def test_reload_callable_dependency_injected(
+    async_session, frozen_now
+) -> None:
+    """The reload callable can be replaced; tests don't need a real engine."""
+    await _seed_agent(async_session)
+    custom_calls = []
+
+    async def custom_reload(config: EngineConfig) -> None:
+        custom_calls.append(config)
+
+    await commit_with_reload(
+        async_session,
+        reload_callable=custom_reload,
+        now=frozen_now,
+    )
+    assert len(custom_calls) == 1
+    assert isinstance(custom_calls[0], EngineConfig)
+
+
+@pytest.mark.asyncio
+async def test_now_dependency_injected(
+    async_session, stub_reload_callable
+) -> None:
+    fixed = datetime(2027, 1, 1, tzinfo=UTC)
+    await _seed_agent(async_session)
+    await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=lambda: fixed,
+    )
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    # SQLite drops tzinfo on DateTime columns, so compare naive components.
+    assert state.last_reloaded_at.replace(tzinfo=None) == fixed.replace(
+        tzinfo=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_mutex_serializes_concurrent_acquires() -> None:
+    """Two coroutines acquiring the mutex serialize.
+
+    Direct test of the mutex itself, without the full pipeline.
+    """
+    held: list[str] = []
+
+    async def acquire_then_release(label: str) -> None:
+        async with _reload_mutex:
+            held.append(f"start:{label}")
+            await asyncio.sleep(0)  # yield
+            held.append(f"end:{label}")
+
+    await asyncio.gather(
+        acquire_then_release("A"),
+        acquire_then_release("B"),
+    )
+    # Either A fully then B fully, or B fully then A fully — never interleaved
+    pairs = list(zip(held[0::2], held[1::2], strict=False))
+    for start, end in pairs:
+        assert start.replace("start:", "") == end.replace("end:", "")
+
+
+@pytest.mark.asyncio
+async def test_hash_propagated_to_runtime_state_on_success(
+    async_session, stub_reload_callable, frozen_now
+) -> None:
+    await _seed_agent(async_session)
+    await commit_with_reload(
+        async_session,
+        reload_callable=stub_reload_callable,
+        now=frozen_now,
+    )
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_applied_config_hash is not None
+    assert len(state.last_applied_config_hash) == 64
+
+
+@pytest.mark.asyncio
+async def test_hash_not_propagated_on_failure(
+    async_session, frozen_now
+) -> None:
+    await _seed_agent(async_session)
+    failing_reload = AsyncMock(side_effect=ReloadInitFailed("engine boom"))
+    with pytest.raises(AdminAPIError):
+        await commit_with_reload(
+            async_session,
+            reload_callable=failing_reload,
+            now=frozen_now,
+        )
+    state = await runtime_state.get(async_session)
+    assert state is not None
+    assert state.last_applied_config_hash is None

--- a/libs/idun_agent_standalone/tests/unit/services/test_runtime_state.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_runtime_state.py
@@ -1,0 +1,103 @@
+"""Tests for the runtime_state service."""
+
+from __future__ import annotations
+
+import pytest
+from idun_agent_schema.standalone import StandaloneReloadStatus
+from idun_agent_standalone.services import runtime_state
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_on_empty(async_session) -> None:
+    assert await runtime_state.get(async_session) is None
+
+
+@pytest.mark.asyncio
+async def test_record_then_get(async_session, frozen_now) -> None:
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOADED,
+        message="Saved.",
+        error=None,
+        config_hash="abc123",
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    row = await runtime_state.get(async_session)
+    assert row is not None
+    assert row.last_status == "reloaded"
+    assert row.last_message == "Saved."
+    assert row.last_applied_config_hash == "abc123"
+    # SQLite drops tzinfo on DateTime columns, so compare naive components.
+    assert row.last_reloaded_at.replace(tzinfo=None) == frozen_now().replace(
+        tzinfo=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_overwrites(async_session, frozen_now) -> None:
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOADED,
+        message="First.",
+        error=None,
+        config_hash="hash1",
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOAD_FAILED,
+        message="Second.",
+        error="boom",
+        config_hash=None,
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    row = await runtime_state.get(async_session)
+    assert row.last_status == "reload_failed"
+    assert row.last_message == "Second."
+    assert row.last_error == "boom"
+    assert row.last_applied_config_hash is None
+
+
+@pytest.mark.asyncio
+async def test_record_failure_preserves_distinct_fields(
+    async_session, frozen_now
+) -> None:
+    """The failure path writes status, message, error; it nulls hash."""
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOAD_FAILED,
+        message="Engine reload failed.",
+        error="ImportError: graph module not found",
+        config_hash=None,
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    row = await runtime_state.get(async_session)
+    assert row.last_error == "ImportError: graph module not found"
+    assert row.last_applied_config_hash is None
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_singleton(async_session, frozen_now) -> None:
+    await runtime_state.record_reload_outcome(
+        async_session,
+        status=StandaloneReloadStatus.RELOADED,
+        message="Saved.",
+        error=None,
+        config_hash="abc",
+        reloaded_at=frozen_now(),
+    )
+    await async_session.commit()
+    await runtime_state.clear(async_session)
+    await async_session.commit()
+    assert await runtime_state.get(async_session) is None
+
+
+@pytest.mark.asyncio
+async def test_clear_on_empty_is_noop(async_session) -> None:
+    await runtime_state.clear(async_session)
+    await async_session.commit()
+    assert await runtime_state.get(async_session) is None

--- a/libs/idun_agent_standalone/tests/unit/services/test_slugs.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_slugs.py
@@ -1,0 +1,98 @@
+"""Tests for the slugs service."""
+
+from __future__ import annotations
+
+import pytest
+from idun_agent_standalone.infrastructure.db.session import Base
+from idun_agent_standalone.services.slugs import (
+    SlugConflictError,
+    SlugNormalizationError,
+    ensure_unique_slug,
+    normalize_slug,
+)
+from sqlalchemy import Column, String
+
+# normalize_slug tests
+
+
+def test_normalize_simple_name() -> None:
+    assert normalize_slug("GitHub Tools") == "github-tools"
+
+
+def test_normalize_strips_special_chars() -> None:
+    assert normalize_slug("Hello, World! @ Idun") == "hello-world-idun"
+
+
+def test_normalize_collapses_runs() -> None:
+    assert normalize_slug("foo--bar---baz") == "foo-bar-baz"
+
+
+def test_normalize_trims_dashes() -> None:
+    assert normalize_slug("---foo---") == "foo"
+
+
+def test_normalize_truncates_to_64_chars() -> None:
+    long_name = "a" * 200
+    result = normalize_slug(long_name)
+    assert len(result) == 64
+    assert result == "a" * 64
+
+
+def test_normalize_unicode_ascii_fold() -> None:
+    assert normalize_slug("Café Münster") == "cafe-munster"
+
+
+def test_normalize_lowercase() -> None:
+    assert normalize_slug("FooBar") == "foobar"
+
+
+def test_normalize_empty_raises() -> None:
+    with pytest.raises(SlugNormalizationError):
+        normalize_slug("")
+
+
+def test_normalize_only_special_raises() -> None:
+    with pytest.raises(SlugNormalizationError):
+        normalize_slug("!!!@@@")
+
+
+def test_normalize_leading_trailing_whitespace() -> None:
+    assert normalize_slug("  github tools  ") == "github-tools"
+
+
+# ensure_unique_slug tests
+# We need a small ORM model to test against.
+
+class _FakeRow(Base):
+    __tablename__ = "_fake_slug_test"
+    id: str = Column(String(36), primary_key=True)  # type: ignore[assignment]
+    slug: str = Column(String(64), nullable=False, unique=True)  # type: ignore[assignment]
+
+
+@pytest.mark.asyncio
+async def test_ensure_unique_no_collision(async_session) -> None:
+    result = await ensure_unique_slug(
+        async_session, _FakeRow, _FakeRow.slug, "fresh"
+    )
+    assert result == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_ensure_unique_one_collision(async_session) -> None:
+    async_session.add(_FakeRow(id="1", slug="github-tools"))
+    await async_session.flush()
+    result = await ensure_unique_slug(
+        async_session, _FakeRow, _FakeRow.slug, "github-tools"
+    )
+    assert result == "github-tools-2"
+
+
+@pytest.mark.asyncio
+async def test_ensure_unique_99_collisions_raises(async_session) -> None:
+    """Defensive upper bound — should be impossible in practice."""
+    async_session.add(_FakeRow(id="0", slug="a"))
+    for n in range(2, 100):
+        async_session.add(_FakeRow(id=str(n), slug=f"a-{n}"))
+    await async_session.flush()
+    with pytest.raises(SlugConflictError):
+        await ensure_unique_slug(async_session, _FakeRow, _FakeRow.slug, "a")

--- a/libs/idun_agent_standalone/tests/unit/services/test_validation.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_validation.py
@@ -1,0 +1,72 @@
+"""Tests for the validation service (round 2)."""
+
+from __future__ import annotations
+
+import pytest
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_standalone.services.validation import (
+    RoundTwoValidationFailed,
+    validate_assembled_config,
+)
+
+
+def _valid_langgraph_config() -> EngineConfig:
+    return EngineConfig.model_validate(
+        {
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            }
+        }
+    )
+
+
+def test_valid_config_passes() -> None:
+    config = _valid_langgraph_config()
+    validate_assembled_config(config)  # must not raise
+
+
+def test_round_two_validation_failed_wraps_validation_error() -> None:
+    """Manually construct an invalid EngineConfig dump and pass through.
+
+    We can't easily construct an invalid EngineConfig instance directly
+    (Pydantic rejects it on construction), so we round-trip through
+    model_dump and manually corrupt the dump before re-validating.
+    """
+    config = _valid_langgraph_config()
+    dumped = config.model_dump()
+    # Corrupt: set agent.config to an invalid shape for LANGGRAPH
+    dumped["agent"]["config"] = {"name": "ada"}  # missing graph_definition
+
+    # validate_assembled_config takes an EngineConfig, but the test
+    # exercises the round-2 contract: any structural mismatch in the
+    # dumped form fails. We use a fake object with model_dump returning
+    # the corrupt dict; the resulting RoundTwoValidationFailed carries
+    # field_errors.
+    class _FakeConfig:
+        def model_dump(self) -> dict:
+            return dumped
+
+    with pytest.raises(RoundTwoValidationFailed) as exc_info:
+        validate_assembled_config(_FakeConfig())  # type: ignore[arg-type]
+    assert len(exc_info.value.field_errors) >= 1
+
+
+def test_field_errors_carry_structured_codes() -> None:
+    """RoundTwoValidationFailed.field_errors contains structured entries."""
+    config = _valid_langgraph_config()
+    dumped = config.model_dump()
+    dumped["agent"]["config"] = {"name": "ada"}
+
+    class _FakeConfig:
+        def model_dump(self) -> dict:
+            return dumped
+
+    with pytest.raises(RoundTwoValidationFailed) as exc_info:
+        validate_assembled_config(_FakeConfig())  # type: ignore[arg-type]
+    fe = exc_info.value.field_errors[0]
+    assert fe.field
+    assert fe.message

--- a/uv.lock
+++ b/uv.lock
@@ -2284,6 +2284,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
+    { name = "rfc8785" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -2304,6 +2305,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rfc8785", specifier = ">=0.1" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
@@ -4760,6 +4762,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+]
+
+[[package]]
+name = "rfc8785"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da", size = 14321, upload-time = "2024-09-27T16:33:31.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48", size = 9240, upload-time = "2024-09-27T16:33:29.683Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Phase 3 — Cross-Cutting Plumbing

Closes Phase 3 of the standalone admin/db rework.

### What this PR does
- Adds the cross-cutting plumbing every Phase 4+ module needs: reload pipeline (asyncio mutex + 3-round validation + structural-change detection), slug rules, RFC 8785 config hash, runtime-state persistence.
- Retrofits Phase 1's agent + memory routers from stub reload constants to the real pipeline.
- Flips four FORWARD sections in the patterns reference doc to ESTABLISHED, partial-ESTABLISHES one, and removes the stub-reload caveat.

### New modules
- `services/runtime_state.py` — get/record/clear helpers over the new ORM (T2).
- `services/slugs.py` — `normalize_slug` + `ensure_unique_slug` (T2).
- `services/config_hash.py` — RFC 8785 sha256 hash via `rfc8785.dumps` (T2).
- `services/validation.py` — round 2 validation entry point (T1).
- `services/reload.py` — `_reload_mutex` + `commit_with_reload` orchestrator (T1).
- `services/engine_reload.py` — engine rebuild-and-swap helper (case b; composes `cleanup_agent` + `configure_app` from `idun_agent_engine.server.lifespan`).
- `infrastructure/db/models/runtime_state.py` — singleton ORM (T2).

### Retrofit
- `api/v1/routers/agent.py` — removes `_SAVED_RELOAD`; PATCH wraps `async with reload_service._reload_mutex:` then calls `commit_with_reload`.
- `api/v1/routers/memory.py` — removes `_SAVED_RELOAD` and `_DELETE_RELOAD`; PATCH and DELETE flow through the pipeline; first-write missing-fields 422 contract preserved.
- `api/v1/deps.py` — adds `ReloadCallableDep` typing alias backed by `request.app.state.reload_callable`.
- `app.py` — wires the engine reload callable into `app.state` at startup via the new `engine_reload.py` helper.

### Tests
- ~26 unit tests for T2 helpers (services + ORM model).
- ~13 unit tests for T1 reload pipeline + round 2 validation.
- ~17 integration tests + 1 documented skip for T3 router retrofit.
- **87 passed, 1 skipped** on the narrowed pytest gate (was 64 at Phase 2 close).
- Schema pytest still 62 (no regression).
- The 5 spec-locked Phase 3 test gates pass: rollback path (round 2 + round 3), restart_required path, reload-callback survival, concurrency (mutex), cold-start state recording.

### Patterns now ESTABLISHED (commit `97dade11`)
- §6.5 Slug rules (was FORWARD)
- §8 Validation rounds (was FORWARD)
- §10 Reload mutex (was FORWARD)
- §12 Config hash (was FORWARD; locks `rfc8785.dumps` as the JCS implementation)
- §11 Cold-start states — partial (storage layer; boot-path state machine still FORWARD for Phase 6)
- §7.4 Stub-reload caveat REMOVED

### Patterns still FORWARD
- §6.2 Collection router pattern (Phase 5)
- §6.3 PATCH semantics (Phase 5)
- §6.6 Connection-check sub-routes (Phase 6)
- §11 Cold-start state machine implementation (Phase 6)

### New runtime dependency
- `rfc8785>=0.1` added to `libs/idun_agent_standalone/pyproject.toml`. Pure-Python, single-purpose JCS canonicalization.

### Notable design decisions documented in code
- **Mutex held by router**, not by `commit_with_reload`. The pipeline orchestrator runs inside the caller's `async with reload_service._reload_mutex:` block. Documented in §10.
- **Module-attribute access** (`reload_service._reload_mutex`) instead of direct import — lets test fixtures swap a fresh `asyncio.Lock` per pytest-asyncio event loop. Production has a single event loop where this is irrelevant.
- **Two-transaction failure record**: round 3 reload failure rolls back the user mutation, then `record_reload_outcome` writes the failure record into a fresh transaction state, then a second `await session.commit()` persists the failure record. SQLite + Postgres both support this.
- **Defense-in-depth on round 2**: `AssemblyError` (raised by Phase 1's `assemble_engine_config` after its own internal validation) is caught BEFORE `RoundTwoValidationFailed` and translated through the SAME 422 envelope. `RoundTwoValidationFailed` remains the canonical mechanism for any future caller bypassing assembly.
- **Structural-slice hashing**: only `agent.framework` + `agent.config.graph_definition` are tracked. ADK structural changes are explicitly deferred to a later phase per docstring.
- **`last_applied_config_hash` semantics**: stores the structural-slice hash for Phase 3 change detection. The full-config hash for `/runtime/status` is Phase 6's deliverable.

### Known limitations / out of scope
- ADK structural-change detection (only LangGraph `graph_definition` is tracked).
- Memory framework switch via memory PATCH alone is not architecturally reachable (assemble reads `agent.type` from the agent row, not the memory row's `agent_framework`). One integration test is `pytest.skip`-marked with the architectural reason; the unit-level structural-change path IS exercised in `tests/unit/services/test_reload.py` via direct ORM mutation.
- Alembic migration for `standalone_runtime_state` — Phase 4 picks up the ORM in its fresh baseline.
- `/runtime/status`, `/readyz`, `/health`, connection-check route handlers — Phase 6.
- Boot-path state machine deriving `StandaloneRuntimeStatusKind` — Phase 6.
- Smart per-field hot-reload classification — deferred to next version.
- Audit-event logging — deferred per Phase 1 amendment.

### Test plan
- [x] `make lint` passes
- [x] `uv run mypy --follow-imports=silent <new-tree>` passes (45 source files)
- [x] `uv run pytest libs/idun_agent_schema -q` passes (62 tests)
- [x] `uv run pytest libs/idun_agent_standalone -q --ignore=...` passes (87 + 1 skipped)

### Review notes
SDD review loop ran each task through implementer + spec reviewer + code-quality reviewer with Opus 4.7 throughout. Two non-blocking fix loops landed inline:
- T1 (reload pipeline): docstring accuracy (`RoundTwoValidationFailed` no longer claims to wrap the original error as an attribute), ADK structural-detection note added to `_structural_slice` docstring, `details={"recovered": True}` assertion added to round-3 failure test.
- T4 (patterns doc): three reference-snippet drifts corrected — `ensure_unique_slug` 4-arg signature, `commit_with_reload` no `structural=` kwarg, §10 prose corrected to state the router holds the mutex (not the orchestrator).

### Next phase
Phase 4 (`feat/rework-phase4-db-models`): build the collection resource ORMs (guardrails, mcp_servers, observability, integrations, prompts) and the fresh Alembic baseline that includes them plus the `runtime_state` ORM. Branches off the umbrella after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)