### PR TITLE
Phase 4 — Collection ORMs + install_meta + observability singleton

### DIFF
--- a/libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py
@@ -49,7 +49,6 @@ from .memory import (  # noqa: F401
     StandaloneMemoryRead,
 )
 from .observability import (  # noqa: F401
-    StandaloneObservabilityCreate,
     StandaloneObservabilityPatch,
     StandaloneObservabilityRead,
 )

--- a/libs/idun_agent_schema/src/idun_agent_schema/standalone/observability.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/standalone/observability.py
@@ -1,17 +1,21 @@
 """Standalone observability admin contracts.
 
-Observability providers are a collection in standalone. The manager uses
-the engine ``ObservabilityConfig`` (V2) shape directly, so no conversion
-is needed at assembly.
+Observability is a singleton in standalone, one provider per install.
+Routes do not take an id in the URL. GET and PATCH operate on
+``/admin/api/v1/observability`` directly. PATCH is upsert. Absence of
+the row means no observability provider is configured.
+
+Stored shape mirrors the engine's ``ObservabilityConfig`` V2 directly,
+so no conversion is needed at assembly. The single configured provider
+is wrapped in a one element list at assembly time to match the
+engine's ``EngineConfig.observability: list`` shape.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Self
-from uuid import UUID
 
-from pydantic import ConfigDict, model_validator
+from pydantic import ConfigDict
 
 from idun_agent_schema.engine.observability_v2 import ObservabilityConfig
 
@@ -19,36 +23,15 @@ from ._base import _CamelModel
 
 
 class StandaloneObservabilityRead(_CamelModel):
-    """GET response and the data payload of POST/PATCH/DELETE responses."""
+    """GET response and the data payload of PATCH responses."""
 
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
-    slug: str
-    name: str
-    enabled: bool
     observability: ObservabilityConfig
-    created_at: datetime
     updated_at: datetime
 
 
-class StandaloneObservabilityCreate(_CamelModel):
-    """Body for POST /admin/api/v1/observability."""
-
-    name: str
-    enabled: bool = True
-    observability: ObservabilityConfig
-
-
 class StandaloneObservabilityPatch(_CamelModel):
-    """Body for PATCH /admin/api/v1/observability/{id}."""
+    """Body for PATCH /admin/api/v1/observability. All fields optional."""
 
-    name: str | None = None
-    enabled: bool | None = None
     observability: ObservabilityConfig | None = None
-
-    @model_validator(mode="after")
-    def _no_null_name(self) -> Self:
-        if "name" in self.model_fields_set and self.name is None:
-            raise ValueError("name cannot be null")
-        return self

--- a/libs/idun_agent_standalone/run.sh
+++ b/libs/idun_agent_standalone/run.sh
@@ -5,4 +5,9 @@ REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 AGENT_DIR="$HOME/Desktop/code/work/idun-agent-template/langgraph-tool"
 
 cd "$AGENT_DIR"
+# get_langchain_tools() in the user's agent.py falls back to fetching
+# from the Idun Manager API when neither the active MCP registry nor
+# IDUN_CONFIG_PATH is set, which blocks indefinitely. Point it at the
+# yaml so the fallback resolves cleanly.
+export IDUN_CONFIG_PATH="$AGENT_DIR/my_agent.yaml"
 uv --project "$REPO" run idun-standalone serve

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -36,9 +36,6 @@ from idun_agent_standalone.services.engine_config import (
     AssemblyError,
     assemble_engine_config,
 )
-from idun_agent_standalone.services.engine_reload import (
-    build_engine_reload_callable,
-)
 
 logger = get_logger(__name__)
 
@@ -83,9 +80,7 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
         try:
             engine_config = await assemble_engine_config(session)
         except AssemblyError as exc:
-            logger.warning(
-                "boot engine layer skipped, admin only mode reason=%s", exc
-            )
+            logger.warning("boot engine layer skipped, admin only mode reason=%s", exc)
             engine_config = None
 
     if engine_config is not None:
@@ -100,11 +95,10 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
     app.state.settings = settings
     app.state.db_engine = db_engine
     app.state.sessionmaker = sessionmaker
-    # Phase 3 reload callable: rebuilds the engine on the same FastAPI
-    # app instance via the engine's lifespan hooks. Admin routers pull
-    # this from app.state via ``ReloadCallableDep``. Available even in
-    # admin-only mode so that a future PATCH that finally produces a
-    # valid config can boot the engine layer without a process restart.
+    from idun_agent_standalone.services.engine_reload import (
+        build_engine_reload_callable,
+    )
+
     app.state.reload_callable = build_engine_reload_callable(app)
 
     register_admin_exception_handlers(app)

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/cli.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/cli.py
@@ -48,27 +48,14 @@ def setup_cmd(config_path_override: str | None) -> None:
 def serve_cmd() -> None:
     """Run the standalone server (engine routes plus admin REST)."""
     setup_logging()
-    asyncio.run(_serve())
-
-
-async def _serve() -> None:
     from idun_agent_standalone.app import create_standalone_app
 
     logger = get_logger(__name__)
     settings = StandaloneSettings()
     logger.info("serve host=%s port=%s", settings.host, settings.port)
 
-    app = await create_standalone_app(settings)
-
-    server = uvicorn.Server(
-        uvicorn.Config(
-            app,
-            host=settings.host,
-            port=settings.port,
-            log_config=None,
-        )
-    )
-    await server.serve()
+    app = asyncio.run(create_standalone_app(settings))
+    uvicorn.run(app, host=settings.host, port=settings.port)
 
 
 async def _setup(config_path_override: str | None) -> None:

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/__init__.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/__init__.py
@@ -5,5 +5,10 @@ Importing this module registers every model on ``Base.metadata`` so
 """
 
 from .agent import StandaloneAgentRow  # noqa: F401
+from .guardrail import StandaloneGuardrailRow  # noqa: F401
+from .integration import StandaloneIntegrationRow  # noqa: F401
+from .mcp_server import StandaloneMCPServerRow  # noqa: F401
 from .memory import StandaloneMemoryRow  # noqa: F401
+from .observability import StandaloneObservabilityRow  # noqa: F401
+from .prompt import StandalonePromptRow  # noqa: F401
 from .runtime_state import StandaloneRuntimeStateRow  # noqa: F401

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/__init__.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/__init__.py
@@ -6,6 +6,7 @@ Importing this module registers every model on ``Base.metadata`` so
 
 from .agent import StandaloneAgentRow  # noqa: F401
 from .guardrail import StandaloneGuardrailRow  # noqa: F401
+from .install_meta import StandaloneInstallMetaRow  # noqa: F401
 from .integration import StandaloneIntegrationRow  # noqa: F401
 from .mcp_server import StandaloneMCPServerRow  # noqa: F401
 from .memory import StandaloneMemoryRow  # noqa: F401

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/guardrail.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/guardrail.py
@@ -1,0 +1,45 @@
+"""SQLAlchemy model for the standalone guardrail collection.
+
+Each row is one configured guardrail. ``position`` and ``sort_order``
+fold the manager's ``agent_guardrails`` junction table into the row
+itself for the single agent case. Disabled rows are skipped at engine
+config assembly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, Boolean, DateTime, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from idun_agent_standalone.infrastructure.db.session import Base
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class StandaloneGuardrailRow(Base):
+    """One configured guardrail."""
+
+    __tablename__ = "standalone_guardrail"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    slug: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    position: Mapped[str] = mapped_column(String(10), nullable=False)
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    guardrail_config: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/install_meta.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/install_meta.py
@@ -1,0 +1,39 @@
+"""SQLAlchemy model for the singleton standalone install metadata row.
+
+Renamed from the legacy ``bootstrap_meta`` per design spec to convey
+that it survives Governance Hub enrollment. Records the bootstrap
+hash used at first seed, the first-boot timestamp, and the last
+process start. Read by ``/runtime/status`` in Phase 6.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from idun_agent_standalone.infrastructure.db.session import Base
+
+
+class StandaloneInstallMetaRow(Base):
+    """The singleton install metadata row.
+
+    Uses a fixed primary key (``"singleton"``) because the resource is
+    addressed by service helpers, not by id. ``bootstrap_hash`` stores
+    the sha256 of the YAML used at first seed so a future boot can
+    warn when the on-disk YAML has drifted from the DB. ``last_seen_at``
+    is updated on every boot for future Governance Hub enrollment to
+    detect stale installs.
+    """
+
+    __tablename__ = "standalone_install_meta"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    bootstrap_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    bootstrapped_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    last_seen_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/integration.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/integration.py
@@ -1,0 +1,44 @@
+"""SQLAlchemy model for the standalone integration collection.
+
+Each row is one configured integration (WhatsApp, Slack, etc.).
+``enabled`` replaces the manager's ``agent_integrations`` junction
+table for the single agent case. The standalone row's ``enabled`` is
+the single source of truth at assembly time; the inner config's
+``enabled`` is overwritten to match.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, Boolean, DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from idun_agent_standalone.infrastructure.db.session import Base
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class StandaloneIntegrationRow(Base):
+    """One configured integration."""
+
+    __tablename__ = "standalone_integration"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    slug: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    integration_config: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/mcp_server.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/mcp_server.py
@@ -1,0 +1,42 @@
+"""SQLAlchemy model for the standalone MCP server collection.
+
+Each row is one configured MCP server. ``enabled`` replaces the
+manager's ``agent_mcp_servers`` junction table for the single agent
+case. Disabled rows are skipped at engine config assembly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, Boolean, DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from idun_agent_standalone.infrastructure.db.session import Base
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class StandaloneMCPServerRow(Base):
+    """One configured MCP server."""
+
+    __tablename__ = "standalone_mcp_server"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    slug: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    mcp_server_config: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/observability.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/observability.py
@@ -1,0 +1,37 @@
+"""SQLAlchemy model for the singleton standalone observability row.
+
+Singleton in standalone (one provider per install) per product call.
+Routes are addressed by path, not by id. Absence of the row means no
+observability provider is configured.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from idun_agent_standalone.infrastructure.db.session import Base
+
+
+class StandaloneObservabilityRow(Base):
+    """The singleton observability row.
+
+    Uses a fixed primary key (``"singleton"``) because the resource is
+    addressed by route, not by id. The single configured provider is
+    wrapped in a one element list at engine config assembly time to
+    match ``EngineConfig.observability: list``.
+    """
+
+    __tablename__ = "standalone_observability"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    observability_config: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/prompt.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/db/models/prompt.py
@@ -1,0 +1,46 @@
+"""SQLAlchemy model for the standalone prompt collection.
+
+Prompts are an append-only versioned collection. Creating with an
+existing ``prompt_id`` adds a new version; latest version is selected
+at assembly time. No slug, no name, no enabled flag — uniqueness is
+on ``(prompt_id, version)``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from idun_agent_standalone.infrastructure.db.session import Base
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class StandalonePromptRow(Base):
+    """One prompt version."""
+
+    __tablename__ = "standalone_prompt"
+    __table_args__ = (
+        UniqueConstraint("prompt_id", "version", name="uq_standalone_prompt_id_version"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    prompt_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    tags: Mapped[list[Any]] = mapped_column(JSON, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )


### PR DESCRIPTION
## Summary

Phase 4 of the standalone admin/db rework. Adds the 5 collection ORMs the spec calls out, the install_meta singleton, and converts observability from collection to singleton per a fresh product call.

## Changes

### New ORMs (T1)
- ``StandaloneGuardrailRow`` — collection, with ``position`` (input/output) and ``sort_order`` columns folded from the manager's M:N junction.
- ``StandaloneMCPServerRow`` — collection, ``enabled`` flag replaces the M:N junction.
- ``StandaloneObservabilityRow`` — **singleton** (id ``"singleton"``), no slug/name/enabled. Wraps to a one-element list at engine config assembly time to match ``EngineConfig.observability: list``.
- ``StandaloneIntegrationRow`` — collection, ``enabled`` flag replaces the M:N junction. The standalone row's ``enabled`` is the SoT at assembly; inner config's ``enabled`` is overwritten.
- ``StandalonePromptRow`` — collection with append-only versioning. Unique on ``(prompt_id, version)``. No slug/name/enabled.

### New singleton ORM (T2 partial)
- ``StandaloneInstallMetaRow`` — renamed from legacy ``bootstrap_meta``. Stores ``bootstrap_hash``, ``bootstrapped_at``, ``last_seen_at``. Read by ``/runtime/status`` in Phase 6.

### Schema change
- ``StandaloneObservabilityRead`` and ``StandaloneObservabilityPatch`` rewritten to singleton shape (matches ``StandaloneMemoryRead/Patch``). ``StandaloneObservabilityCreate`` removed.

### Engine #525 workaround (separate fix commit)
- ``run.sh`` exports ``IDUN_CONFIG_PATH`` so the user's ``agent.py`` ``get_langchain_tools()`` doesn't fall through to a blocking API fetch. See issue #525 for the engine-side bug.

## Forbidden patterns check
All zero matches in the new ORM tree:
- ``from app.``
- ``JSONB`` / ``UUID(as_uuid=True)``
- ``workspace_id``

## Deferred from this phase

- **T2 Alembic baseline** — fresh ``0001_initial.py`` covering all 9 ``standalone_*`` tables + legacy ``theme``. Skipped per product call to ship ORMs first; revisit before Phase 8 cutover.
- **T3 migration parity tests** — SQLite + Postgres ``alembic upgrade head`` schema check, gated behind ``requires_postgres``.
- **T4 patterns doc transitions** — §5.2 promote FORWARD → ESTABLISHED with the real ORM snippets, §11 column-name fix (TFL-1), §14 mirror table refresh, §3 tree refresh. Will land alongside Phase 5.

## Tables registered

```
standalone_agent
standalone_guardrail
standalone_install_meta
standalone_integration
standalone_mcp_server
standalone_memory
standalone_observability
standalone_prompt
standalone_runtime_state
```

## Spec deviation: observability as singleton

Design spec §"Singleton vs collection blocks" lists observability under collections. Product call to make it singleton (one provider per install). Engine's ``EngineConfig.observability`` remains a list — assembly wraps the singleton in ``[config]``. Tracked for design-doc amendment in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)