### PR TITLE
Wagon 3: sync docs with rework deviations and deferred features

### DIFF
--- a/docs/superpowers/specs/2026-04-27-rework-patterns.md
+++ b/docs/superpowers/specs/2026-04-27-rework-patterns.md
@@ -173,7 +173,9 @@ Subagents copying this pattern: `from ._base import _CamelModel` and inherit. Do
 
 ### 4.2 Singleton resource schemas — ESTABLISHED
 
-Singleton resources (agent, memory) follow the Read/Patch pattern. There is no Create model — the row is seeded from YAML at first boot. Read models opt into `from_attributes=True` so they project from SQLAlchemy rows directly via `Model.model_validate(row)`.
+Singleton resources (agent, memory, observability) follow the Read/Patch pattern. There is no Create model — the row is either seeded from YAML at first boot (agent) or upserted via PATCH (memory, observability). Read models opt into `from_attributes=True` so they project from SQLAlchemy rows directly via `Model.model_validate(row)`.
+
+Observability was originally drafted as a collection in §4.3 (mirroring manager); Phase 4 collapsed it to a singleton because standalone has one active provider per install — see spec §"Observability". The Read/Patch shape lives in `idun_agent_schema/standalone/observability.py`.
 
 Reference snippet at `libs/idun_agent_schema/src/idun_agent_schema/standalone/agent.py:27-61`:
 
@@ -220,13 +222,12 @@ Why: explicit-null rejection at the Pydantic layer keeps the router free of `if 
 
 ### 4.3 Collection resource schemas — ESTABLISHED
 
-Five collection resources land in Phase 2. Each follows the same Read/Create/Patch pattern and is anchored to the manager-shape config it wraps.
+Four collection resources land in Phase 2. Each follows the same Read/Create/Patch pattern and is anchored to the manager-shape config it wraps. Observability was originally drafted as a collection here; Phase 4 collapsed it to a singleton (see §4.2 and spec §"Observability") because standalone scopes the install to a single active provider.
 
 | Module | Read class line | Wraps | Conversion at assembly |
 | --- | --- | --- | --- |
 | `guardrails.py` | `26` | `ManagerGuardrailConfig` | `convert_guardrail()` reused from manager |
 | `mcp_servers.py` | `23` | `MCPServer` (engine) | none |
-| `observability.py` | `21` | `ObservabilityConfig` (V2 engine) | none |
 | `integrations.py` | `23` | `IntegrationConfig` (engine) | inner `enabled` overwritten at assembly to match standalone row |
 | `prompts.py` | `24` | `ManagedPromptCreate/Read/Patch` (manager) | content-vs-tags split (PATCH only `tags`; content patches POST a new version) |
 
@@ -274,7 +275,7 @@ Patterns to copy in Phase 5+ collection routers:
 - Read variants set `model_config = ConfigDict(from_attributes=True)` so they project from SQLAlchemy rows directly via `Model.model_validate(row)`.
 - Create variants default `enabled=True`.
 - Patch variants reject explicit-null on `name` via `_no_null_name` (mirrors agent.py:57-61). Prompts uses `_no_null_tags` instead because the null-vs-empty-list ambiguity on `tags` warrants explicit disambiguation.
-- Inner config field (`mcp_server`, `observability`, `integration`, `guardrail`) accepts the wrapped shape unchanged on input; outbound wire format follows the wrapped shape's own aliasing rules.
+- Inner config field (`mcp_server`, `integration`, `guardrail`) accepts the wrapped shape unchanged on input; outbound wire format follows the wrapped shape's own aliasing rules. Observability follows the same convention but lives under §4.2 as a singleton.
 
 Special case — guardrails fold M:N junction columns:
 
@@ -645,7 +646,7 @@ Three connection-check endpoints are MVP scope (spec §"Connection checks"):
 
 ```text
 POST /admin/api/v1/memory/check-connection
-POST /admin/api/v1/observability/{id}/check-connection
+POST /admin/api/v1/observability/check-connection         # singleton — no {id}
 POST /admin/api/v1/mcp-servers/{id}/tools
 ```
 
@@ -1010,13 +1011,13 @@ Verbatim from spec §"Manager schema mirror rule":
 | `managed_agents` | `standalone_agent` | drop `workspace_id`, `memory_id` FK (memory is singleton on the agent), `sso_id` FK (SSO out of scope) |
 | `managed_memories` | `standalone_memory` | drop `workspace_id`; singleton in standalone |
 | `managed_mcp_servers` | `standalone_mcp_server` | drop `workspace_id`; add `enabled bool` |
-| `managed_observabilities` | `standalone_observability` | drop `workspace_id`; add `enabled bool` |
+| `managed_observabilities` | `standalone_observability` | drop `workspace_id`; **singleton in standalone** (id fixed to `"singleton"`, no `enabled`/`name`/`slug`) — see spec §"Observability" |
 | `managed_integrations` | `standalone_integration` | drop `workspace_id`; add `enabled bool` |
 | `managed_guardrails` | `standalone_guardrail` | drop `workspace_id`; add `enabled bool`, `position`, `sort_order` (folded from junction) |
 | `managed_prompts` | `standalone_prompt` | drop `workspace_id`; uniqueness becomes `(prompt_id, version)` |
 | `agent_guardrails` (junction) | folded | `position` and `sort_order` move onto `standalone_guardrail` |
 | `agent_mcp_servers` (junction) | folded | replaced by `standalone_mcp_server.enabled` |
-| `agent_observabilities` (junction) | folded | replaced by `standalone_observability.enabled` |
+| `agent_observabilities` (junction) | excluded | observability is singleton in standalone |
 | `agent_integrations` (junction) | folded | replaced by `standalone_integration.enabled` |
 | `agent_prompt_assignments` (junction) | excluded | one agent in standalone; every prompt applies |
 | `workspaces`, `users`, `memberships`, `invitations`, `managed_ssos`, `settings` | excluded | not a multi-tenant control plane |
@@ -1057,9 +1058,10 @@ Each collection schema in `idun_agent_schema/standalone/` wraps a manager-shape 
 | --- | --- | --- | --- |
 | `StandaloneGuardrailRead/Create/Patch` | `guardrails.py:26` | `ManagerGuardrailConfig` | `idun_agent_schema/manager/guardrail_configs.py` |
 | `StandaloneMCPServerRead/Create/Patch` | `mcp_servers.py:23` | `MCPServer` | `idun_agent_schema/engine/mcp_server.py` |
-| `StandaloneObservabilityRead/Create/Patch` | `observability.py:21` | `ObservabilityConfig` (V2) | `idun_agent_schema/engine/observability_v2.py` |
 | `StandaloneIntegrationRead/Create/Patch` | `integrations.py:23` | `IntegrationConfig` | `idun_agent_schema/engine/integrations` |
 | `StandalonePromptRead/Create/Patch` | `prompts.py:24` | (mirrors) `ManagedPromptCreate/Read/Patch` | `idun_agent_schema/manager/managed_prompt.py` |
+
+Observability landed as a singleton during Phase 4 implementation — see §"Singleton schemas" / §"Singleton ORM" for its `Read/Patch`-only shape (no `Create`, upsert via PATCH). The deviation from manager's collection layout is locked in spec §"Observability".
 
 Phase 4 ORM modules apply the §14.3 audit checklist to the corresponding `StandaloneXRow` SQLAlchemy declarations; the wrapping shape lands here at the schema layer.
 

--- a/docs/superpowers/specs/2026-04-27-standalone-admin-config-db-design.md
+++ b/docs/superpowers/specs/2026-04-27-standalone-admin-config-db-design.md
@@ -135,13 +135,13 @@ Mirror table:
 | `managed_agents` | `standalone_agent` | drop `workspace_id`, `memory_id` FK (memory is singleton on the agent), `sso_id` FK (SSO out of scope) |
 | `managed_memories` | `standalone_memory` | drop `workspace_id`; singleton in standalone |
 | `managed_mcp_servers` | `standalone_mcp_server` | drop `workspace_id`; add `enabled bool` |
-| `managed_observabilities` | `standalone_observability` | drop `workspace_id`; add `enabled bool` |
+| `managed_observabilities` | `standalone_observability` | drop `workspace_id`; **singleton in standalone** (id fixed to `"singleton"`, no `enabled`, no `name`/`slug`); see §"Observability" |
 | `managed_integrations` | `standalone_integration` | drop `workspace_id`; add `enabled bool` |
 | `managed_guardrails` | `standalone_guardrail` | drop `workspace_id`; add `enabled bool`, `position`, `sort_order` (folded from junction) |
 | `managed_prompts` | `standalone_prompt` | drop `workspace_id`; uniqueness becomes `(prompt_id, version)` |
 | `agent_guardrails` (junction) | folded | `position` and `sort_order` move onto `standalone_guardrail` |
 | `agent_mcp_servers` (junction) | folded | replaced by `standalone_mcp_server.enabled` |
-| `agent_observabilities` (junction) | folded | replaced by `standalone_observability.enabled` |
+| `agent_observabilities` (junction) | excluded | observability is a singleton in standalone; the row is the active provider |
 | `agent_integrations` (junction) | folded | replaced by `standalone_integration.enabled` |
 | `agent_prompt_assignments` (junction) | excluded | one agent in standalone; every prompt applies |
 | `workspaces`, `users`, `memberships`, `invitations`, `managed_ssos`, `settings` | excluded | not a multi-tenant control plane |
@@ -640,19 +640,17 @@ enabled standalone_mcp_server rows
 
 Locked:
 
-- Standalone observability matches manager exactly: `name` + `observability`.
-- Inner config is `ObservabilityConfig` V2.
+- Standalone observability is a **singleton**, one provider per install.
+- Inner config is `ObservabilityConfig` V2 — same shape as manager.
+
+Deviation from manager: manager allows multiple observability rows per agent through `managed_observabilities` plus the `agent_observabilities` junction. Standalone has one agent and a single active provider, so the junction is excluded and the row is identified by a fixed `"singleton"` id (no slug, no name, no enabled flag). Absence of the row means no observability is configured.
 
 Conceptual model:
 
 ```text
 StandaloneObservability
-  id: UUID
-  slug: string | null
-  name: string
-  enabled: bool
+  id: "singleton"
   observability: ObservabilityConfig
-  created_at: datetime
   updated_at: datetime
 ```
 
@@ -662,18 +660,21 @@ Schema source:
 
 Rules:
 
-- Observability providers are a collection.
-- Providers may be disabled.
-- Disabled providers are not included in `EngineConfig`.
+- Exactly zero or one observability row at any time.
+- Absence of the row = engine runs without an observability provider.
 - Validation comes from `ObservabilityConfig`.
+- API addressed without `{id}` (consistent with other singletons; see §"Singleton vs collection blocks").
 
 Assembly:
 
 ```text
-enabled standalone_observability rows
-  -> list[ObservabilityConfig]
+standalone_observability row (if present)
+  -> ObservabilityConfig
+  -> [ObservabilityConfig]              # one-element list
   -> EngineConfig.observability
 ```
+
+The one-element list at assembly preserves the engine's existing `EngineConfig.observability: list[ObservabilityConfig]` shape; the standalone runtime materializes the singleton into that list rather than reshaping the engine config.
 
 ### Integrations
 
@@ -1018,6 +1019,7 @@ Locked classification:
 ```text
 agent
 memory
+observability
 runtime_state
 install_meta
 admin_auth
@@ -1031,12 +1033,13 @@ Rules:
 - API addressed without `{id}` (e.g. `GET /admin/api/v1/memory`, `PATCH /admin/api/v1/agent`)
 - DB rows may carry a UUID for future cross-system identity, but the URL never uses it
 
+`observability` was originally classified as a collection (mirroring manager). Standalone scopes the install to one agent and one active provider, so the table folds to a singleton. See §"Observability" for the assembly rule that wraps the row into the engine's existing list shape.
+
 ### Collection blocks
 
 ```text
 guardrails
 mcp_servers
-observability
 integrations
 prompts
 trace_sessions
@@ -1122,20 +1125,18 @@ POST   /admin/api/v1/mcp-servers/{id}/tools         # MVP: discover tools; doubl
 
 PATCH semantics: the inner `mcp_server` config is replaced wholesale, not deep-merged. Clients send the full `MCPServer` object with any unchanged fields preserved. This keeps client logic simple and avoids merge surprises.
 
-### Observability
+### Observability (singleton)
 
-Manager route name: `observability`.
+Manager route name: `observability`. Standalone deviates to no-`{id}` routes; see §"Singleton vs collection blocks" for why.
 
 ```text
 GET    /admin/api/v1/observability
-POST   /admin/api/v1/observability
-GET    /admin/api/v1/observability/{id}
-PATCH  /admin/api/v1/observability/{id}
-DELETE /admin/api/v1/observability/{id}
-POST   /admin/api/v1/observability/{id}/check-connection   # MVP connection check
+PATCH  /admin/api/v1/observability
+DELETE /admin/api/v1/observability
+POST   /admin/api/v1/observability/check-connection        # MVP connection check
 ```
 
-PATCH semantics: shallow replace of the inner `observability` config, same rule as MCP servers.
+`PATCH /observability` is upsert: if no row exists, create it; otherwise update. First write requires the `observability` field; subsequent PATCHes can be partial. PATCH semantics for the inner `observability` config are shallow replace, same rule as MCP servers.
 
 ### Integrations
 

--- a/libs/idun_agent_standalone/CLAUDE.md
+++ b/libs/idun_agent_standalone/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What this is
 
-`idun_agent_standalone` is a single-process, single-tenant agent runtime. It wraps `idun-agent-engine` with an embedded admin REST surface, traces capture, a bundled Next.js UI (chat / admin / traces), and a reload orchestrator. Designed for one-agent deployments — laptop, VM, or Cloud Run.
+`idun_agent_standalone` is a single-process, single-tenant agent runtime. It wraps `idun-agent-engine` with an embedded admin REST surface, an in-process reload pipeline, and a bundled Next.js UI (chat plus admin pages). One agent per install — laptop, VM, or Cloud Run.
 
 Published to PyPI as `idun-agent-standalone`. CLI entry point: `idun-standalone`.
 
@@ -10,57 +10,69 @@ Published to PyPI as `idun-agent-standalone`. CLI entry point: `idun-standalone`
 
 ```
 idun_agent_standalone/
-├── cli.py              # Click commands: serve, init, hash-password, export
-├── app.py              # create_standalone_app(settings) — FastAPI factory wrapping the engine app
-├── settings.py         # Pydantic settings: IDUN_*, DATABASE_URL, IDUN_UI_DIR, container detection
-├── config_assembly.py  # Merges DB-backed admin state into engine EngineConfig
-├── config_io.py        # YAML <-> DB import/export
-├── reload.py           # Reload orchestrator: rebuild engine app on admin write, swap routes atomically
-├── runtime.py          # Live agent handle, observer registration after each reload
-├── scaffold.py         # `init` command — copies template into a new project dir
-├── middleware.py       # Session cookie middleware, container-aware Secure flag, auth gate
-├── errors.py           # Standalone-specific HTTPException subclasses
-├── auth/               # Password auth (none mode short-circuits); session cookies, sliding renewal, rotation
-├── db/                 # SQLAlchemy async models + Alembic migrations (admin tables + trace_event)
-├── admin/routers/      # /admin/api/v1/* — agent, guardrails, mcp, prompts, observability, integrations, theme, settings
-├── traces/             # AG-UI run-event observer, batched writer, retention purge (APScheduler)
-├── theme/              # Theme model, defaults, /runtime-config.js bootstrap
-├── static/             # Bundled Next.js export (copied in by build-standalone-ui make target)
-├── testing.py          # Pytest helpers: in-memory app fixture
-└── testing_app.py      # Lightweight app variant for tests (skips static UI mount)
+├── cli.py                    # Click commands: setup, serve
+├── app.py                    # create_standalone_app(settings) — async FastAPI factory wrapping the engine app
+├── runtime_config.py         # GET /runtime-config.js — bootstrap script the SPA loads before first paint
+├── core/
+│   ├── settings.py           # Pydantic settings: IDUN_*, DATABASE_URL, AuthMode (NONE | PASSWORD)
+│   └── logging.py            # logger setup
+├── api/v1/
+│   ├── deps.py               # SessionDep, ReloadCallableDep, require_auth, reload_disabled
+│   ├── errors.py             # AdminAPIError + register_admin_exception_handlers
+│   └── routers/              # agent, memory, guardrails, mcp_servers, observability, integrations, prompts, auth (/me stub)
+├── services/
+│   ├── reload.py             # commit_with_reload, _reload_mutex, ReloadInitFailed
+│   ├── engine_config.py      # assemble_engine_config — DB rows → EngineConfig
+│   ├── engine_reload.py      # build_engine_reload_callable — wraps engine cleanup + reconfigure
+│   ├── runtime_state.py      # last reload outcome (status, ts, message) persisted to runtime_state row
+│   ├── slugs.py              # NFKD normalize + ensure_unique_slug helpers (-2, -3, ... up to -99)
+│   └── validation.py         # round-2 assembled-config validation helpers
+├── infrastructure/
+│   ├── db/
+│   │   ├── session.py        # async_sessionmaker + Base
+│   │   └── models/           # ORMs: agent, memory, guardrail, mcp_server, observability, integration, prompt, install_meta, runtime_state
+│   └── scripts/seed.py       # YAML → DB seed at first boot
+├── db/
+│   ├── alembic.ini
+│   ├── migrate.py
+│   └── migrations/           # Alembic baseline (5e05fbe68d61_baseline.py)
+└── static/                   # Bundled Next.js export (copied in by build-standalone-ui make target)
 ```
+
+Empty legacy directories (`admin/`, `auth/`, `theme/`, `traces/`) remain only as namespace placeholders for features deferred to a later release; see "Deferred features" below.
 
 ## Key entry points
 
-- `idun-standalone serve` — runs `create_standalone_app(settings)` under uvicorn.
-- `create_standalone_app(settings: StandaloneSettings) -> FastAPI` — public factory used by tests and embedders.
-- `idun-standalone init <name>` — scaffold a new project from `scaffold/`.
-- `idun-standalone hash-password [--password ...]` — bcrypt the admin password.
-- `idun-standalone export [--out config.yaml]` — dump current DB state to YAML.
+- `idun-standalone setup` — runs Alembic migrations and seeds the DB from `IDUN_CONFIG_PATH` if empty.
+- `idun-standalone serve` — runs `create_standalone_app(settings)` under uvicorn in the same event loop.
+- `create_standalone_app(settings: StandaloneSettings) -> FastAPI` — public async factory used by tests and embedders.
 
 ## Config flow
 
-1. **First boot**: if the DB is empty and `IDUN_CONFIG_PATH` points to a YAML file, `config_io.import_yaml()` seeds the admin tables.
-2. **Steady state**: the DB is the source of truth. `config_assembly.build_engine_config()` materializes a fresh `EngineConfig` for the engine on every (re)load.
-3. **Admin write**: every admin REST mutation calls `reload.trigger()`, which rebuilds the engine app and swaps it atomically — running requests finish on the old app.
+1. **First boot**: operator runs `idun-standalone setup`. If the DB is empty and `IDUN_CONFIG_PATH` points to a YAML file, `infrastructure/scripts/seed.seed_from_yaml_if_empty` materializes the admin tables.
+2. **Steady state**: the DB is the source of truth. `services/engine_config.assemble_engine_config()` materializes a fresh `EngineConfig` for the engine on every (re)load.
+3. **Admin write**: every admin REST mutation runs through `services/reload.commit_with_reload`, which (a) reassembles + validates the engine config, (b) on success calls the engine reload callable so the running engine picks up the new shape, (c) on failure rolls back the DB write so the API surface remains consistent.
 
 ## Auth
 
 Two modes, gated by `IDUN_ADMIN_AUTH_MODE`:
 
-- `none` — open admin (laptop default).
-- `password` — bcrypt hash + session cookie (containerized default).
+- `none` — open admin (laptop default). The `require_auth` dependency is a pass-through.
+- `password` — fails closed with `503` until the real password+session implementation lands. The dependency stub is in place so router-level wiring won't change when auth ships; only the dependency body becomes meaningful.
 
-OIDC is deferred to MVP-2. Sessions use signed cookies with sliding renewal on the configured TTL. Password rotation invalidates outstanding sessions. `IDUN_SESSION_SECRET` must be at least 32 characters in `password` mode (enforced at startup).
+`/admin/api/v1/auth/me` is a stub: in `none` mode it returns `{authenticated: True, auth_mode: "none"}` so the bundled UI can render without a login wall.
 
-**Password rotation:** On first boot, the admin row is seeded from
-`IDUN_ADMIN_PASSWORD_HASH`. After that, the DB is the source of truth —
-admin password changes via the UI are durable across restarts. Re-seed
-from env by setting `IDUN_FORCE_ADMIN_PASSWORD_RESET=1` for one boot.
+`api/v1/deps.py:reload_disabled` is wired as `reload_auth=` on `create_engine_app`. Engine `POST /reload` returns `403` — admin reloads must go through `/admin/api/v1/*`, which run under the rebuild-and-validate pipeline.
 
-## Traces
+## Reload pipeline
 
-The runtime registers an AG-UI observer on the engine after every reload (`runtime.attach_observer()`). Events are buffered in-process and flushed in batches to `trace_event` to avoid blocking the request path. APScheduler runs an hourly retention purge (`IDUN_TRACES_RETENTION_DAYS`).
+Three rounds of validation:
+
+1. **Round 1** — FastAPI Pydantic body validation. Bad input shape → `422` with `field_errors`.
+2. **Round 2** — assembled `EngineConfig` revalidation. Cross-resource mismatches (e.g. LangGraph agent + ADK SessionService memory) → `422` with `field_errors`, DB rolled back.
+3. **Round 3** — engine reload callable applies the new config. Engine init failure → `500` (`ReloadInitFailed`), DB rolled back, `runtime_state` records the outcome.
+
+Structural changes the running engine cannot pick up (e.g. agent.type switch) commit the DB and return `restart_required` instead of invoking reload. The `runtime_state` row records the most recent reload outcome for the operator dashboard.
 
 ## Tests
 
@@ -68,9 +80,27 @@ The runtime registers an AG-UI observer on the engine after every reload (`runti
 uv run pytest libs/idun_agent_standalone/tests
 ```
 
-`tests/unit/` — module-level (settings, auth, config_assembly, reload).
-`tests/integration/` — end-to-end via the test app fixture; uses SQLite by default.
+`tests/unit/` — module-level (settings, reload service, runtime state, slug normalization, validation, CLI shape regression, require_auth, reload_disabled).
+`tests/integration/api/v1/` — end-to-end through ASGITransport with router-level dependency overrides; uses in-memory SQLite. One test per resource flow plus `test_auth_gate.py` covering the `require_auth` gate end-to-end.
+
+The `_reload_mutex` is module-level for production but bound to a fresh `asyncio.Lock` per test by `tests/integration/api/v1/conftest.py:_reset_reload_mutex` (autouse).
+
+## Deferred features
+
+These were present in the pre-rework standalone but have **no router or service in the current api/v1 layer**. They will return in a future release; the standalone CLAUDE.md will be updated when they do.
+
+| Feature | Pre-rework location | Status |
+| --- | --- | --- |
+| Real password auth (login, logout, change-password, sessions, sliding renewal, rotation) | `auth/` | Stub: `require_auth` returns 503 in `password` mode |
+| `/admin/api/v1/theme` (theme model + admin route) | `theme/` | The runtime-config bootstrap (`runtime_config.py`) still exposes a default theme to the SPA, but there is no admin route to mutate it |
+| Traces (AG-UI run-event observer, batched writer to `trace_event`, hourly retention purge via APScheduler) | `traces/` | Backend dropped; `trace_event` table is not materialized by the baseline migration. UI pages under `/traces` will 404 against the API |
+| `idun-standalone init <name>` scaffold command | `scaffold.py` | Removed; bootstrap a new project by writing a `config.yaml` directly and running `idun-standalone setup` |
+| `idun-standalone hash-password` | `cli.py` | Removed pending password auth |
+| `idun-standalone export` | `config_io.py` | Removed; YAML export comes back with the materialized-config endpoints (deferred) |
+| `runtime.py` (live agent handle, observer registration after each reload) | top-level | Removed with traces |
+
+The empty `admin/`, `auth/`, `theme/`, `traces/` directories remain on disk so import paths used by deferred-feature work-in-progress branches don't have to change name.
 
 ## Conventions
 
-Same as the rest of the monorepo: ruff + black, mypy, async throughout, schema lives in `idun_agent_schema`. The engine remains the single source of truth for runtime config — the standalone never duplicates engine logic.
+Same as the rest of the monorepo: ruff + black, mypy, async throughout, schema lives in `idun_agent_schema`. The engine remains the single source of truth for runtime config — the standalone never duplicates engine logic; assembly is JSON normalization plus the manager-shape converters where needed.

--- a/services/idun_agent_standalone_ui/CLAUDE.md
+++ b/services/idun_agent_standalone_ui/CLAUDE.md
@@ -2,23 +2,53 @@
 
 ## What this is
 
-A Next.js 15 + Tailwind v4 + React 19 SPA shipped as a static export. Bundled into the `idun-agent-standalone` Python wheel and served by FastAPI at `/`. Provides the chat surface, admin panel, and traces viewer for a single-agent deployment.
+A Next.js 15 + Tailwind v4 + React 19 SPA shipped as a static export. Bundled into the `idun-agent-standalone` Python wheel and served by FastAPI at `/`. Provides the chat surface and admin panel for a single-agent deployment.
 
 ## Routes
 
-- `/` — chat UI; layout switched at runtime (branded / minimal / inspector).
-- `/login` — password sign-in (only reachable when `auth_mode = password`).
-- `/admin/*` — agent, guardrails, memory, observability, MCP, prompts, integrations, theme, settings editors.
-- `/traces/*` — sessions list, run timeline, event detail.
-- `/logs` — live tail of recent events.
+| Route | Status |
+| --- | --- |
+| `/` | Chat UI; layout switched at runtime (branded / minimal / inspector) |
+| `/admin/agent` | Agent identity + base config — wired to `/admin/api/v1/agent` |
+| `/admin/memory` | Memory singleton — wired to `/admin/api/v1/memory` |
+| `/admin/guardrails` | Guardrails collection — wired to `/admin/api/v1/guardrails` |
+| `/admin/mcp` | MCP servers collection — wired to `/admin/api/v1/mcp-servers` |
+| `/admin/observability` | Observability singleton — wired to `/admin/api/v1/observability` |
+| `/admin/integrations` | Integrations collection — partially migrated; still references the old `kind` field |
+| `/admin/prompts` | Prompts versioned collection — wired to `/admin/api/v1/prompts` |
+| `/admin/settings` | Theme + password sections — **runtime 404** (deferred backend; see "Half-migration state") |
+| `/admin` | Dashboard with sessions list — **runtime 404** (sessions route deferred) |
+| `/login` | Password sign-in — **runtime 404** (deferred backend) |
+| `/traces`, `/traces/session` | Sessions list, run timeline, event detail — **runtime 404** (traces dropped from backend) |
+| `/logs` | Live tail of recent events — **runtime 404** (no backend route) |
 
 ## Theme
 
-CSS variables driven at runtime via `/runtime-config.js`, served by the standalone backend. `ThemeLoader` reads the runtime config in the document head before first paint, applies the variables, and exposes the `auth_mode` to the rest of the app. Light/dark palettes, radius, font, app name, greeting, layout, and starter prompts are all theme-driven — no rebuild required to rebrand.
+CSS variables driven at runtime via `/runtime-config.js`, served by the standalone backend (`runtime_config.py`). `ThemeLoader` reads the runtime config in the document head before first paint, applies the variables, and exposes `authMode` to the rest of the app. Light/dark palettes, radius, font, app name, greeting, layout, and starter prompts are all theme-driven — no rebuild required to rebrand.
+
+There is no admin route to mutate the theme yet; the bootstrap exposes a hardcoded default. A theme admin endpoint is deferred.
 
 ## API client
 
-All admin calls go through `lib/api.ts`. Every request sets `credentials: include` so the session cookie travels. Endpoints map 1:1 to `/admin/api/v1/*`. Errors are normalized to `ApiError` with `status` and `detail` fields.
+All admin calls go through `lib/api/`:
+
+- `lib/api/client.ts` — `apiFetch<T>` wrapper. Every request sets `credentials: include` so a future session cookie travels with it. 401 redirects to `/login/` once.
+- `lib/api/index.ts` — the `api` object exporting one method per endpoint. Endpoints map 1:1 to `/admin/api/v1/*`.
+- `lib/api/types/{agent,common,guardrails,integrations,mcp,memory,observability,prompts,sessions}.ts` — typed request/response models that mirror the standalone admin schemas (camelCase wire keys).
+
+Errors are normalized to `ApiError` with `status` and `detail` fields.
+
+## Half-migration state
+
+`next.config.mjs` sets `typescript: { ignoreBuildErrors: true }`. This is intentional and temporary.
+
+The Phase 6 UI rewrite migrated five admin pages (agent, memory, mcp, observability, prompts) to `lib/api/`, but several pages and components still reference the previous API client shape and the old backend features (auth login/logout/change-password, theme, traces sessions). Those pages typecheck-fail; the build flag lets the static export keep shipping.
+
+`tsc --noEmit` lists the remaining gaps — fix or delete the broken references when:
+- the corresponding backend feature returns (auth, theme, traces), or
+- the deferred decision turns into "drop the page".
+
+Once all pages compile, flip `ignoreBuildErrors` back to `false`.
 
 ## AG-UI
 
@@ -28,8 +58,8 @@ Hand-rolled SSE reader in `lib/agui.ts` — no `@ag-ui/client` dependency. Strea
 
 ```bash
 cd services/idun_agent_standalone_ui
-pnpm install
-pnpm build       # produces ./out (static export)
+npm install
+npm run build       # produces ./out (static export)
 ```
 
 The repo Make target `build-standalone-ui` runs the build and copies `out/` into `libs/idun_agent_standalone/src/idun_agent_standalone/static/`.
@@ -38,5 +68,5 @@ The repo Make target `build-standalone-ui` runs the build and copies `out/` into
 
 - TypeScript strict mode; avoid `any` — read the source for the real type.
 - Components are grouped by surface: `components/{ui,admin,chat,traces,common}/`.
-- All fetches go through `lib/api.ts` — components never call `fetch` directly.
+- All fetches go through `lib/api/` — components never call `fetch` directly.
 - Styles via Tailwind utilities + CSS variables; no styled-components.


### PR DESCRIPTION
## Summary

Reconciles the rework specs and CLAUDE.md files with what Phases 4-5 actually shipped. Two deviations:

1. **Observability collapsed from collection to singleton.** Phase 4's implementation made it a singleton (one active provider per install, no \`{id}\`, no \`enabled\`, no junction). The spec and patterns doc still described it as a collection.
2. **Phase 5 dropped legacy admin features.** Commit \`32a34e6e\` removed traces, theme admin, auth login/logout/change-password, the \`init\` scaffold command, \`hash-password\`, \`export\`, and \`runtime.py\`. The standalone CLAUDE.md still listed them as present.

## What changed

### \`docs/superpowers/specs/2026-04-27-standalone-admin-config-db-design.md\`
- §"Manager schema mirror rule" mirror table — \`standalone_observability\` row now flags singleton; the \`agent_observabilities\` junction line moves from "folded" to "excluded".
- §"Observability" rewritten — conceptual model loses \`slug\`/\`name\`/\`enabled\`, gains the fixed \`"singleton"\` id; assembly wraps the singleton row into a one-element list to keep the engine's existing \`EngineConfig.observability: list[ObservabilityConfig]\` shape.
- §"Singleton vs collection blocks" — observability moves to the singleton list; collection list shrinks from 5 to 4 (guardrails, mcp_servers, integrations, prompts; trace_sessions/trace_events stay listed but the underlying tables are not materialized in the baseline migration).
- §"Observability" endpoint map — drops \`POST\` and \`{id}\` paths; mirrors the memory shape (\`GET\`/\`PATCH\`/\`DELETE\` on bare path, plus a singleton check-connection sub-route).

### \`docs/superpowers/specs/2026-04-27-rework-patterns.md\`
- §4.2 adds observability alongside agent + memory in the singleton schemas list.
- §4.3 collection-resource table drops observability; the "inner config field" footnote follows.
- §6.6 connection-check sub-route loses the \`{id}\` for observability.
- §14.1 mirror table — observability row reflects the singleton shape.
- §14.4 ESTABLISHED references — \`StandaloneObservabilityRead/Create/Patch\` row removed; a paragraph notes the deviation and points back to §4.2.

### \`libs/idun_agent_standalone/CLAUDE.md\`
Full rewrite. The previous version still described \`config_assembly.py\`, \`config_io.py\`, \`reload.py\`, \`runtime.py\`, \`scaffold.py\`, \`middleware.py\`, the \`init\`/\`hash-password\`/\`export\` CLI commands, full password-mode auth with sliding sessions, the AG-UI traces observer + APScheduler retention purge, and the theme admin endpoint — none of which exist in the current code.

The new version reflects the actual layout (\`api/v1/\`, \`core/\`, \`services/\`, \`infrastructure/\`), describes the three-round reload pipeline, and adds a "Deferred features" table mapping each pre-rework feature to its current status. Empty legacy directories (\`admin/\`, \`auth/\`, \`theme/\`, \`traces/\`) are noted as namespace placeholders.

### \`services/idun_agent_standalone_ui/CLAUDE.md\`
- \`lib/api.ts\` references replaced with \`lib/api/\` (the new typed-by-resource client landed in #530/#532).
- Per-route status table flags which admin pages will 404 at runtime against the current backend (login, traces, settings password+theme sections, sessions list).
- "Half-migration state" section documents the temporary \`typescript: { ignoreBuildErrors: true }\` and the conditions for flipping it back.

## Test plan

- [x] No code changes — purely docs.
- [x] \`uv run pytest libs/idun_agent_standalone/tests\` → 120 passed, 1 skipped (unchanged).
- [x] Cross-references checked — every "see §X" or file-path reference in the new docs maps to a real section / file.
- [ ] Reviewer sanity-check: open the spec + patterns doc side-by-side with the actual \`api/v1/routers/observability.py\` to confirm the singleton contract matches the docs.

## Notes

This closes the third and final wagon of the post-rework cleanup. Wagons 1-3 in order:

| # | PR | What |
|---|---|---|
| 1 | #531 | auth gate stub + single-loop serve + engine /reload guard |
| 2 | #533 | 59 integration tests for the 5 collection routers |
| 3 | this PR | doc sync (observability singleton + deferred features) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)