### PR TITLE
feat(standalone): onboarding wizard — sub-projects A + B + C

### DIFF
--- a/docs/superpowers/plans/2026-04-28-onboarding-scanner.md
+++ b/docs/superpowers/plans/2026-04-28-onboarding-scanner.md
@@ -1,0 +1,1751 @@
+# Onboarding scanner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a pure-Python filesystem scanner that detects LangGraph and Google ADK agents from source files, `langgraph.json`, and Idun `config.yaml`, returning a structured `ScanResult` consumed by the onboarding wizard's HTTP layer.
+
+**Architecture:** Two artifacts. The wire schema lives in `idun_agent_schema.standalone.onboarding` so backend and UI share one source of truth. The implementation lives in `idun_agent_standalone.services.scanner` as a single async function `scan_folder(root: Path) -> ScanResult`. Detection is the union of three independent paths (Idun config → `langgraph.json` → `.py` AST), deduplicated by `(file_path, variable_name)` keeping HIGH confidence over MEDIUM. The scanner is stateless, never mutates the filesystem, and never raises on malformed input.
+
+**Tech Stack:** Python 3.12 stdlib (`os`, `ast`, `re`, `tomllib`, `json`), `pydantic` 2.11+, `pyyaml` (already a standalone dep), `pytest` + `pytest-asyncio` (`asyncio_mode = auto` already configured for the standalone test suite).
+
+**Spec:** [`docs/superpowers/specs/2026-04-28-onboarding-scanner-design.md`](../specs/2026-04-28-onboarding-scanner-design.md)
+
+---
+
+## File map
+
+| File | Status | Responsibility |
+|---|---|---|
+| `libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py` | Create | `DetectedAgent` + `ScanResult` Pydantic models |
+| `libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py` | Modify | re-export the two new types |
+| `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py` | Create | `scan_folder` + private helpers (walk, three detection paths, dedup, inference cascade) |
+| `libs/idun_agent_standalone/tests/unit/services/test_scanner.py` | Create | unit tests, all fixtures via `pytest`'s `tmp_path` |
+
+---
+
+## Task 1: Schema (`DetectedAgent`, `ScanResult`)
+
+**Files:**
+- Create: `libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py`
+- Modify: `libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py`
+- Test: `libs/idun_agent_schema/tests/standalone/test_onboarding.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `libs/idun_agent_schema/tests/standalone/test_onboarding.py`:
+
+```python
+"""Wire-shape tests for the onboarding schema."""
+
+from __future__ import annotations
+
+from idun_agent_schema.standalone import DetectedAgent, ScanResult
+
+
+def test_detected_agent_camelcase_roundtrip() -> None:
+    """Snake-case input + camelCase output by default."""
+    agent = DetectedAgent(
+        framework="LANGGRAPH",
+        file_path="agent.py",
+        variable_name="graph",
+        inferred_name="My Agent",
+        confidence="HIGH",
+        source="config",
+    )
+    dumped = agent.model_dump(by_alias=True)
+    assert dumped == {
+        "framework": "LANGGRAPH",
+        "filePath": "agent.py",
+        "variableName": "graph",
+        "inferredName": "My Agent",
+        "confidence": "HIGH",
+        "source": "config",
+    }
+
+
+def test_scan_result_camelcase_roundtrip() -> None:
+    result = ScanResult(
+        root="/tmp/x",
+        detected=[],
+        has_python_files=False,
+        has_idun_config=False,
+        scan_duration_ms=42,
+    )
+    dumped = result.model_dump(by_alias=True)
+    assert dumped == {
+        "root": "/tmp/x",
+        "detected": [],
+        "hasPythonFiles": False,
+        "hasIdunConfig": False,
+        "scanDurationMs": 42,
+    }
+
+
+def test_detected_agent_rejects_unknown_framework() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        DetectedAgent(
+            framework="HAYSTACK",
+            file_path="x.py",
+            variable_name="x",
+            inferred_name="X",
+            confidence="HIGH",
+            source="config",
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest libs/idun_agent_schema/tests/standalone/test_onboarding.py -v
+```
+
+Expected: collection error or import error — `DetectedAgent` and `ScanResult` are not yet exported.
+
+- [ ] **Step 3: Create the schema module**
+
+Create `libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py`:
+
+```python
+"""Wire schema for the onboarding scanner.
+
+These models are shared by the standalone backend (which produces them)
+and the standalone UI (which consumes them through the onboarding API).
+The five-state wizard classification is *not* in this schema — it is
+derived at the API layer by combining a ``ScanResult`` with the DB
+state of the singleton agent row.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ._base import _CamelModel
+
+
+class DetectedAgent(_CamelModel):
+    """One agent the scanner found in the target folder."""
+
+    framework: Literal["LANGGRAPH", "ADK"]
+    file_path: str
+    variable_name: str
+    inferred_name: str
+    confidence: Literal["HIGH", "MEDIUM"]
+    source: Literal["config", "source", "langgraph_json"]
+
+
+class ScanResult(_CamelModel):
+    """Aggregate result of a single ``scan_folder`` call."""
+
+    root: str
+    detected: list[DetectedAgent]
+    has_python_files: bool
+    has_idun_config: bool
+    scan_duration_ms: int
+```
+
+- [ ] **Step 4: Re-export from the namespace `__init__`**
+
+Modify `libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py`. After the existing `from .observability import (...)` block (and before `from .prompts import (...)`), insert:
+
+```python
+from .onboarding import (  # noqa: F401
+    DetectedAgent,
+    ScanResult,
+)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+uv run pytest libs/idun_agent_schema/tests/standalone/test_onboarding.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py \
+        libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py \
+        libs/idun_agent_schema/tests/standalone/test_onboarding.py
+git commit -m "feat(schema): add onboarding ScanResult + DetectedAgent shapes"
+```
+
+---
+
+## Task 2: Scanner skeleton (walk, skip-list, depth limit, `has_python_files`)
+
+**Files:**
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py`
+- Test: `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`:
+
+```python
+"""Unit tests for ``services.scanner``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from idun_agent_standalone.services.scanner import scan_folder
+
+
+async def test_empty_folder(tmp_path: Path) -> None:
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+    assert result.has_python_files is False
+    assert result.has_idun_config is False
+    assert result.root == str(tmp_path)
+    assert result.scan_duration_ms >= 0
+
+
+async def test_has_python_files_set_when_py_present(tmp_path: Path) -> None:
+    (tmp_path / "noise.py").write_text("print('hi')\n")
+    result = await scan_folder(tmp_path)
+    assert result.has_python_files is True
+    assert result.detected == []
+
+
+async def test_skip_list_ignores_dot_venv(tmp_path: Path) -> None:
+    """A graph file inside .venv must not be detected."""
+    venv = tmp_path / ".venv" / "lib"
+    venv.mkdir(parents=True)
+    (venv / "trap.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+    # The walk did not recurse into .venv at all
+    assert result.has_python_files is False
+
+
+async def test_skip_list_ignores_dotted_dir(tmp_path: Path) -> None:
+    hidden = tmp_path / ".cache"
+    hidden.mkdir()
+    (hidden / "x.py").write_text("x = 1\n")
+    result = await scan_folder(tmp_path)
+    assert result.has_python_files is False
+
+
+async def test_depth_limit_4(tmp_path: Path) -> None:
+    """Files deeper than 4 levels are not visited."""
+    deep = tmp_path / "a" / "b" / "c" / "d" / "e"
+    deep.mkdir(parents=True)
+    (deep / "deep.py").write_text("x = 1\n")
+    shallow = tmp_path / "a" / "b" / "c" / "d"
+    (shallow / "shallow.py").write_text("y = 1\n")
+    result = await scan_folder(tmp_path)
+    # Depth ≤ 4 means up to 4 path components below the root, so
+    # ``a/b/c/d/shallow.py`` is in (4 components) and ``e/deep.py`` is out.
+    assert result.has_python_files is True  # shallow.py was visited
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v
+```
+
+Expected: collection error — `services.scanner` does not exist yet.
+
+- [ ] **Step 3: Implement the skeleton**
+
+Create `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py`:
+
+```python
+"""Pure-Python filesystem scanner for the onboarding wizard.
+
+Walks a folder, detects LangGraph and Google ADK agents from three
+sources (Idun config.yaml, langgraph.json, .py source via regex
+pre-filter + AST), and returns a structured ``ScanResult``.
+
+The scanner never mutates the filesystem, never raises on malformed
+input (parse errors are silently skipped), and runs purely off
+stdlib + pydantic + pyyaml. The five-state wizard classification is
+*not* the scanner's responsibility — it is derived at the API layer.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from idun_agent_schema.standalone import DetectedAgent, ScanResult
+
+from idun_agent_standalone.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".venv",
+        "venv",
+        "env",
+        "dist",
+        "build",
+        "target",
+    }
+)
+_MAX_DEPTH = 4
+_MAX_FILE_BYTES = 1_000_000  # 1 MB
+
+
+def _is_skipped(name: str) -> bool:
+    return name in _SKIP_DIRS or name.startswith(".")
+
+
+def _walk(root: Path):
+    """Yield (rel_path, abs_path) for every ``.py`` file under root.
+
+    Honors the skip-list and depth limit. Symlinks are not followed.
+    """
+    root_str = str(root)
+    for dirpath, dirnames, filenames in os.walk(root_str, followlinks=False):
+        rel = os.path.relpath(dirpath, root_str)
+        depth = 0 if rel == "." else len(Path(rel).parts)
+        if depth >= _MAX_DEPTH:
+            dirnames[:] = []  # do not descend further
+        # Prune skipped subdirs in-place so os.walk does not enter them.
+        dirnames[:] = [d for d in dirnames if not _is_skipped(d)]
+        for filename in filenames:
+            if not filename.endswith(".py"):
+                continue
+            abs_path = Path(dirpath) / filename
+            try:
+                if abs_path.stat().st_size > _MAX_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            rel_path = "" if rel == "." else rel
+            posix_rel = (Path(rel_path) / filename).as_posix()
+            yield posix_rel, abs_path
+
+
+async def scan_folder(root: Path) -> ScanResult:
+    """Walk ``root`` and return a ``ScanResult``.
+
+    Async for caller ergonomics — the parent spec wraps this in a 5s
+    ``asyncio.wait_for`` budget at the API layer. The function itself
+    is CPU-bound and does not need true async IO.
+    """
+    started = time.monotonic()
+    has_python_files = False
+    detected: list[DetectedAgent] = []
+
+    for _rel, _abs in _walk(root):
+        has_python_files = True
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    return ScanResult(
+        root=str(root),
+        detected=detected,
+        has_python_files=has_python_files,
+        has_idun_config=False,
+        scan_duration_ms=duration_ms,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py \
+        libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+git commit -m "feat(standalone): scanner skeleton with walk + skip-list + depth limit"
+```
+
+---
+
+## Task 3: `.py` source detection (LangGraph + ADK)
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py`
+- Modify: `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`:
+
+```python
+async def test_detect_minimal_langgraph(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "LANGGRAPH"
+    assert d.file_path == "agent.py"
+    assert d.variable_name == "graph"
+    assert d.confidence == "MEDIUM"
+    assert d.source == "source"
+
+
+async def test_detect_uncompiled_langgraph(tmp_path: Path) -> None:
+    """A bare StateGraph(...) assignment counts."""
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int)\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "graph"
+
+
+async def test_detect_compiled_via_intermediate(tmp_path: Path) -> None:
+    """g = StateGraph(...); graph = g.compile() → 1 detection on the compiled binding."""
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "g = StateGraph(int)\n"
+        "graph = g.compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "graph"
+
+
+async def test_no_false_positive_on_unrelated_compile(tmp_path: Path) -> None:
+    """``something.compile()`` with no traceable StateGraph receiver is ignored."""
+    (tmp_path / "noise.py").write_text(
+        "import re\n"
+        "pat = re.compile(r'x')\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_detect_minimal_adk(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text(
+        "from google.adk.agents import Agent\n"
+        "root_agent = Agent(name='x')\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "ADK"
+    assert d.variable_name == "root_agent"
+    assert d.source == "source"
+
+
+async def test_detect_adk_subclasses(tmp_path: Path) -> None:
+    """LlmAgent / SequentialAgent / ParallelAgent / LoopAgent all count."""
+    src = (
+        "from google.adk.agents import LlmAgent, SequentialAgent\n"
+        "from google.adk.agents import ParallelAgent, LoopAgent\n"
+        "a = LlmAgent(name='a')\n"
+        "b = SequentialAgent(name='b')\n"
+        "c = ParallelAgent(name='c')\n"
+        "d = LoopAgent(name='d')\n"
+    )
+    (tmp_path / "agents.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    names = {d.variable_name for d in result.detected}
+    assert names == {"a", "b", "c", "d"}
+
+
+async def test_skip_unparseable_source(tmp_path: Path) -> None:
+    """A SyntaxError in one file does not crash the scan."""
+    (tmp_path / "broken.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int  # missing paren\n"
+    )
+    (tmp_path / "good.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    files = {d.file_path for d in result.detected}
+    assert files == {"good.py"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v -k "detect or false_positive or unparseable"
+```
+
+Expected: 7 failures (no detection logic yet).
+
+- [ ] **Step 3: Implement source detection**
+
+Modify `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py`. Replace the imports section and add detection helpers. The full file content after this step:
+
+```python
+"""Pure-Python filesystem scanner for the onboarding wizard.
+
+Walks a folder, detects LangGraph and Google ADK agents from three
+sources (Idun config.yaml, langgraph.json, .py source via regex
+pre-filter + AST), and returns a structured ``ScanResult``.
+
+The scanner never mutates the filesystem, never raises on malformed
+input (parse errors are silently skipped), and runs purely off
+stdlib + pydantic + pyyaml. The five-state wizard classification is
+*not* the scanner's responsibility — it is derived at the API layer.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import time
+from pathlib import Path
+
+from idun_agent_schema.standalone import DetectedAgent, ScanResult
+
+from idun_agent_standalone.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".venv",
+        "venv",
+        "env",
+        "dist",
+        "build",
+        "target",
+    }
+)
+_MAX_DEPTH = 4
+_MAX_FILE_BYTES = 1_000_000  # 1 MB
+
+_LANGGRAPH_IMPORT_RE = re.compile(
+    r"(?m)^\s*(from\s+langgraph[\s.]|import\s+langgraph)"
+)
+_ADK_IMPORT_RE = re.compile(
+    r"(?m)^\s*(from\s+google\.adk|import\s+google\.adk)"
+)
+_ADK_AGENT_CLASSES = frozenset(
+    {"Agent", "LlmAgent", "SequentialAgent", "ParallelAgent", "LoopAgent"}
+)
+
+
+def _is_skipped(name: str) -> bool:
+    return name in _SKIP_DIRS or name.startswith(".")
+
+
+def _walk(root: Path):
+    """Yield (rel_path, abs_path) for every ``.py`` file under root.
+
+    Honors the skip-list and depth limit. Symlinks are not followed.
+    """
+    root_str = str(root)
+    for dirpath, dirnames, filenames in os.walk(root_str, followlinks=False):
+        rel = os.path.relpath(dirpath, root_str)
+        depth = 0 if rel == "." else len(Path(rel).parts)
+        if depth >= _MAX_DEPTH:
+            dirnames[:] = []
+        dirnames[:] = [d for d in dirnames if not _is_skipped(d)]
+        for filename in filenames:
+            if not filename.endswith(".py"):
+                continue
+            abs_path = Path(dirpath) / filename
+            try:
+                if abs_path.stat().st_size > _MAX_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            rel_path = "" if rel == "." else rel
+            posix_rel = (Path(rel_path) / filename).as_posix()
+            yield posix_rel, abs_path
+
+
+def _is_call_to(node: ast.AST, names: frozenset[str]) -> bool:
+    """True if ``node`` is a Call whose callable is a Name in ``names``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in names
+    return False
+
+
+def _is_state_graph_call(node: ast.AST) -> bool:
+    return _is_call_to(node, frozenset({"StateGraph"}))
+
+
+def _is_adk_agent_call(node: ast.AST) -> bool:
+    return _is_call_to(node, _ADK_AGENT_CLASSES)
+
+
+def _module_compile_target(node: ast.AST, state_graph_bindings: set[str]) -> bool:
+    """True if ``node`` is ``<expr>.compile(...)`` where receiver is a known StateGraph."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr != "compile":
+        return False
+    recv = func.value
+    if isinstance(recv, ast.Name) and recv.id in state_graph_bindings:
+        return True
+    if isinstance(recv, ast.Call) and _is_state_graph_call(recv):
+        return True
+    return False
+
+
+def _detect_in_source(rel_path: str, abs_path: Path) -> list[DetectedAgent]:
+    """Return all source-detected agents from a single ``.py`` file."""
+    try:
+        text = abs_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    has_lg = bool(_LANGGRAPH_IMPORT_RE.search(text))
+    has_adk = bool(_ADK_IMPORT_RE.search(text))
+    if not (has_lg or has_adk):
+        return []
+
+    try:
+        module = ast.parse(text)
+    except SyntaxError:
+        logger.debug("scanner: skip %s, syntax error", rel_path)
+        return []
+
+    found: list[DetectedAgent] = []
+    state_graph_bindings: set[str] = set()
+    compiled_from_binding: set[str] = set()
+
+    # First pass: collect StateGraph bindings so we can resolve `.compile()`.
+    for stmt in module.body:
+        targets = _assign_targets(stmt)
+        if not targets:
+            continue
+        rhs = _assign_rhs(stmt)
+        if rhs is None:
+            continue
+        if has_lg and _is_state_graph_call(rhs):
+            for name in targets:
+                state_graph_bindings.add(name)
+
+    # Second pass: emit detections.
+    for stmt in module.body:
+        targets = _assign_targets(stmt)
+        if not targets:
+            continue
+        rhs = _assign_rhs(stmt)
+        if rhs is None:
+            continue
+        target_name = targets[0]
+
+        if has_lg and _module_compile_target(rhs, state_graph_bindings):
+            # The compiled binding shadows the intermediate StateGraph
+            # binding (we only emit one detection per file/var).
+            compiled_from_binding.update(
+                _receiver_name(rhs)
+            )  # type: ignore[arg-type]
+            found.append(
+                DetectedAgent(
+                    framework="LANGGRAPH",
+                    file_path=rel_path,
+                    variable_name=target_name,
+                    inferred_name="",  # filled by inference cascade later
+                    confidence="MEDIUM",
+                    source="source",
+                )
+            )
+            continue
+
+        if has_lg and _is_state_graph_call(rhs):
+            found.append(
+                DetectedAgent(
+                    framework="LANGGRAPH",
+                    file_path=rel_path,
+                    variable_name=target_name,
+                    inferred_name="",
+                    confidence="MEDIUM",
+                    source="source",
+                )
+            )
+            continue
+
+        if has_adk and _is_adk_agent_call(rhs):
+            found.append(
+                DetectedAgent(
+                    framework="ADK",
+                    file_path=rel_path,
+                    variable_name=target_name,
+                    inferred_name="",
+                    confidence="MEDIUM",
+                    source="source",
+                )
+            )
+
+    # Drop the intermediate StateGraph binding when a compiled form
+    # also exists in the same file pointing at it.
+    if compiled_from_binding:
+        found = [
+            d
+            for d in found
+            if not (
+                d.framework == "LANGGRAPH" and d.variable_name in compiled_from_binding
+            )
+        ]
+    return found
+
+
+def _assign_targets(stmt: ast.AST) -> list[str]:
+    """Return the list of single-Name LHS targets for an Assign / AnnAssign."""
+    if isinstance(stmt, ast.Assign):
+        out: list[str] = []
+        for tgt in stmt.targets:
+            if isinstance(tgt, ast.Name):
+                out.append(tgt.id)
+        return out
+    if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+        return [stmt.target.id]
+    return []
+
+
+def _assign_rhs(stmt: ast.AST) -> ast.AST | None:
+    if isinstance(stmt, ast.Assign):
+        return stmt.value
+    if isinstance(stmt, ast.AnnAssign):
+        return stmt.value
+    return None
+
+
+def _receiver_name(call: ast.Call) -> set[str]:
+    """If call is `<Name>.compile(...)`, return {Name.id}; else empty."""
+    func = call.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return {func.value.id}
+    return set()
+
+
+async def scan_folder(root: Path) -> ScanResult:
+    """Walk ``root`` and return a ``ScanResult``."""
+    started = time.monotonic()
+    has_python_files = False
+    detected: list[DetectedAgent] = []
+
+    for rel, abs_path in _walk(root):
+        has_python_files = True
+        detected.extend(_detect_in_source(rel, abs_path))
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    return ScanResult(
+        root=str(root),
+        detected=detected,
+        has_python_files=has_python_files,
+        has_idun_config=False,
+        scan_duration_ms=duration_ms,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v
+```
+
+Expected: 12 passed (the 5 from Task 2 plus 7 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py \
+        libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+git commit -m "feat(standalone): detect LangGraph and ADK agents from .py source"
+```
+
+---
+
+## Task 4: `langgraph.json` detection at root
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py`
+- Modify: `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`:
+
+```python
+import json
+
+
+async def test_langgraph_json_single_graph(tmp_path: Path) -> None:
+    (tmp_path / "langgraph.json").write_text(
+        json.dumps(
+            {
+                "dependencies": ["./agent.py"],
+                "graphs": {"helpdesk": "./agent.py:graph"},
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "LANGGRAPH"
+    assert d.file_path == "agent.py"
+    assert d.variable_name == "graph"
+    assert d.confidence == "HIGH"
+    assert d.source == "langgraph_json"
+    # has_idun_config is *not* set by langgraph.json
+    assert result.has_idun_config is False
+
+
+async def test_langgraph_json_multiple_graphs(tmp_path: Path) -> None:
+    (tmp_path / "langgraph.json").write_text(
+        json.dumps(
+            {
+                "graphs": {
+                    "alpha": "./a.py:graph",
+                    "beta": "./b.py:graph",
+                },
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 2
+    assert {d.variable_name for d in result.detected} == {"graph"}
+    assert {d.file_path for d in result.detected} == {"a.py", "b.py"}
+
+
+async def test_langgraph_json_malformed_skipped(tmp_path: Path) -> None:
+    (tmp_path / "langgraph.json").write_text("{not valid json")
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_langgraph_json_only_at_root(tmp_path: Path) -> None:
+    """langgraph.json deeper than depth 0 is not consulted."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "langgraph.json").write_text(
+        json.dumps({"graphs": {"x": "./agent.py:graph"}})
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v -k "langgraph_json"
+```
+
+Expected: 4 failures.
+
+- [ ] **Step 3: Implement `langgraph.json` detection**
+
+Modify `scanner.py`. Add at the top of the imports:
+
+```python
+import json
+```
+
+Add a new helper after `_receiver_name`:
+
+```python
+def _detect_in_langgraph_json(root: Path) -> list[DetectedAgent]:
+    """Parse ``<root>/langgraph.json`` and emit one detection per graphs entry."""
+    path = root / "langgraph.json"
+    if not path.is_file():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        logger.debug("scanner: skip langgraph.json, parse error")
+        return []
+    if not isinstance(data, dict):
+        return []
+    graphs = data.get("graphs")
+    if not isinstance(graphs, dict):
+        return []
+
+    out: list[DetectedAgent] = []
+    for key, value in graphs.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        if ":" not in value:
+            continue
+        file_part, _, variable = value.partition(":")
+        # Strip leading "./" so the wire shape stays normalized.
+        rel = file_part.removeprefix("./").lstrip("/")
+        if not rel or not variable:
+            continue
+        out.append(
+            DetectedAgent(
+                framework="LANGGRAPH",
+                file_path=rel,
+                variable_name=variable,
+                inferred_name=key,  # langgraph.json key wins inference rule 2
+                confidence="HIGH",
+                source="langgraph_json",
+            )
+        )
+    return out
+```
+
+Modify the body of `scan_folder` to merge the new path:
+
+```python
+async def scan_folder(root: Path) -> ScanResult:
+    """Walk ``root`` and return a ``ScanResult``."""
+    started = time.monotonic()
+    has_python_files = False
+    detected: list[DetectedAgent] = []
+
+    detected.extend(_detect_in_langgraph_json(root))
+
+    for rel, abs_path in _walk(root):
+        has_python_files = True
+        detected.extend(_detect_in_source(rel, abs_path))
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    return ScanResult(
+        root=str(root),
+        detected=detected,
+        has_python_files=has_python_files,
+        has_idun_config=False,
+        scan_duration_ms=duration_ms,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v
+```
+
+Expected: 16 passed (12 prior + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py \
+        libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+git commit -m "feat(standalone): detect LangGraph agents from langgraph.json"
+```
+
+---
+
+## Task 5: Idun `config.yaml` detection (depth 0–2)
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py`
+- Modify: `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`:
+
+```python
+import yaml
+
+
+async def test_idun_config_langgraph(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {
+                        "name": "Helpdesk",
+                        "graph_definition": "./agent.py:graph",
+                    },
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is True
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "LANGGRAPH"
+    assert d.file_path == "agent.py"
+    assert d.variable_name == "graph"
+    assert d.confidence == "HIGH"
+    assert d.source == "config"
+
+
+async def test_idun_config_adk(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "ADK",
+                    "config": {
+                        "name": "Helpdesk",
+                        "agent": "./agent.py:root_agent",
+                    },
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is True
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "ADK"
+    assert d.variable_name == "root_agent"
+
+
+async def test_idun_config_yml_extension(tmp_path: Path) -> None:
+    (tmp_path / "config.yml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {"graph_definition": "./agent.py:graph"},
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is True
+    assert len(result.detected) == 1
+
+
+async def test_idun_config_at_depth_2(tmp_path: Path) -> None:
+    nested = tmp_path / "sub" / "deeper"
+    nested.mkdir(parents=True)
+    (nested / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {"graph_definition": "./agent.py:graph"},
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is True
+
+
+async def test_idun_config_at_depth_3_ignored(tmp_path: Path) -> None:
+    """Idun config at depth > 2 is not consulted."""
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    (nested / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {"graph_definition": "./agent.py:graph"},
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is False
+
+
+async def test_idun_config_malformed_skipped(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("not: valid: yaml: at: all:")
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is False
+    assert result.detected == []
+
+
+async def test_idun_config_unsupported_type_skipped(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "HAYSTACK",
+                    "config": {"component_definition": "./pipe.py:pipe"},
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is False
+    assert result.detected == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v -k "idun_config"
+```
+
+Expected: 7 failures.
+
+- [ ] **Step 3: Implement `config.yaml` detection**
+
+Modify `scanner.py`. Add at the top of the imports:
+
+```python
+import yaml
+```
+
+Add a new helper after `_detect_in_langgraph_json`:
+
+```python
+def _detect_in_idun_config(
+    root: Path,
+) -> tuple[list[DetectedAgent], bool]:
+    """Walk depth 0–2 for ``config.yaml`` / ``config.yml``.
+
+    Returns the detections plus a boolean ``has_idun_config`` that the
+    caller folds into the ``ScanResult``.
+    """
+    detections: list[DetectedAgent] = []
+    has_idun_config = False
+
+    for path in _iter_idun_config_paths(root, max_depth=2):
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, yaml.YAMLError):
+            logger.debug("scanner: skip %s, yaml error", path)
+            continue
+        if not isinstance(data, dict):
+            continue
+        agent = data.get("agent")
+        if not isinstance(agent, dict):
+            continue
+        agent_type = agent.get("type")
+        if agent_type not in ("LANGGRAPH", "ADK"):
+            continue
+        config = agent.get("config")
+        if not isinstance(config, dict):
+            continue
+
+        target = (
+            config.get("graph_definition")
+            if agent_type == "LANGGRAPH"
+            else config.get("agent")
+        )
+        if not isinstance(target, str) or ":" not in target:
+            continue
+        file_part, _, variable = target.partition(":")
+        rel = file_part.removeprefix("./").lstrip("/")
+        if not rel or not variable:
+            continue
+
+        has_idun_config = True
+        inferred = config.get("name")
+        if not isinstance(inferred, str) or not inferred:
+            inferred = ""  # filled by inference cascade
+        detections.append(
+            DetectedAgent(
+                framework=agent_type,
+                file_path=rel,
+                variable_name=variable,
+                inferred_name=inferred,
+                confidence="HIGH",
+                source="config",
+            )
+        )
+    return detections, has_idun_config
+
+
+def _iter_idun_config_paths(root: Path, *, max_depth: int):
+    """Yield candidate ``config.yaml`` / ``config.yml`` paths up to depth 2."""
+    for dirpath, dirnames, filenames in os.walk(str(root), followlinks=False):
+        rel = os.path.relpath(dirpath, str(root))
+        depth = 0 if rel == "." else len(Path(rel).parts)
+        if depth > max_depth:
+            dirnames[:] = []
+            continue
+        if depth == max_depth:
+            dirnames[:] = []
+        dirnames[:] = [d for d in dirnames if not _is_skipped(d)]
+        for filename in filenames:
+            if filename in ("config.yaml", "config.yml"):
+                yield Path(dirpath) / filename
+```
+
+Modify the body of `scan_folder` to add the new path:
+
+```python
+async def scan_folder(root: Path) -> ScanResult:
+    """Walk ``root`` and return a ``ScanResult``."""
+    started = time.monotonic()
+    has_python_files = False
+    detected: list[DetectedAgent] = []
+
+    config_detections, has_idun_config = _detect_in_idun_config(root)
+    detected.extend(config_detections)
+    detected.extend(_detect_in_langgraph_json(root))
+
+    for rel, abs_path in _walk(root):
+        has_python_files = True
+        detected.extend(_detect_in_source(rel, abs_path))
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    return ScanResult(
+        root=str(root),
+        detected=detected,
+        has_python_files=has_python_files,
+        has_idun_config=has_idun_config,
+        scan_duration_ms=duration_ms,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v
+```
+
+Expected: 23 passed (16 prior + 7 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py \
+        libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+git commit -m "feat(standalone): detect agents from Idun config.yaml (depth 0-2)"
+```
+
+---
+
+## Task 6: Deduplication on `(file_path, variable_name)`
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py`
+- Modify: `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`:
+
+```python
+async def test_dedup_config_over_source(tmp_path: Path) -> None:
+    """Config (HIGH) and source (MEDIUM) on same file:var → 1 entry, HIGH wins."""
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {
+                        "name": "From config",
+                        "graph_definition": "./agent.py:graph",
+                    },
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.confidence == "HIGH"
+    assert d.source == "config"
+    assert d.inferred_name == "From config"
+
+
+async def test_dedup_langgraph_json_over_source(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    (tmp_path / "langgraph.json").write_text(
+        json.dumps({"graphs": {"helpdesk": "./agent.py:graph"}})
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.source == "langgraph_json"
+    assert d.inferred_name == "helpdesk"
+
+
+async def test_distinct_files_not_deduped(tmp_path: Path) -> None:
+    """Two genuinely different agents both surface."""
+    (tmp_path / "alpha.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    (tmp_path / "beta.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v -k "dedup or distinct_files"
+```
+
+Expected: 2 failures (`test_distinct_files_not_deduped` already passes).
+
+- [ ] **Step 3: Implement deduplication**
+
+Modify `scanner.py`. Add a private helper above `scan_folder`:
+
+```python
+_CONFIDENCE_ORDER = {"HIGH": 2, "MEDIUM": 1}
+
+
+def _dedup(detections: list[DetectedAgent]) -> list[DetectedAgent]:
+    """Collapse entries sharing ``(file_path, variable_name)`` to the highest-confidence one.
+
+    Insertion order is preserved for the surviving entry. Ties on
+    confidence keep the first occurrence (i.e. the order
+    ``_detect_in_idun_config`` → ``_detect_in_langgraph_json`` →
+    ``_detect_in_source`` in ``scan_folder`` defines preference).
+    """
+    by_key: dict[tuple[str, str], DetectedAgent] = {}
+    for d in detections:
+        key = (d.file_path, d.variable_name)
+        existing = by_key.get(key)
+        if existing is None:
+            by_key[key] = d
+            continue
+        if _CONFIDENCE_ORDER[d.confidence] > _CONFIDENCE_ORDER[existing.confidence]:
+            by_key[key] = d
+    return list(by_key.values())
+```
+
+Modify the body of `scan_folder` to call `_dedup`:
+
+```python
+async def scan_folder(root: Path) -> ScanResult:
+    """Walk ``root`` and return a ``ScanResult``."""
+    started = time.monotonic()
+    has_python_files = False
+    raw: list[DetectedAgent] = []
+
+    config_detections, has_idun_config = _detect_in_idun_config(root)
+    raw.extend(config_detections)
+    raw.extend(_detect_in_langgraph_json(root))
+
+    for rel, abs_path in _walk(root):
+        has_python_files = True
+        raw.extend(_detect_in_source(rel, abs_path))
+
+    detected = _dedup(raw)
+    duration_ms = int((time.monotonic() - started) * 1000)
+    return ScanResult(
+        root=str(root),
+        detected=detected,
+        has_python_files=has_python_files,
+        has_idun_config=has_idun_config,
+        scan_duration_ms=duration_ms,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v
+```
+
+Expected: 26 passed (23 prior + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py \
+        libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+git commit -m "feat(standalone): dedup detections by (file_path, variable_name) keeping highest confidence"
+```
+
+---
+
+## Task 7: Inference cascade for `inferred_name`
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py`
+- Modify: `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`:
+
+```python
+async def test_inferred_name_uses_pyproject(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "my-bot"\nversion = "0.1.0"\n'
+    )
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "My Bot"
+
+
+async def test_inferred_name_falls_back_to_parent_dir(tmp_path: Path) -> None:
+    sub = tmp_path / "chat_assistant"
+    sub.mkdir()
+    (sub / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "Chat Assistant"
+
+
+async def test_inferred_name_skips_src_in_parent(tmp_path: Path) -> None:
+    """A src/ wrapper is skipped during parent-dir inference."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    # src/ is skipped → falls through to filename-based inference
+    assert result.detected[0].inferred_name == "Agent"
+
+
+async def test_inferred_name_strips_underscore_agent_suffix(tmp_path: Path) -> None:
+    (tmp_path / "chatbot_agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "Chatbot"
+
+
+async def test_inferred_name_fallback(tmp_path: Path) -> None:
+    """Filename ``agent.py`` with no parent context → titlecased filename, not fallback."""
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    # No pyproject, no parent dir, filename ``agent`` after stripping is empty
+    # so we fall through to the literal "My Agent" fallback.
+    assert result.detected[0].inferred_name == "My Agent"
+
+
+async def test_inferred_name_langgraph_json_key_wins(tmp_path: Path) -> None:
+    """langgraph.json key takes priority over pyproject."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "my-bot"\n'
+    )
+    (tmp_path / "langgraph.json").write_text(
+        json.dumps({"graphs": {"helpdesk": "./agent.py:graph"}})
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "helpdesk"
+
+
+async def test_inferred_name_config_name_wins(tmp_path: Path) -> None:
+    """Idun config.name takes priority over everything."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "my-bot"\n'
+    )
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {
+                        "name": "From Config",
+                        "graph_definition": "./agent.py:graph",
+                    },
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "From Config"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v -k "inferred_name"
+```
+
+Expected: 4–6 failures (the config-name and langgraph-json-key tests already pass since rules 1–2 are wired in earlier tasks; pyproject / parent-dir / filename / fallback rules are not).
+
+- [ ] **Step 3: Implement the inference cascade**
+
+Modify `scanner.py`. Add at the top of the imports:
+
+```python
+import tomllib
+```
+
+Add a private helper above `scan_folder`:
+
+```python
+_TRAILING_AGENT_RE = re.compile(r"_?agent$", re.IGNORECASE)
+
+
+def _humanize(token: str) -> str:
+    """Return a Title-Cased label from a slug-ish token (``my-bot`` → ``My Bot``)."""
+    parts = re.split(r"[-_\s]+", token.strip())
+    return " ".join(p.capitalize() for p in parts if p)
+
+
+def _read_pyproject_name(root: Path) -> str | None:
+    path = root / "pyproject.toml"
+    if not path.is_file():
+        return None
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    project = data.get("project")
+    if isinstance(project, dict):
+        name = project.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return None
+
+
+def _infer_name(detected: DetectedAgent, root: Path) -> str:
+    """Apply the 6-rule cascade to compute the human-friendly name.
+
+    Rules 1 and 2 — config.name and langgraph.json key — are already
+    populated by the detection paths; this function only fills the
+    blanks for source-detected entries (and overrides empty values
+    that slipped through from config without a name).
+    """
+    if detected.inferred_name:
+        return detected.inferred_name
+
+    pyproject_name = _read_pyproject_name(root)
+    if pyproject_name:
+        return _humanize(pyproject_name)
+
+    file_path = Path(detected.file_path)
+    parent = file_path.parent
+    # Rule 4: parent dir, skipping ``src``
+    if parent.parts and parent.parts != (".",):
+        candidate = parent.parts[-1]
+        if candidate == "src" and len(parent.parts) >= 2:
+            candidate = parent.parts[-2]
+        if candidate and candidate != "src":
+            return _humanize(candidate)
+
+    # Rule 5: filename without extension, strip ``_agent`` / ``agent``
+    stem = file_path.stem
+    stripped = _TRAILING_AGENT_RE.sub("", stem)
+    if stripped:
+        return _humanize(stripped)
+
+    return "My Agent"
+```
+
+Modify the body of `scan_folder` to apply the cascade after dedup:
+
+```python
+async def scan_folder(root: Path) -> ScanResult:
+    """Walk ``root`` and return a ``ScanResult``."""
+    started = time.monotonic()
+    has_python_files = False
+    raw: list[DetectedAgent] = []
+
+    config_detections, has_idun_config = _detect_in_idun_config(root)
+    raw.extend(config_detections)
+    raw.extend(_detect_in_langgraph_json(root))
+
+    for rel, abs_path in _walk(root):
+        has_python_files = True
+        raw.extend(_detect_in_source(rel, abs_path))
+
+    deduped = _dedup(raw)
+    detected = [
+        d.model_copy(update={"inferred_name": _infer_name(d, root)})
+        for d in deduped
+    ]
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    return ScanResult(
+        root=str(root),
+        detected=detected,
+        has_python_files=has_python_files,
+        has_idun_config=has_idun_config,
+        scan_duration_ms=duration_ms,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v
+```
+
+Expected: 33 passed (26 prior + 7 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py \
+        libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+git commit -m "feat(standalone): inference cascade for DetectedAgent.inferred_name"
+```
+
+---
+
+## Task 8: Final safety + integration coverage
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`
+
+- [ ] **Step 1: Write the final failing / coverage tests**
+
+Append to `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`:
+
+```python
+async def test_ipynb_files_ignored(tmp_path: Path) -> None:
+    """Notebook files are never parsed."""
+    (tmp_path / "agent.ipynb").write_text(
+        "{ \"cells\": [{ \"source\": [\"from langgraph.graph import StateGraph\\n\","
+        " \"graph = StateGraph(int).compile()\\n\"] }] }"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+    assert result.has_python_files is False
+
+
+async def test_oversized_py_skipped(tmp_path: Path) -> None:
+    """Files > 1 MB are skipped (binary heuristic)."""
+    (tmp_path / "huge.py").write_text("# pad\n" * 200_000)  # ~1.4 MB
+    result = await scan_folder(tmp_path)
+    assert result.has_python_files is False  # huge.py was skipped
+    assert result.detected == []
+
+
+async def test_scan_duration_populated(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.scan_duration_ms >= 0
+
+
+async def test_full_state_2_shape(tmp_path: Path) -> None:
+    """End-to-end: state-2 (one supported agent) feeds the wizard correctly."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "support-bot"\n'
+    )
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_python_files is True
+    assert result.has_idun_config is False
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "LANGGRAPH"
+    assert d.inferred_name == "Support Bot"
+    assert d.confidence == "MEDIUM"
+    assert d.source == "source"
+
+
+async def test_full_state_3_shape(tmp_path: Path) -> None:
+    """End-to-end: state-3 (multiple agents) returns a list the wizard can show."""
+    (tmp_path / "alpha.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    (tmp_path / "beta.py").write_text(
+        "from google.adk.agents import Agent\n"
+        "root_agent = Agent(name='b')\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 2
+    frameworks = {d.framework for d in result.detected}
+    assert frameworks == {"LANGGRAPH", "ADK"}
+```
+
+- [ ] **Step 2: Run all scanner tests**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py -v
+```
+
+Expected: 38 passed (33 prior + 5 new). No new implementation required — these tests cover existing behaviour.
+
+- [ ] **Step 3: Run the full standalone suite to check for regressions**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests
+```
+
+Expected: every prior test still green. The new scanner tests join the existing 156 baseline (plus the 30 from connection-checks if #536 has been merged) for a total around 194 — exact count depends on which umbrella commits are present.
+
+- [ ] **Step 4: Run the lint gate**
+
+```bash
+uv run ruff check libs/idun_agent_standalone/ libs/idun_agent_schema/src/idun_agent_schema/standalone/
+uv run black --check libs/idun_agent_standalone/ libs/idun_agent_schema/src/idun_agent_schema/standalone/
+uv run mypy libs/idun_agent_standalone/src/
+```
+
+Expected: all clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+git commit -m "test(standalone): scanner integration coverage for spec states 2 and 3"
+```
+
+---
+
+## Task 9: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/onboarding-scanner
+```
+
+(Adjust the branch name if you started from a different name; the rest of the umbrella has used `feat/<topic>` naming.)
+
+- [ ] **Step 2: Open the PR against the umbrella**
+
+```bash
+gh pr create --base feat/standalone-admin-db-rework --head feat/onboarding-scanner \
+  --title "feat(standalone): onboarding scanner — sub-project A" \
+  --body 'Implements the onboarding scanner per `docs/superpowers/specs/2026-04-28-onboarding-scanner-design.md`.
+
+Pure-Python filesystem walk, three detection paths (Idun config.yaml, langgraph.json, .py source via regex pre-filter + AST), deduplicated by (file_path, variable_name) with HIGH confidence winning over MEDIUM. Six-rule inference cascade for inferred_name. Notebooks ignored, files > 1 MB skipped, malformed YAML/JSON/Python silently skipped.
+
+Wire schema lives in idun_agent_schema/standalone/onboarding.py so the upcoming onboarding API (sub-project B) and UI (sub-project C) share one source of truth.
+
+## Tests
+
+38 unit tests under libs/idun_agent_standalone/tests/unit/services/test_scanner.py. The standalone test suite stays green end-to-end.
+
+## What this does NOT include
+
+- HTTP surface — sub-project B
+- Wizard UI — sub-project C
+- Five-state classification — sub-project B (the scanner stays stateless and deterministic)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** every section of the scanner spec maps to a task. Schema (§"Module location and public API") → Task 1. Walk + skip-list + depth + file size + `has_python_files` (§"Walk strategy" + §"Performance and safety") → Task 2 + Task 8. Source detection (§"Path 3") → Task 3. `langgraph.json` (§"Path 2") → Task 4. Idun `config.yaml` (§"Path 1" + `has_idun_config`) → Task 5. Dedup (§"Detection sources" intro paragraph) → Task 6. Inference cascade (§"Name inference cascade") → Task 7. Notebook ignore (§"Walk strategy") → Task 8. Safety on malformed input (§"Performance and safety") → covered across Tasks 3 / 4 / 5 with explicit tests.
+
+- **Placeholders:** no TBD / TODO / "implement later" / "similar to Task N" / vague guidance.
+
+- **Type consistency:** `DetectedAgent` and `ScanResult` field names match across Task 1 (definition) and every later task (usage). Helper names (`_walk`, `_is_skipped`, `_detect_in_source`, `_detect_in_langgraph_json`, `_detect_in_idun_config`, `_dedup`, `_infer_name`, `_humanize`, `_read_pyproject_name`) are introduced exactly once and referenced consistently. The `source` literal triple `"config" | "source" | "langgraph_json"` is the same in the schema (Task 1) and in every detection path (Tasks 3 / 4 / 5).

--- a/docs/superpowers/plans/2026-04-29-onboarding-http-api.md
+++ b/docs/superpowers/plans/2026-04-29-onboarding-http-api.md
@@ -1,0 +1,1839 @@
+# Onboarding HTTP API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship sub-project B from `2026-04-29-onboarding-http-api-design.md`: three HTTP endpoints under `/admin/api/v1/onboarding/` that scan the user's project, materialize an agent from a detection, or scaffold a starter project — all wired to the existing reload pipeline.
+
+**Architecture:** Three thin endpoints in `routers/onboarding.py` delegating to a stateless `services/onboarding.py` (state classification, EngineConfig assembly from a detection) and a pure-IO `services/scaffold.py` (template strings + atomic writes). Materialize endpoints use the same `commit_with_reload` pipeline as `agent.py`/`memory.py`, returning `StandaloneMutationResponse[StandaloneAgentRead]`.
+
+**Tech Stack:** Python 3.12+, FastAPI, SQLAlchemy 2.x async, Pydantic 2.11+, pytest-asyncio, httpx ASGITransport.
+
+**Branch:** `feat/onboarding-scanner` — extending the same branch that PR #538 lives on. Additive only.
+
+---
+
+## Files at a glance
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py` | Modify | Add `OnboardingState`, `ScanResponse`, `CreateFromDetectionBody`, `CreateStarterBody` |
+| `libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py` | Modify | Re-export the new classes |
+| `libs/idun_agent_schema/tests/standalone/test_onboarding.py` | Modify | Add tests for the new wire models |
+| `libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py` | Create | Template strings + atomic 5-file writer + `ScaffoldConflictError` |
+| `libs/idun_agent_standalone/tests/unit/services/test_scaffold.py` | Create | Unit tests for the scaffolder |
+| `libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py` | Create | `classify_state`, EngineConfig builder, materialize functions |
+| `libs/idun_agent_standalone/tests/unit/services/test_onboarding.py` | Create | Unit tests for the service |
+| `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py` | Create | 3 endpoints + error translation |
+| `libs/idun_agent_standalone/src/idun_agent_standalone/app.py` | Modify | Wire the new router |
+| `libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py` | Create | Integration tests for all 3 endpoints |
+
+---
+
+## Pattern reminders for implementers
+
+When implementing, lean on these existing patterns (not abstractions to invent):
+
+- **camelCase schemas:** `_CamelModel` from `idun_agent_schema.standalone._base`. Pydantic `populate_by_name=True` is already configured — accepts both snake_case and camelCase on input.
+- **Mutation envelope:** `StandaloneMutationResponse[StandaloneAgentRead]` with `data` + `reload: StandaloneReloadResult`.
+- **Reload pipeline:** Acquire `reload_service._reload_mutex`, stage the row, `await session.flush()`, then `result = await commit_with_reload(session, reload_callable=reload_callable)`. The pipeline owns commit/rollback.
+- **Error envelope:** Raise `AdminAPIError(status_code=..., error=StandaloneAdminError(code=StandaloneErrorCode.CONFLICT, message=...))`. The exception handler renders the wire shape.
+- **DI:** `SessionDep`, `ReloadCallableDep` from `api/v1/deps.py`. `Depends(require_auth)` is wired at `app.include_router(...)` level — don't re-add per-endpoint.
+- **Engine config keys:** LangGraph uses `agent.config.graph_definition`. ADK uses `agent.config.agent`. Framework name on the wire: `"LANGGRAPH"` / `"ADK"` (uppercase strings, matching `AgentFramework` enum values).
+- **Scanner output:** Each `DetectedAgent` already has `framework`, `file_path`, `variable_name`, `inferred_name`, `confidence`, `source`. Re-scan callers compare on `(framework, file_path, variable_name)` only.
+- **Integration test layout:** Each test file builds its own minimal `FastAPI()` with the routers it needs (see `test_memory_flow.py:admin_app`). Reuses `async_session`, `stub_reload_callable` fixtures from `conftest.py`. Use `monkeypatch.chdir(tmp_path)` to isolate scan root.
+
+---
+
+## Task 1: Schema additions for the wizard wire format
+
+**Files:**
+- Modify: `libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py`
+- Modify: `libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py`
+- Test: `libs/idun_agent_schema/tests/standalone/test_onboarding.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `libs/idun_agent_schema/tests/standalone/test_onboarding.py`:
+
+```python
+from idun_agent_schema.standalone import (
+    CreateFromDetectionBody,
+    CreateStarterBody,
+    DetectedAgent,
+    ScanResponse,
+    ScanResult,
+)
+
+
+def test_scan_response_camel_case_serialization() -> None:
+    response = ScanResponse(
+        state="EMPTY",
+        scan_result=ScanResult(
+            root="/tmp/foo",
+            detected=[],
+            has_python_files=False,
+            has_idun_config=False,
+            scan_duration_ms=12,
+        ),
+        current_agent=None,
+    )
+    dumped = response.model_dump(by_alias=True)
+    assert dumped["state"] == "EMPTY"
+    assert dumped["scanResult"]["hasPythonFiles"] is False
+    assert dumped["currentAgent"] is None
+
+
+def test_scan_response_already_configured_carries_current_agent() -> None:
+    """When state == ALREADY_CONFIGURED the UI needs the current agent payload."""
+    response = ScanResponse.model_validate(
+        {
+            "state": "ALREADY_CONFIGURED",
+            "scanResult": {
+                "root": "/tmp/foo",
+                "detected": [],
+                "hasPythonFiles": True,
+                "hasIdunConfig": False,
+                "scanDurationMs": 0,
+            },
+            "currentAgent": None,
+        }
+    )
+    assert response.state == "ALREADY_CONFIGURED"
+
+
+def test_create_from_detection_body_accepts_camel_case() -> None:
+    body = CreateFromDetectionBody.model_validate(
+        {
+            "framework": "LANGGRAPH",
+            "filePath": "agent.py",
+            "variableName": "graph",
+        }
+    )
+    assert body.file_path == "agent.py"
+    assert body.variable_name == "graph"
+
+
+def test_create_from_detection_body_rejects_unknown_framework() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateFromDetectionBody(
+            framework="HAYSTACK",  # type: ignore[arg-type]
+            file_path="agent.py",
+            variable_name="graph",
+        )
+
+
+def test_create_starter_body_default_name_is_none() -> None:
+    body = CreateStarterBody(framework="LANGGRAPH")
+    assert body.name is None
+
+
+def test_create_starter_body_rejects_empty_name() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateStarterBody(framework="LANGGRAPH", name="")
+
+
+def test_create_starter_body_rejects_overlong_name() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateStarterBody(framework="LANGGRAPH", name="x" * 81)
+```
+
+- [ ] **Step 2: Run tests — they must fail**
+
+```bash
+uv run pytest libs/idun_agent_schema/tests/standalone/test_onboarding.py -v
+```
+
+Expected: ImportError or AttributeError on `ScanResponse` / `CreateFromDetectionBody` / `CreateStarterBody`.
+
+- [ ] **Step 3: Add the schema classes**
+
+Append to `libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py`:
+
+```python
+# Add to imports at the top of the file (alongside existing imports):
+from pydantic import Field
+
+from .agent import StandaloneAgentRead
+
+
+# Append after the existing ScanResult class:
+
+OnboardingState = Literal[
+    "EMPTY",
+    "NO_SUPPORTED",
+    "ONE_DETECTED",
+    "MANY_DETECTED",
+    "ALREADY_CONFIGURED",
+]
+
+
+class ScanResponse(_CamelModel):
+    """Response for ``POST /admin/api/v1/onboarding/scan``.
+
+    The five-state classification is computed server-side from the
+    scan result plus the agent row's existence. ``current_agent`` is
+    only populated when ``state == "ALREADY_CONFIGURED"``.
+    """
+
+    state: OnboardingState
+    scan_result: ScanResult
+    current_agent: StandaloneAgentRead | None = None
+
+
+class CreateFromDetectionBody(_CamelModel):
+    """Body for ``POST /admin/api/v1/onboarding/create-from-detection``.
+
+    The triple ``(framework, file_path, variable_name)`` is the lookup
+    key for re-validation against a fresh scan inside the handler.
+    ``inferred_name`` is intentionally not on the wire — the server
+    computes it from the fresh scan, not from the body.
+    """
+
+    framework: Literal["LANGGRAPH", "ADK"]
+    file_path: str
+    variable_name: str
+
+
+class CreateStarterBody(_CamelModel):
+    """Body for ``POST /admin/api/v1/onboarding/create-starter``.
+
+    ``name`` is optional. When omitted the server uses
+    ``"Starter Agent"``. Empty string is rejected.
+    """
+
+    framework: Literal["LANGGRAPH", "ADK"]
+    name: str | None = Field(default=None, min_length=1, max_length=80)
+```
+
+- [ ] **Step 4: Add re-exports**
+
+Modify `libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py`:
+
+Replace the existing `onboarding` import block:
+
+```python
+from .onboarding import (  # noqa: F401
+    DetectedAgent,
+    ScanResult,
+)
+```
+
+with:
+
+```python
+from .onboarding import (  # noqa: F401
+    CreateFromDetectionBody,
+    CreateStarterBody,
+    DetectedAgent,
+    OnboardingState,
+    ScanResponse,
+    ScanResult,
+)
+```
+
+- [ ] **Step 5: Run tests — must pass**
+
+```bash
+uv run pytest libs/idun_agent_schema/tests/standalone/test_onboarding.py -v
+```
+
+Expected: 7+ tests pass (3 pre-existing from sub-project A + 7 new).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+uv run ruff check libs/idun_agent_schema/
+uv run black --check libs/idun_agent_schema/
+git add libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py \
+        libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py \
+        libs/idun_agent_schema/tests/standalone/test_onboarding.py
+git commit -m "feat(schema): wire models for onboarding HTTP API"
+```
+
+---
+
+## Task 2: Scaffolder — LangGraph templates + happy path
+
+**Files:**
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py`
+- Create: `libs/idun_agent_standalone/tests/unit/services/test_scaffold.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `libs/idun_agent_standalone/tests/unit/services/test_scaffold.py`:
+
+```python
+"""Unit tests for the starter-project scaffolder."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from idun_agent_standalone.services import scaffold
+
+
+def test_create_starter_langgraph_writes_five_files(tmp_path: Path) -> None:
+    written = scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+
+    expected_names = {
+        "agent.py",
+        "requirements.txt",
+        ".env.example",
+        "README.md",
+        ".gitignore",
+    }
+    assert {p.name for p in written} == expected_names
+    for path in written:
+        assert path.exists()
+        assert path.is_file()
+
+
+def test_langgraph_agent_py_is_syntactically_valid(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    source = (tmp_path / "agent.py").read_text()
+    # ast.parse raises SyntaxError on invalid source
+    ast.parse(source)
+    # Sanity: the variable our scanner expects is present.
+    assert "graph = " in source
+
+
+def test_langgraph_requirements_lists_idun_and_langgraph(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    contents = (tmp_path / "requirements.txt").read_text()
+    assert "idun-agent-standalone" in contents
+    assert "langgraph" in contents
+
+
+def test_langgraph_env_example_carries_openai_key(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    assert "OPENAI_API_KEY" in (tmp_path / ".env.example").read_text()
+
+
+def test_gitignore_covers_env_and_caches(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    contents = (tmp_path / ".gitignore").read_text()
+    for entry in (".env", "__pycache__/", ".venv/"):
+        assert entry in contents
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scaffold.py -v
+```
+
+Expected: ImportError on `scaffold` module.
+
+- [ ] **Step 3: Implement the LangGraph scaffolder**
+
+Create `libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py`:
+
+```python
+"""Starter project scaffolder.
+
+Pure-IO module: emits a fixed set of files into a target directory.
+No DB, no FastAPI, no event loop. Imported by the onboarding HTTP
+endpoint and (later) by sub-project D's ``idun init`` CLI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final, Literal
+
+from idun_agent_standalone.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ScaffoldConflictError(Exception):
+    """Raised when one or more target files already exist.
+
+    Holds ``paths`` so the router can echo them back to the UI for a
+    human-readable conflict message. The scaffolder writes nothing
+    when it raises this, so the user can resolve manually and retry.
+    """
+
+    def __init__(self, paths: list[Path]) -> None:
+        self.paths = paths
+        super().__init__(f"Scaffold conflict: {[str(p) for p in paths]}")
+
+
+_LANGGRAPH_AGENT_PY: Final[str] = '''\
+"""Minimal LangGraph hello-world agent."""
+
+from typing import TypedDict
+
+from langgraph.graph import END, StateGraph
+
+
+class State(TypedDict):
+    message: str
+
+
+def echo(state: State) -> State:
+    return {"message": f"You said: {state['message']}"}
+
+
+_builder = StateGraph(State)
+_builder.add_node("echo", echo)
+_builder.set_entry_point("echo")
+_builder.add_edge("echo", END)
+graph = _builder.compile()
+'''
+
+
+_LANGGRAPH_REQUIREMENTS: Final[str] = """\
+idun-agent-standalone
+langgraph>=0.2.0
+langchain-core>=0.3.0
+langchain-openai>=0.2.0
+"""
+
+
+_LANGGRAPH_ENV_EXAMPLE: Final[str] = "OPENAI_API_KEY=\n"
+
+
+_README: Final[str] = """\
+# My Idun Agent
+
+Quick start:
+
+1. Copy `.env.example` to `.env` and fill in your API key.
+2. `pip install -r requirements.txt`
+3. `idun standalone`
+
+Edit `agent.py` to customize the agent.
+"""
+
+
+_GITIGNORE: Final[str] = """\
+.env
+__pycache__/
+*.pyc
+.venv/
+.idun/
+"""
+
+
+def _build_file_map(
+    root: Path,
+    framework: Literal["LANGGRAPH", "ADK"],
+) -> dict[Path, str]:
+    if framework == "LANGGRAPH":
+        agent_py = _LANGGRAPH_AGENT_PY
+        requirements = _LANGGRAPH_REQUIREMENTS
+        env_example = _LANGGRAPH_ENV_EXAMPLE
+    else:
+        # ADK templates land in Task 3.
+        raise NotImplementedError(f"Framework not yet supported: {framework}")
+    return {
+        root / "agent.py": agent_py,
+        root / "requirements.txt": requirements,
+        root / ".env.example": env_example,
+        root / "README.md": _README,
+        root / ".gitignore": _GITIGNORE,
+    }
+
+
+def create_starter_project(
+    root: Path,
+    framework: Literal["LANGGRAPH", "ADK"],
+) -> list[Path]:
+    """Atomically write the 5-file starter into ``root``.
+
+    Either all files land or none do. On any mid-write IO failure we
+    remove anything we managed to create so the user's working
+    directory is untouched.
+    """
+    files = _build_file_map(root, framework)
+    conflicts = [p for p in files if p.exists()]
+    if conflicts:
+        logger.info("scaffold.conflict count=%d", len(conflicts))
+        raise ScaffoldConflictError(conflicts)
+
+    written: list[Path] = []
+    try:
+        for path, content in files.items():
+            tmp = path.with_suffix(path.suffix + ".idun-tmp")
+            tmp.write_text(content)
+            tmp.replace(path)
+            written.append(path)
+    except Exception:
+        for p in written:
+            p.unlink(missing_ok=True)
+        raise
+
+    logger.info("scaffold.written framework=%s count=%d", framework, len(written))
+    return written
+```
+
+- [ ] **Step 4: Run tests — must pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scaffold.py -v
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py \
+        libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
+git commit -m "feat(standalone): scaffold service — LangGraph starter templates"
+```
+
+---
+
+## Task 3: Scaffolder — ADK templates
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py`
+- Modify: `libs/idun_agent_standalone/tests/unit/services/test_scaffold.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `libs/idun_agent_standalone/tests/unit/services/test_scaffold.py`:
+
+```python
+def test_create_starter_adk_writes_five_files(tmp_path: Path) -> None:
+    written = scaffold.create_starter_project(tmp_path, framework="ADK")
+    assert {p.name for p in written} == {
+        "agent.py",
+        "requirements.txt",
+        ".env.example",
+        "README.md",
+        ".gitignore",
+    }
+
+
+def test_adk_agent_py_is_syntactically_valid(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="ADK")
+    source = (tmp_path / "agent.py").read_text()
+    ast.parse(source)
+    # The scanner expects an `agent` variable bound to an ADK Agent.
+    assert "agent = " in source
+    assert "Agent(" in source
+
+
+def test_adk_requirements_lists_idun_and_adk(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="ADK")
+    contents = (tmp_path / "requirements.txt").read_text()
+    assert "idun-agent-standalone" in contents
+    assert "google-adk" in contents
+
+
+def test_adk_env_example_carries_google_key(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="ADK")
+    assert "GOOGLE_API_KEY" in (tmp_path / ".env.example").read_text()
+```
+
+- [ ] **Step 2: Run new tests — must fail**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scaffold.py -v -k adk
+```
+
+Expected: 4 ADK tests fail with `NotImplementedError`.
+
+- [ ] **Step 3: Add ADK templates**
+
+Modify `libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py`:
+
+Add these constants below the existing LangGraph constants:
+
+```python
+_ADK_AGENT_PY: Final[str] = '''\
+"""Minimal Google ADK hello-world agent."""
+
+from google.adk.agents import Agent
+
+agent = Agent(
+    name="starter",
+    model="gemini-2.0-flash",
+    description="A minimal starter agent.",
+    instruction="You are a helpful assistant. Respond concisely.",
+)
+'''
+
+
+_ADK_REQUIREMENTS: Final[str] = """\
+idun-agent-standalone
+google-adk>=0.1.0
+"""
+
+
+_ADK_ENV_EXAMPLE: Final[str] = "GOOGLE_API_KEY=\n"
+```
+
+Replace the body of `_build_file_map` to dispatch on framework:
+
+```python
+def _build_file_map(
+    root: Path,
+    framework: Literal["LANGGRAPH", "ADK"],
+) -> dict[Path, str]:
+    if framework == "LANGGRAPH":
+        agent_py = _LANGGRAPH_AGENT_PY
+        requirements = _LANGGRAPH_REQUIREMENTS
+        env_example = _LANGGRAPH_ENV_EXAMPLE
+    elif framework == "ADK":
+        agent_py = _ADK_AGENT_PY
+        requirements = _ADK_REQUIREMENTS
+        env_example = _ADK_ENV_EXAMPLE
+    else:  # pragma: no cover — Literal exhausts at type-check time
+        raise ValueError(f"Unknown framework: {framework}")
+    return {
+        root / "agent.py": agent_py,
+        root / "requirements.txt": requirements,
+        root / ".env.example": env_example,
+        root / "README.md": _README,
+        root / ".gitignore": _GITIGNORE,
+    }
+```
+
+- [ ] **Step 4: Run tests — must pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scaffold.py -v
+```
+
+Expected: 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py \
+        libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
+git commit -m "feat(standalone): scaffold service — ADK starter templates"
+```
+
+---
+
+## Task 4: Scaffolder — atomicity + cleanup
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/tests/unit/services/test_scaffold.py`
+
+The scaffolder code already implements conflict-check and cleanup (Task 2). This task adds the tests that pin those behaviors so they don't regress.
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `libs/idun_agent_standalone/tests/unit/services/test_scaffold.py`:
+
+```python
+def test_conflict_pre_check_raises_with_paths(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text("# pre-existing\n")
+    (tmp_path / ".gitignore").write_text("# pre-existing\n")
+    with pytest.raises(scaffold.ScaffoldConflictError) as exc_info:
+        scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    conflicts = {p.name for p in exc_info.value.paths}
+    assert conflicts == {"agent.py", ".gitignore"}
+
+
+def test_conflict_writes_zero_files(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text("# pre-existing\n")
+    pre_count = len(list(tmp_path.iterdir()))
+    with pytest.raises(scaffold.ScaffoldConflictError):
+        scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    assert len(list(tmp_path.iterdir())) == pre_count
+
+
+def test_mid_write_failure_cleans_up_partial_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If write_text raises midway through, already-written files get unlinked."""
+    real_write_text = Path.write_text
+    call_count = {"n": 0}
+
+    def flaky_write_text(self: Path, content: str, *args: object, **kwargs: object) -> int:
+        call_count["n"] += 1
+        # Fail on the 3rd file written (any in-progress write triggers cleanup).
+        if call_count["n"] == 3:
+            raise OSError("simulated disk full")
+        return real_write_text(self, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", flaky_write_text)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+
+    # Cleanup loop only removes files we successfully renamed before the failure.
+    leftover = {p.name for p in tmp_path.iterdir() if not p.name.endswith(".idun-tmp")}
+    assert leftover == set(), f"unexpected leftover files: {leftover}"
+
+
+def test_returned_paths_resolve_inside_root(tmp_path: Path) -> None:
+    written = scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    for path in written:
+        assert path.parent == tmp_path
+```
+
+- [ ] **Step 2: Run tests — verify all pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scaffold.py -v
+```
+
+Expected: 13 tests pass. (Conflict and cleanup behavior already implemented in Task 2 — these tests validate the contract.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
+git commit -m "test(standalone): pin scaffold atomicity and cleanup contracts"
+```
+
+---
+
+## Task 5: Onboarding service — state classification + EngineConfig builder
+
+**Files:**
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py`
+- Create: `libs/idun_agent_standalone/tests/unit/services/test_onboarding.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `libs/idun_agent_standalone/tests/unit/services/test_onboarding.py`:
+
+```python
+"""Unit tests for the onboarding service helpers."""
+
+from __future__ import annotations
+
+import pytest
+from idun_agent_schema.standalone import DetectedAgent, ScanResult
+from idun_agent_standalone.services import onboarding
+
+
+def _scan_result(
+    *,
+    detected: list[DetectedAgent] | None = None,
+    has_python_files: bool = False,
+    has_idun_config: bool = False,
+) -> ScanResult:
+    return ScanResult(
+        root="/tmp",
+        detected=detected or [],
+        has_python_files=has_python_files,
+        has_idun_config=has_idun_config,
+        scan_duration_ms=0,
+    )
+
+
+def _det(framework: str = "LANGGRAPH", *, name: str = "Agent") -> DetectedAgent:
+    return DetectedAgent(
+        framework=framework,  # type: ignore[arg-type]
+        file_path="agent.py",
+        variable_name="graph" if framework == "LANGGRAPH" else "agent",
+        inferred_name=name,
+        confidence="HIGH",
+        source="source",
+    )
+
+
+def test_classify_state_already_configured_short_circuits() -> None:
+    """Agent row trumps everything else."""
+    state = onboarding.classify_state(
+        _scan_result(detected=[_det()]), agent_row_exists=True
+    )
+    assert state == "ALREADY_CONFIGURED"
+
+
+def test_classify_state_empty() -> None:
+    state = onboarding.classify_state(_scan_result(), agent_row_exists=False)
+    assert state == "EMPTY"
+
+
+def test_classify_state_no_supported() -> None:
+    state = onboarding.classify_state(
+        _scan_result(has_python_files=True), agent_row_exists=False
+    )
+    assert state == "NO_SUPPORTED"
+
+
+def test_classify_state_one_detected() -> None:
+    state = onboarding.classify_state(
+        _scan_result(detected=[_det()], has_python_files=True),
+        agent_row_exists=False,
+    )
+    assert state == "ONE_DETECTED"
+
+
+def test_classify_state_many_detected() -> None:
+    state = onboarding.classify_state(
+        _scan_result(
+            detected=[_det(name="A"), _det(name="B")],
+            has_python_files=True,
+        ),
+        agent_row_exists=False,
+    )
+    assert state == "MANY_DETECTED"
+
+
+def test_engine_config_for_langgraph_detection() -> None:
+    detection = _det(framework="LANGGRAPH", name="My Agent")
+    config_dict = onboarding.engine_config_dict_from_detection(detection)
+    assert config_dict["agent"]["type"] == "LANGGRAPH"
+    assert config_dict["agent"]["config"]["graph_definition"] == "agent.py:graph"
+    # Names that hit the engine config must be slugified — engine ADK validator
+    # derives app_name from name, and arbitrary unicode breaks downstream.
+    assert config_dict["agent"]["config"]["name"]
+
+
+def test_engine_config_for_adk_detection() -> None:
+    detection = _det(framework="ADK", name="My Agent")
+    config_dict = onboarding.engine_config_dict_from_detection(detection)
+    assert config_dict["agent"]["type"] == "ADK"
+    assert config_dict["agent"]["config"]["agent"] == "agent.py:agent"
+    assert config_dict["agent"]["config"]["name"]
+
+
+def test_engine_config_for_starter_langgraph() -> None:
+    config_dict = onboarding.engine_config_dict_for_starter(
+        framework="LANGGRAPH", name="Starter Agent"
+    )
+    assert config_dict["agent"]["type"] == "LANGGRAPH"
+    assert config_dict["agent"]["config"]["graph_definition"] == "agent.py:graph"
+
+
+def test_engine_config_for_starter_adk() -> None:
+    config_dict = onboarding.engine_config_dict_for_starter(
+        framework="ADK", name="Starter Agent"
+    )
+    assert config_dict["agent"]["type"] == "ADK"
+    assert config_dict["agent"]["config"]["agent"] == "agent.py:agent"
+
+
+def test_engine_config_passes_engine_validation_langgraph() -> None:
+    """The dict we hand to StandaloneAgentRow.base_engine_config must validate."""
+    from idun_agent_schema.engine import EngineConfig
+
+    detection = _det(framework="LANGGRAPH", name="Foo")
+    EngineConfig.model_validate(onboarding.engine_config_dict_from_detection(detection))
+
+
+def test_engine_config_passes_engine_validation_adk() -> None:
+    from idun_agent_schema.engine import EngineConfig
+
+    detection = _det(framework="ADK", name="Foo")
+    EngineConfig.model_validate(onboarding.engine_config_dict_from_detection(detection))
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_onboarding.py -v
+```
+
+Expected: ImportError on `idun_agent_standalone.services.onboarding`.
+
+- [ ] **Step 3: Implement the service helpers**
+
+Create `libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py`:
+
+```python
+"""Onboarding service: state classification + EngineConfig assembly.
+
+This module is the orchestration layer between the ``/onboarding/*``
+HTTP endpoints, the scanner (read-only), and the scaffolder
+(side-effecting). It owns:
+
+  - The 5-state classification rule.
+  - Building an ``EngineConfig`` dict from a ``DetectedAgent``.
+  - Building an ``EngineConfig`` dict for a starter scaffold.
+  - The two materialize coroutines that insert the singleton agent
+    row and run it through the existing ``commit_with_reload`` pipeline.
+
+Errors raised here are translated to HTTP envelopes by the router.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Literal
+
+from fastapi import status as http_status
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_schema.standalone import (
+    CreateFromDetectionBody,
+    CreateStarterBody,
+    DetectedAgent,
+    OnboardingState,
+    ScanResult,
+    StandaloneAdminError,
+    StandaloneAgentRead,
+    StandaloneErrorCode,
+    StandaloneMutationResponse,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from idun_agent_standalone.api.v1.errors import AdminAPIError
+from idun_agent_standalone.core.logging import get_logger
+from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.services import reload as reload_service
+from idun_agent_standalone.services import scaffold, scanner
+from idun_agent_standalone.services.reload import commit_with_reload
+
+ReloadCallable = Callable[[EngineConfig], Awaitable[None]]
+
+logger = get_logger(__name__)
+
+
+_STARTER_DEFAULT_NAME = "Starter Agent"
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(name: str) -> str:
+    """Return a slug suitable for ``agent.config.name``.
+
+    The engine's ADK validator derives ``app_name`` from ``name`` by
+    lower-casing and replacing non-alphanumerics with ``_``, so we run
+    the same transformation up-front to keep the value stable across
+    re-validations and avoid surprising round-trip differences.
+    Falls back to ``"agent"`` when the input slugifies to empty.
+    """
+    slug = _SLUG_RE.sub("_", name.lower()).strip("_")
+    return slug or "agent"
+
+
+def classify_state(
+    scan_result: ScanResult,
+    *,
+    agent_row_exists: bool,
+) -> OnboardingState:
+    """Compute the wizard's 5-state classification."""
+    if agent_row_exists:
+        return "ALREADY_CONFIGURED"
+    if not scan_result.has_python_files:
+        return "EMPTY"
+    if not scan_result.detected:
+        return "NO_SUPPORTED"
+    if len(scan_result.detected) == 1:
+        return "ONE_DETECTED"
+    return "MANY_DETECTED"
+
+
+def engine_config_dict_from_detection(detection: DetectedAgent) -> dict[str, Any]:
+    """Build the ``base_engine_config`` dict from a detected agent."""
+    name_slug = _slugify(detection.inferred_name)
+    if detection.framework == "LANGGRAPH":
+        agent_block: dict[str, Any] = {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": name_slug,
+                "graph_definition": f"{detection.file_path}:{detection.variable_name}",
+            },
+        }
+    else:
+        agent_block = {
+            "type": "ADK",
+            "config": {
+                "name": name_slug,
+                "agent": f"{detection.file_path}:{detection.variable_name}",
+            },
+        }
+    return {
+        "server": {"api": {"port": 8000}},
+        "agent": agent_block,
+    }
+
+
+def engine_config_dict_for_starter(
+    *,
+    framework: Literal["LANGGRAPH", "ADK"],
+    name: str,
+) -> dict[str, Any]:
+    """Build the ``base_engine_config`` dict for a starter scaffold."""
+    name_slug = _slugify(name)
+    if framework == "LANGGRAPH":
+        agent_block: dict[str, Any] = {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": name_slug,
+                "graph_definition": "agent.py:graph",
+            },
+        }
+    else:
+        agent_block = {
+            "type": "ADK",
+            "config": {
+                "name": name_slug,
+                "agent": "agent.py:agent",
+            },
+        }
+    return {
+        "server": {"api": {"port": 8000}},
+        "agent": agent_block,
+    }
+
+
+async def _agent_row(session: AsyncSession) -> StandaloneAgentRow | None:
+    return (await session.execute(select(StandaloneAgentRow))).scalar_one_or_none()
+
+
+def _conflict(code: StandaloneErrorCode, message: str, **extra: Any) -> AdminAPIError:
+    """Helper for 409 envelopes. Extra fields go into ``message`` is enough for MVP."""
+    return AdminAPIError(
+        status_code=http_status.HTTP_409_CONFLICT,
+        error=StandaloneAdminError(code=code, message=message),
+    )
+```
+
+- [ ] **Step 4: Run tests — must pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_onboarding.py -v
+```
+
+Expected: 11 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py \
+        libs/idun_agent_standalone/tests/unit/services/test_onboarding.py
+git commit -m "feat(standalone): onboarding service — state classifier + EngineConfig builders"
+```
+
+---
+
+## Task 6: Onboarding service — materialize functions
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py`
+
+The two materialize coroutines do the same dance: pre-check, build config, insert row, run reload pipeline. They call into the existing `commit_with_reload` so the reload contract stays identical to `agent.py` and `memory.py`.
+
+- [ ] **Step 1: Append the materialize functions**
+
+Append to `libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py`:
+
+```python
+async def materialize_from_detection(
+    session: AsyncSession,
+    body: CreateFromDetectionBody,
+    *,
+    scan_root: Path,
+    reload_callable: ReloadCallable,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    """Materialize a detection picked by the wizard.
+
+    Re-scans inside the handler so the detection's ``inferred_name``
+    and confidence come from the authoritative server-side scan, not
+    from anything the client could tamper with.
+    """
+    if await _agent_row(session) is not None:
+        raise _conflict(
+            StandaloneErrorCode.CONFLICT,
+            "Agent already configured.",
+        )
+
+    scan_result = scanner.scan_folder(scan_root)
+    match: DetectedAgent | None = None
+    for detection in scan_result.detected:
+        if (
+            detection.framework == body.framework
+            and detection.file_path == body.file_path
+            and detection.variable_name == body.variable_name
+        ):
+            match = detection
+            break
+    if match is None:
+        raise _conflict(
+            StandaloneErrorCode.CONFLICT,
+            (
+                f"Detection not found: {body.framework} "
+                f"{body.file_path}:{body.variable_name}. "
+                "The project may have changed — re-run the scan."
+            ),
+        )
+
+    config_dict = engine_config_dict_from_detection(match)
+    row = StandaloneAgentRow(
+        name=match.inferred_name,
+        base_engine_config=config_dict,
+    )
+
+    async with reload_service._reload_mutex:
+        session.add(row)
+        await session.flush()
+        result = await commit_with_reload(session, reload_callable=reload_callable)
+        await session.refresh(row)
+
+    logger.info(
+        "admin.onboarding.create_from_detection framework=%s name=%s status=%s",
+        match.framework,
+        match.inferred_name,
+        result.status.value,
+    )
+    return StandaloneMutationResponse(
+        data=StandaloneAgentRead.model_validate(row),
+        reload=result,
+    )
+
+
+async def materialize_starter(
+    session: AsyncSession,
+    body: CreateStarterBody,
+    *,
+    scaffold_root: Path,
+    reload_callable: ReloadCallable,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    """Scaffold a starter project + insert the singleton agent row.
+
+    On any pre-check failure (existing agent, scaffold conflict)
+    nothing is written to disk and no row is inserted. After a
+    successful scaffold + row insert, reload failures leave both the
+    files and the row in place; the user's recovery path is to edit
+    ``agent.py`` and ``PATCH /agent`` to retry the reload.
+    """
+    if await _agent_row(session) is not None:
+        raise _conflict(
+            StandaloneErrorCode.CONFLICT,
+            "Agent already configured.",
+        )
+
+    name = body.name or _STARTER_DEFAULT_NAME
+
+    try:
+        written = scaffold.create_starter_project(
+            scaffold_root, framework=body.framework
+        )
+    except scaffold.ScaffoldConflictError as exc:
+        names = ", ".join(p.name for p in exc.paths)
+        raise _conflict(
+            StandaloneErrorCode.CONFLICT,
+            f"Scaffold target exists: {names}. Move or delete and retry.",
+        ) from exc
+
+    config_dict = engine_config_dict_for_starter(
+        framework=body.framework, name=name
+    )
+    row = StandaloneAgentRow(name=name, base_engine_config=config_dict)
+
+    async with reload_service._reload_mutex:
+        session.add(row)
+        await session.flush()
+        result = await commit_with_reload(session, reload_callable=reload_callable)
+        await session.refresh(row)
+
+    logger.info(
+        "admin.onboarding.create_starter framework=%s files=%d status=%s",
+        body.framework,
+        len(written),
+        result.status.value,
+    )
+    return StandaloneMutationResponse(
+        data=StandaloneAgentRead.model_validate(row),
+        reload=result,
+    )
+```
+
+- [ ] **Step 2: Run unit tests — must still pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/unit/services/test_onboarding.py -v
+```
+
+Expected: 11 tests pass (no new tests yet — materialize coroutines are exercised end-to-end in Task 8).
+
+- [ ] **Step 3: Lint check**
+
+```bash
+uv run ruff check libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
+```
+
+Expected: clean. If the inline `from pathlib import Path` triggers E402, move the import to the top of the file (the inline placement above is intentional documentation but ruff config may forbid it; resolve in favour of ruff).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
+git commit -m "feat(standalone): onboarding service — materialize coroutines"
+```
+
+---
+
+## Task 7: Router — three onboarding endpoints + app wiring
+
+**Files:**
+- Create: `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py`
+- Modify: `libs/idun_agent_standalone/src/idun_agent_standalone/app.py`
+
+- [ ] **Step 1: Create the router**
+
+Create `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py`:
+
+```python
+"""``/admin/api/v1/onboarding`` router.
+
+Three endpoints:
+
+  - ``POST /scan``: classify the user's project + return scanner output.
+  - ``POST /create-from-detection``: materialize an agent the user picked.
+  - ``POST /create-starter``: scaffold a fresh starter project.
+
+Materialize endpoints flow through the same ``commit_with_reload``
+pipeline as ``/admin/api/v1/agent``. Failure modes:
+
+  - 409 ``conflict`` when an agent row already exists.
+  - 409 ``conflict`` when a re-scan can no longer find the picked detection.
+  - 409 ``conflict`` when a scaffold target file already exists.
+
+Auth is wired at ``app.include_router`` level, not per-endpoint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from idun_agent_schema.standalone import (
+    CreateFromDetectionBody,
+    CreateStarterBody,
+    ScanResponse,
+    StandaloneAgentRead,
+    StandaloneMutationResponse,
+)
+
+from idun_agent_standalone.api.v1.deps import ReloadCallableDep, SessionDep
+from idun_agent_standalone.core.logging import get_logger
+from idun_agent_standalone.services import onboarding
+from idun_agent_standalone.services import scanner
+
+router = APIRouter(prefix="/admin/api/v1/onboarding", tags=["admin"])
+
+logger = get_logger(__name__)
+
+
+def _scan_root(request: Request) -> Path:
+    """Resolve the scan root.
+
+    Default: ``Path.cwd()``. Tests override via
+    ``app.state.onboarding_scan_root`` so the wizard can be exercised
+    without ``monkeypatch.chdir`` collisions across asyncio tasks.
+    """
+    override = getattr(request.app.state, "onboarding_scan_root", None)
+    if override is not None:
+        return Path(override)
+    return Path.cwd()
+
+
+@router.post("/scan", response_model=ScanResponse)
+async def scan(request: Request, session: SessionDep) -> ScanResponse:
+    """Classify the project and return the scanner result."""
+    from sqlalchemy import select
+
+    from idun_agent_standalone.infrastructure.db.models.agent import (
+        StandaloneAgentRow,
+    )
+
+    row = (await session.execute(select(StandaloneAgentRow))).scalar_one_or_none()
+    agent_row_exists = row is not None
+    current_agent: StandaloneAgentRead | None = None
+
+    if agent_row_exists:
+        # Skip the walk — UI shouldn't be calling /scan in this state, and
+        # if something does, surface the existing config so the operator
+        # can see what they are looking at.
+        from idun_agent_schema.standalone import ScanResult
+
+        scan_result = ScanResult(
+            root=str(_scan_root(request)),
+            detected=[],
+            has_python_files=False,
+            has_idun_config=False,
+            scan_duration_ms=0,
+        )
+        current_agent = StandaloneAgentRead.model_validate(row)
+    else:
+        scan_result = scanner.scan_folder(_scan_root(request))
+
+    state = onboarding.classify_state(
+        scan_result, agent_row_exists=agent_row_exists
+    )
+    logger.info(
+        "admin.onboarding.scan state=%s detections=%d duration_ms=%d",
+        state,
+        len(scan_result.detected),
+        scan_result.scan_duration_ms,
+    )
+    return ScanResponse(
+        state=state, scan_result=scan_result, current_agent=current_agent
+    )
+
+
+@router.post(
+    "/create-from-detection",
+    response_model=StandaloneMutationResponse[StandaloneAgentRead],
+)
+async def create_from_detection(
+    body: CreateFromDetectionBody,
+    request: Request,
+    session: SessionDep,
+    reload_callable: ReloadCallableDep,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    """Materialize a detection picked by the wizard."""
+    return await onboarding.materialize_from_detection(
+        session,
+        body,
+        scan_root=_scan_root(request),
+        reload_callable=reload_callable,
+    )
+
+
+@router.post(
+    "/create-starter",
+    response_model=StandaloneMutationResponse[StandaloneAgentRead],
+)
+async def create_starter(
+    body: CreateStarterBody,
+    request: Request,
+    session: SessionDep,
+    reload_callable: ReloadCallableDep,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    """Scaffold a starter project + register the singleton agent row."""
+    return await onboarding.materialize_starter(
+        session,
+        body,
+        scaffold_root=_scan_root(request),
+        reload_callable=reload_callable,
+    )
+```
+
+- [ ] **Step 2: Wire the router in `app.py`**
+
+Find the block in `libs/idun_agent_standalone/src/idun_agent_standalone/app.py` that includes the existing admin routers. Add the import and the include alongside them:
+
+```python
+# In the imports section near the other router imports:
+from idun_agent_standalone.api.v1.routers.onboarding import (
+    router as onboarding_router,
+)
+
+# In the app factory where other routers are included (look for the block
+# that calls app.include_router(agent_router, ...) etc.):
+app.include_router(onboarding_router, dependencies=[Depends(require_auth)])
+```
+
+If the existing pattern uses a different DI surface (e.g. `auth_dep` already attached at a parent router), match that — the goal is to land onboarding at the same auth gate as the other admin routes.
+
+- [ ] **Step 3: Smoke-check imports**
+
+```bash
+uv run python -c "from idun_agent_standalone.app import build_app; build_app()"
+```
+
+Expected: no import errors. If the call signature for `build_app` has changed, the goal is to import the module without error.
+
+If `build_app()` requires settings, fall back to:
+
+```bash
+uv run python -c "from idun_agent_standalone.api.v1.routers.onboarding import router; print(router.routes)"
+```
+
+Expected output: three `Route` objects whose paths end in `/scan`, `/create-from-detection`, `/create-starter`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py \
+        libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+git commit -m "feat(standalone): onboarding router — 3 endpoints wired with auth gate"
+```
+
+---
+
+## Task 8: Integration tests — `/scan` flows
+
+**Files:**
+- Create: `libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py`
+
+This file is built incrementally across Tasks 8/9/10. Task 8 adds the fixture and the 5 `/scan` tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py`:
+
+```python
+"""Integration tests for ``/admin/api/v1/onboarding/*``."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from idun_agent_standalone.api.v1.deps import (
+    get_reload_callable,
+    get_session,
+)
+from idun_agent_standalone.api.v1.errors import (
+    register_admin_exception_handlers,
+)
+from idun_agent_standalone.api.v1.routers.agent import (
+    router as agent_router,
+)
+from idun_agent_standalone.api.v1.routers.onboarding import (
+    router as onboarding_router,
+)
+from idun_agent_standalone.infrastructure.db.models.agent import (
+    StandaloneAgentRow,
+)
+
+
+@pytest.fixture
+async def admin_app(async_session, stub_reload_callable, tmp_path):
+    app = FastAPI()
+    register_admin_exception_handlers(app)
+    app.include_router(agent_router)
+    app.include_router(onboarding_router)
+    app.state.reload_callable = stub_reload_callable
+    app.state.onboarding_scan_root = tmp_path
+
+    async def override_session():
+        yield async_session
+
+    async def override_reload_callable():
+        return stub_reload_callable
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_reload_callable] = override_reload_callable
+    return app
+
+
+def _seed_langgraph_file(root: Path, *, var: str = "graph") -> None:
+    (root / "agent.py").write_text(
+        textwrap.dedent(
+            f"""
+            from langgraph.graph import StateGraph
+            from typing import TypedDict
+
+            class State(TypedDict):
+                m: str
+
+            {var} = StateGraph(State).compile()
+            """
+        ).lstrip()
+    )
+
+
+def _seed_adk_file(root: Path) -> None:
+    (root / "main_adk.py").write_text(
+        textwrap.dedent(
+            """
+            from google.adk.agents import Agent
+
+            agent = Agent(name="x", model="gemini-2.0-flash")
+            """
+        ).lstrip()
+    )
+
+
+async def _seed_existing_agent(async_session) -> StandaloneAgentRow:
+    row = StandaloneAgentRow(
+        name="Existing",
+        base_engine_config={
+            "server": {"api": {"port": 8000}},
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {"name": "existing", "graph_definition": "agent.py:graph"},
+            },
+        },
+    )
+    async_session.add(row)
+    await async_session.commit()
+    return row
+
+
+# ---- /scan ----------------------------------------------------------------
+
+
+async def test_scan_state_empty(admin_app, tmp_path) -> None:
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "EMPTY"
+    assert body["scanResult"]["hasPythonFiles"] is False
+    assert body["currentAgent"] is None
+
+
+async def test_scan_state_no_supported(admin_app, tmp_path) -> None:
+    (tmp_path / "hello.py").write_text("print('hi')\n")
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "NO_SUPPORTED"
+    assert body["scanResult"]["hasPythonFiles"] is True
+    assert body["scanResult"]["detected"] == []
+
+
+async def test_scan_state_one_detected(admin_app, tmp_path) -> None:
+    _seed_langgraph_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "ONE_DETECTED"
+    assert len(body["scanResult"]["detected"]) == 1
+    detection = body["scanResult"]["detected"][0]
+    assert detection["framework"] == "LANGGRAPH"
+    assert detection["filePath"] == "agent.py"
+    assert detection["variableName"] == "graph"
+
+
+async def test_scan_state_many_detected(admin_app, tmp_path) -> None:
+    _seed_langgraph_file(tmp_path)
+    _seed_adk_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "MANY_DETECTED"
+    frameworks = {d["framework"] for d in body["scanResult"]["detected"]}
+    assert frameworks == {"LANGGRAPH", "ADK"}
+
+
+async def test_scan_state_already_configured_returns_current_agent(
+    admin_app, async_session, tmp_path
+) -> None:
+    await _seed_existing_agent(async_session)
+    # Even with detectable files on disk, an existing agent row trumps.
+    _seed_langgraph_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "ALREADY_CONFIGURED"
+    assert body["currentAgent"] is not None
+    assert body["currentAgent"]["name"] == "Existing"
+    # The walk is skipped — detected list is empty in this branch.
+    assert body["scanResult"]["detected"] == []
+```
+
+- [ ] **Step 2: Run tests — must pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py -v
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
+git commit -m "test(standalone): integration coverage for /onboarding/scan"
+```
+
+---
+
+## Task 9: Integration tests — `/create-from-detection`
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py`:
+
+```python
+# ---- /create-from-detection ------------------------------------------------
+
+
+async def test_create_from_detection_langgraph_happy_path(
+    admin_app, async_session, tmp_path, stub_reload_callable
+) -> None:
+    _seed_langgraph_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-from-detection",
+            json={
+                "framework": "LANGGRAPH",
+                "filePath": "agent.py",
+                "variableName": "graph",
+            },
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"]["baseEngineConfig"]["agent"]["type"] == "LANGGRAPH"
+    assert (
+        body["data"]["baseEngineConfig"]["agent"]["config"]["graph_definition"]
+        == "agent.py:graph"
+    )
+    assert body["reload"]["status"] == "reloaded"
+    assert stub_reload_callable.call_count == 1
+
+
+async def test_create_from_detection_adk_happy_path(
+    admin_app, tmp_path, stub_reload_callable
+) -> None:
+    _seed_adk_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-from-detection",
+            json={
+                "framework": "ADK",
+                "filePath": "main_adk.py",
+                "variableName": "agent",
+            },
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"]["baseEngineConfig"]["agent"]["type"] == "ADK"
+    assert (
+        body["data"]["baseEngineConfig"]["agent"]["config"]["agent"]
+        == "main_adk.py:agent"
+    )
+
+
+async def test_create_from_detection_already_configured_409(
+    admin_app, async_session, tmp_path
+) -> None:
+    await _seed_existing_agent(async_session)
+    _seed_langgraph_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-from-detection",
+            json={
+                "framework": "LANGGRAPH",
+                "filePath": "agent.py",
+                "variableName": "graph",
+            },
+        )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "conflict"
+
+
+async def test_create_from_detection_stale_pick_409(admin_app, tmp_path) -> None:
+    """File deleted between scan and click → re-scan returns no match → 409."""
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-from-detection",
+            json={
+                "framework": "LANGGRAPH",
+                "filePath": "agent.py",
+                "variableName": "graph",
+            },
+        )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "conflict"
+    # Message should help the user: it mentions the filename they sent.
+    assert "agent.py" in body["error"]["message"]
+```
+
+- [ ] **Step 2: Run tests — must pass**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py -v
+```
+
+Expected: 9 tests pass (5 from Task 8 + 4 new). The `stub_reload_callable` fixture is an `AsyncMock` from `tests/conftest.py`, so `.call_count`, `.assert_called_once()`, `.reset_mock()`, and `.side_effect = ...` all work as expected.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
+git commit -m "test(standalone): integration coverage for /onboarding/create-from-detection"
+```
+
+---
+
+## Task 10: Integration tests — `/create-starter`
+
+**Files:**
+- Modify: `libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py`:
+
+```python
+# ---- /create-starter -------------------------------------------------------
+
+
+async def test_create_starter_langgraph_happy_path(
+    admin_app, tmp_path, stub_reload_callable
+) -> None:
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "LANGGRAPH"},
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"]["name"] == "Starter Agent"
+    assert body["reload"]["status"] == "reloaded"
+
+    expected = {"agent.py", "requirements.txt", ".env.example", "README.md", ".gitignore"}
+    assert {p.name for p in tmp_path.iterdir()} >= expected
+
+
+async def test_create_starter_adk_happy_path(admin_app, tmp_path) -> None:
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "ADK", "name": "My Bot"},
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"]["name"] == "My Bot"
+    assert body["data"]["baseEngineConfig"]["agent"]["type"] == "ADK"
+    assert "GOOGLE_API_KEY" in (tmp_path / ".env.example").read_text()
+
+
+async def test_create_starter_scaffold_conflict_409_zero_writes(
+    admin_app, tmp_path
+) -> None:
+    (tmp_path / "agent.py").write_text("# pre-existing\n")
+    pre_state = {p.name: p.read_text() for p in tmp_path.iterdir()}
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "LANGGRAPH"},
+        )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "conflict"
+    # Pre-existing file untouched, no new files.
+    post_state = {p.name: p.read_text() for p in tmp_path.iterdir()}
+    assert post_state == pre_state
+
+
+async def test_create_starter_already_configured_409_zero_writes(
+    admin_app, async_session, tmp_path
+) -> None:
+    await _seed_existing_agent(async_session)
+    pre_files = list(tmp_path.iterdir())
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "LANGGRAPH"},
+        )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "conflict"
+    # Confirm scaffold did not run.
+    assert list(tmp_path.iterdir()) == pre_files
+
+
+async def test_create_starter_reload_failure_keeps_files(
+    admin_app, tmp_path, stub_reload_callable
+) -> None:
+    """Reload failure surfaces in envelope; scaffolded files persist.
+
+    The reload pipeline rolls back the DB on a ``ReloadInitFailed`` and
+    re-raises as ``AdminAPIError(500, code=reload_failed)`` (see
+    ``services/reload.py``). The scaffolded files live on disk
+    independently of the DB, so they remain — recovery per spec §5.3
+    is to edit ``agent.py`` and re-run the wizard once the row is gone
+    (or PATCH /agent if the row stayed for a different failure mode).
+    """
+    from idun_agent_standalone.services.reload import ReloadInitFailed
+
+    # AsyncMock side_effect: any call to the stub raises this.
+    stub_reload_callable.side_effect = ReloadInitFailed("simulated")
+
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "LANGGRAPH"},
+        )
+    assert response.status_code == 500
+    assert response.json()["error"]["code"] == "reload_failed"
+
+    expected = {"agent.py", "requirements.txt", ".env.example", "README.md", ".gitignore"}
+    assert {p.name for p in tmp_path.iterdir()} >= expected
+```
+
+- [ ] **Step 2: Run tests — verify**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py -v
+```
+
+Expected: 14 tests pass.
+
+- [ ] **Step 3: Run the full standalone test suite**
+
+```bash
+uv run pytest libs/idun_agent_standalone/tests/ -q
+```
+
+Expected: all tests pass — including pre-existing scanner + auth + admin tests.
+
+- [ ] **Step 4: Run lint + format**
+
+```bash
+uv run ruff check libs/idun_agent_standalone/ libs/idun_agent_schema/
+uv run black --check libs/idun_agent_standalone/ libs/idun_agent_schema/
+```
+
+Expected: clean. Fix anything reported before committing.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
+git commit -m "test(standalone): integration coverage for /onboarding/create-starter"
+```
+
+---
+
+## Spec coverage check
+
+| Spec section | Implementing task |
+|---|---|
+| §4 5-state machine | Task 5 (classify_state) + Task 8 (5 /scan tests) |
+| §5.1 /scan | Task 7 (router) + Task 8 (tests) |
+| §5.2 /create-from-detection | Task 6 (materialize) + Task 7 (router) + Task 9 (tests) |
+| §5.3 /create-starter | Task 6 (materialize) + Task 7 (router) + Task 10 (tests) |
+| §6 schema additions | Task 1 |
+| §7 module layout | Tasks 2/5/7 (scaffold.py / onboarding.py / router) |
+| §8 scaffolder atomic algorithm | Tasks 2-4 |
+| §9 onboarding service surface | Tasks 5-6 |
+| §10 concurrency (singleton row) | Pre-existing DB primary key — implicitly covered by 409 tests |
+| §11 auth + reload | Task 7 (Depends(require_auth)) + Task 10 (reload-failure test) |
+| §12 testing strategy | Tasks 2-4 (scaffold unit), Task 5 (service unit), Tasks 8-10 (integration) |
+| §13 future work | Out of scope — explicitly deferred |
+
+## Test count summary
+
+- `tests/standalone/test_onboarding.py`: 7 new (3 pre-existing from sub-project A)
+- `tests/unit/services/test_scaffold.py`: 13 new
+- `tests/unit/services/test_onboarding.py`: 11 new
+- `tests/integration/api/v1/test_onboarding_flow.py`: 14 new
+
+**Total new tests: 45.**

--- a/docs/superpowers/plans/2026-04-29-onboarding-wizard-ui.md
+++ b/docs/superpowers/plans/2026-04-29-onboarding-wizard-ui.md
@@ -1,0 +1,3330 @@
+# Onboarding Wizard UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship sub-project C from `2026-04-29-onboarding-wizard-ui-design.md`: the Next.js wizard at `/onboarding` that consumes sub-project B's three endpoints, plus the chat-root redirect that triggers it and the minimal `?next=` enhancement to login that makes password mode work end-to-end.
+
+**Architecture:** Single-page state-driven wizard. The page (`app/onboarding/page.tsx`) holds a tagged-union `WizardStep` and dispatches to one of nine presentational screen components. TanStack Query owns the scan call and re-scan invalidation. Screens are pure props-in/callbacks-out — no global state, no router calls (the parent owns transitions).
+
+**Tech Stack:** Next.js 15 + React 19 + TypeScript, Tailwind v4, shadcn primitives (already installed: card, button, radio-group, form, input, alert, skeleton, separator, sonner), TanStack Query, react-hook-form + zod, Vitest + RTL for unit tests, Playwright for E2E.
+
+**Branch:** `feat/onboarding-scanner` — extending the same branch sub-projects A and B already live on. Additive only.
+
+---
+
+## Files at a glance
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `services/idun_agent_standalone_ui/lib/api/types/onboarding.ts` | Create | Wire types: `OnboardingState`, `Framework`, `DetectedAgent`, `ScanResult`, `ScanResponse`, `CreateFromDetectionBody`, `CreateStarterBody` |
+| `services/idun_agent_standalone_ui/lib/api/types/index.ts` | Modify | Re-export `./onboarding` |
+| `services/idun_agent_standalone_ui/lib/api/index.ts` | Modify | Add `scan`, `createFromDetection`, `createStarter` methods |
+| `services/idun_agent_standalone_ui/lib/api/client.ts` | Modify | Append `?next=<path>` to the `/login/` redirect |
+| `services/idun_agent_standalone_ui/app/login/page.tsx` | Modify | Read `?next=` and redirect there on success (default `/`) |
+| `services/idun_agent_standalone_ui/app/page.tsx` | Modify | On mount, call `getAgent`; on 404 → `router.replace('/onboarding')` |
+| `services/idun_agent_standalone_ui/app/onboarding/layout.tsx` | Create | Bare themed shell — logo + centered card area |
+| `services/idun_agent_standalone_ui/app/onboarding/page.tsx` | Create | State machine + screen dispatch |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardScanning.tsx` | Create | Initial scan loading state |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardEmpty.tsx` | Create | EMPTY → framework picker (screen 1 of starter flow) |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardNoSupported.tsx` | Create | NO_SUPPORTED → same picker, different copy |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardOneDetected.tsx` | Create | ONE_DETECTED → single-card confirm |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx` | Create | MANY_DETECTED → radio list + confirm |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardStarterConfirm.tsx` | Create | Starter flow screen 2 (name input + 5-file preview) |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardMaterializing.tsx` | Create | Loading during create-* call |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx` | Create | Success + .env reminder + Go-to-chat |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardError.tsx` | Create | Reload-failure diagnostic + Retry |
+| `services/idun_agent_standalone_ui/__tests__/api/onboarding.test.ts` | Create | API client unit tests |
+| `services/idun_agent_standalone_ui/__tests__/onboarding/Wizard*.test.tsx` | Create | Per-screen component tests |
+| `services/idun_agent_standalone_ui/__tests__/login.test.tsx` | Create | Login page tests |
+| `services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx` | Create | Chat root redirect test |
+| `services/idun_agent_standalone_ui/e2e/onboarding.spec.ts` | Create | Playwright flows |
+
+---
+
+## Pattern reminders for implementers
+
+- **`apiFetch`** lives in `lib/api/client.ts`. It sets `credentials: include`, redirects to `/login/` on 401 (with the `redirected` flag preventing loops), throws `ApiError` on non-2xx. Don't bypass it.
+- **TanStack Query** is configured at the root via `lib/query-client.tsx`'s `QueryProvider`. Use `useQuery` for `/scan` (key: `["onboarding-scan"]`), `useMutation` for materialize calls.
+- **shadcn primitives** are already in `components/ui/`. Don't install or create new primitives — reuse what's there.
+- **Tailwind v4** is configured. Use existing CSS variables (`bg-background`, `text-foreground`, `text-muted-foreground`, etc.) — don't write hex colors.
+- **Theme**: every page automatically inherits `ThemeLoader`'s runtime-config theme via the root layout. The wizard layout doesn't need to do anything special.
+- **camelCase wire format**: backend returns camelCase keys; types must use camelCase (`hasPythonFiles`, not `has_python_files`). The shared `apiFetch` doesn't transform; bodies you send must also be camelCase if the backend's `_CamelModel` schema expects camelCase aliases (it accepts both due to `populate_by_name=True`, but stay consistent).
+- **Framework values on the wire are uppercase**: `"LANGGRAPH"`, `"ADK"` — match the schema's `Literal` exactly.
+- **MutationResponse envelope**: every materialize call returns `{ data: AgentRead, reload: { status, ... } }`. Already typed in `lib/api/types/common.ts`.
+- **No CSS-in-JS**: Tailwind utilities only.
+- **Import paths**: use `@/...` (configured in `tsconfig.json` and `vitest.config.ts`).
+
+---
+
+## Task 1: API types + 3 onboarding methods
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/lib/api/types/onboarding.ts`
+- Modify: `services/idun_agent_standalone_ui/lib/api/types/index.ts`
+- Modify: `services/idun_agent_standalone_ui/lib/api/index.ts`
+- Test: `services/idun_agent_standalone_ui/__tests__/api/onboarding.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `services/idun_agent_standalone_ui/__tests__/api/onboarding.test.ts`:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, api } from "@/lib/api";
+
+describe("onboarding api", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("scan() POSTs /admin/api/v1/onboarding/scan with no body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          state: "EMPTY",
+          scanResult: {
+            root: "/tmp",
+            detected: [],
+            hasPythonFiles: false,
+            hasIdunConfig: false,
+            scanDurationMs: 12,
+          },
+          currentAgent: null,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await api.scan();
+    expect(result.state).toBe("EMPTY");
+    expect(result.scanResult.hasPythonFiles).toBe(false);
+
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/admin/api/v1/onboarding/scan");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBeUndefined();
+  });
+
+  it("createFromDetection() POSTs the typed body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: { id: "x", name: "Foo" },
+          reload: { status: "reloaded" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const result = await api.createFromDetection({
+      framework: "LANGGRAPH",
+      filePath: "agent.py",
+      variableName: "graph",
+    });
+    expect(result.data.name).toBe("Foo");
+    expect(result.reload.status).toBe("reloaded");
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/admin/api/v1/onboarding/create-from-detection");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      framework: "LANGGRAPH",
+      filePath: "agent.py",
+      variableName: "graph",
+    });
+  });
+
+  it("createStarter() POSTs the typed body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: { id: "x", name: "Starter Agent" },
+          reload: { status: "reloaded" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const result = await api.createStarter({ framework: "ADK", name: "My Bot" });
+    expect(result.data.name).toBe("Starter Agent");
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/admin/api/v1/onboarding/create-starter");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      framework: "ADK",
+      name: "My Bot",
+    });
+  });
+
+  it("createStarter() omits name when not provided", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: { id: "x", name: "Starter Agent" },
+          reload: { status: "reloaded" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    await api.createStarter({ framework: "LANGGRAPH" });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      framework: "LANGGRAPH",
+    });
+  });
+
+  it("409 conflict surfaces as ApiError with the conflict envelope", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "conflict", message: "Agent already configured." },
+        }),
+        { status: 409, headers: { "content-type": "application/json" } },
+      ),
+    );
+    try {
+      await api.createStarter({ framework: "LANGGRAPH" });
+      throw new Error("expected ApiError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(409);
+      expect((err as ApiError).detail).toMatchObject({
+        error: { code: "conflict" },
+      });
+    }
+  });
+
+  it("500 reload_failed surfaces as ApiError with the reload envelope", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "reload_failed", message: "Engine init failed." },
+        }),
+        { status: 500, headers: { "content-type": "application/json" } },
+      ),
+    );
+    try {
+      await api.createStarter({ framework: "LANGGRAPH" });
+      throw new Error("expected ApiError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(500);
+      expect((err as ApiError).detail).toMatchObject({
+        error: { code: "reload_failed" },
+      });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+cd services/idun_agent_standalone_ui
+pnpm test __tests__/api/onboarding.test.ts
+```
+
+Expected: ImportError on `api.scan` / `api.createFromDetection` / `api.createStarter`.
+
+- [ ] **Step 3: Create the types file**
+
+Create `services/idun_agent_standalone_ui/lib/api/types/onboarding.ts`:
+
+```typescript
+import type { AgentRead } from "./agent";
+
+export type OnboardingState =
+  | "EMPTY"
+  | "NO_SUPPORTED"
+  | "ONE_DETECTED"
+  | "MANY_DETECTED"
+  | "ALREADY_CONFIGURED";
+
+export type Framework = "LANGGRAPH" | "ADK";
+export type DetectionConfidence = "HIGH" | "MEDIUM";
+export type DetectionSource = "config" | "source" | "langgraph_json";
+
+export interface DetectedAgent {
+  framework: Framework;
+  filePath: string;
+  variableName: string;
+  inferredName: string;
+  confidence: DetectionConfidence;
+  source: DetectionSource;
+}
+
+export interface ScanResult {
+  root: string;
+  detected: DetectedAgent[];
+  hasPythonFiles: boolean;
+  hasIdunConfig: boolean;
+  scanDurationMs: number;
+}
+
+export interface ScanResponse {
+  state: OnboardingState;
+  scanResult: ScanResult;
+  currentAgent: AgentRead | null;
+}
+
+export interface CreateFromDetectionBody {
+  framework: Framework;
+  filePath: string;
+  variableName: string;
+}
+
+export interface CreateStarterBody {
+  framework: Framework;
+  name?: string;
+}
+```
+
+- [ ] **Step 4: Re-export from the types barrel**
+
+Modify `services/idun_agent_standalone_ui/lib/api/types/index.ts` — append after the existing re-exports:
+
+```typescript
+export * from "./common";
+export * from "./agent";
+export * from "./memory";
+export * from "./observability";
+export * from "./mcp";
+export * from "./guardrails";
+export * from "./prompts";
+export * from "./integrations";
+export * from "./sessions";
+export * from "./onboarding";
+```
+
+- [ ] **Step 5: Add the three methods to the api object**
+
+Modify `services/idun_agent_standalone_ui/lib/api/index.ts`.
+
+Add to the type-only import block (alongside the existing names):
+
+```typescript
+import type {
+  AgentCapabilities,
+  AgentPatch,
+  AgentRead,
+  AgentSessionDetail,
+  AgentSessionSummary,
+  CreateFromDetectionBody,
+  CreateStarterBody,
+  DeleteResult,
+  GuardrailCreate,
+  GuardrailPatch,
+  GuardrailRead,
+  IntegrationCreate,
+  IntegrationPatch,
+  IntegrationRead,
+  McpCreate,
+  McpPatch,
+  McpRead,
+  MemoryPatch,
+  MemoryRead,
+  MutationResponse,
+  ObservabilityPatch,
+  ObservabilityRead,
+  PromptCreate,
+  PromptPatch,
+  PromptRead,
+  ScanResponse,
+  SingletonDeleteResult,
+} from "./types";
+```
+
+Add the three methods inside the `api` object (place them after `getAgentCapabilities` at the end, or in their own block — doesn't matter as long as they're inside the object literal):
+
+```typescript
+  // onboarding wizard
+  scan: () =>
+    apiFetch<ScanResponse>(`${ADMIN}/onboarding/scan`, {
+      method: "POST",
+    }),
+  createFromDetection: (body: CreateFromDetectionBody) =>
+    apiFetch<MutationResponse<AgentRead>>(
+      `${ADMIN}/onboarding/create-from-detection`,
+      { method: "POST", body: j(body) },
+    ),
+  createStarter: (body: CreateStarterBody) =>
+    apiFetch<MutationResponse<AgentRead>>(`${ADMIN}/onboarding/create-starter`, {
+      method: "POST",
+      body: j(body),
+    }),
+```
+
+- [ ] **Step 6: Run tests — must pass**
+
+```bash
+pnpm test __tests__/api/onboarding.test.ts
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 7: TypeScript check**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no new errors. (The existing config has `ignoreBuildErrors: true` for the build, but `typecheck` runs `tsc --noEmit` and may surface pre-existing errors — only fix errors introduced by THIS task.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/lib/api/types/onboarding.ts \
+        services/idun_agent_standalone_ui/lib/api/types/index.ts \
+        services/idun_agent_standalone_ui/lib/api/index.ts \
+        services/idun_agent_standalone_ui/__tests__/api/onboarding.test.ts
+git commit -m "feat(standalone-ui): typed onboarding API client methods"
+```
+
+---
+
+## Task 2: Append `?next=` to the apiFetch 401 redirect
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/lib/api/client.ts`
+- Test: `services/idun_agent_standalone_ui/__tests__/api/client.test.ts`
+
+The current 401 redirect goes to `/login/` with no query param. The wizard's auth-redirect flow needs `?next=<originalPath>` so the user lands back on the wizard after logging in.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/idun_agent_standalone_ui/__tests__/api/client.test.ts`:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "@/lib/api/client";
+
+describe("apiFetch 401 redirect", () => {
+  const fetchMock = vi.fn();
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    // jsdom doesn't allow assigning to window.location.href directly without
+    // this trick. Replace location with a writable mock so the redirect is
+    // observable.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: {
+        ...originalLocation,
+        pathname: "/onboarding",
+        search: "",
+        href: "",
+      },
+    });
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("redirects to /login/?next=<pathname> on 401", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 401 }),
+    );
+    await expect(apiFetch("/admin/api/v1/agent")).rejects.toThrow();
+    expect(window.location.href).toBe("/login/?next=%2Fonboarding");
+  });
+
+  it("encodes the pathname so query strings stay intact", async () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: {
+        ...originalLocation,
+        pathname: "/admin/agent",
+        search: "?foo=bar",
+        href: "",
+      },
+    });
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 401 }),
+    );
+    await expect(apiFetch("/admin/api/v1/agent")).rejects.toThrow();
+    expect(window.location.href).toBe(
+      "/login/?next=%2Fadmin%2Fagent%3Ffoo%3Dbar",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+pnpm test __tests__/api/client.test.ts
+```
+
+Expected: assertions fail because the current code redirects to `/login/` with no query param.
+
+- [ ] **Step 3: Update the redirect logic**
+
+Modify `services/idun_agent_standalone_ui/lib/api/client.ts`. Find the 401 block:
+
+```typescript
+  if (res.status === 401 && typeof window !== "undefined" && !redirected) {
+    redirected = true;
+    window.location.href = "/login/";
+    throw new ApiError(401, null);
+  }
+```
+
+Replace with:
+
+```typescript
+  if (res.status === 401 && typeof window !== "undefined" && !redirected) {
+    redirected = true;
+    const nextPath = window.location.pathname + window.location.search;
+    const next = encodeURIComponent(nextPath);
+    window.location.href = `/login/?next=${next}`;
+    throw new ApiError(401, null);
+  }
+```
+
+- [ ] **Step 4: Run tests — must pass**
+
+```bash
+pnpm test __tests__/api/client.test.ts
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Run the full test suite — no regressions**
+
+```bash
+pnpm test
+```
+
+Expected: all pre-existing tests still pass. The 401 redirect was previously untested; the new behavior is purely additive (still goes to `/login/`, just with a query param now).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/lib/api/client.ts \
+        services/idun_agent_standalone_ui/__tests__/api/client.test.ts
+git commit -m "feat(standalone-ui): apiFetch 401 redirect carries ?next= path"
+```
+
+---
+
+## Task 3: Login page — `?next=` support + default redirect to `/`
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/app/login/page.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/login.test.tsx`
+
+The existing page hardcodes `router.replace("/admin/")` after login. We change two things:
+1. Read `?next=` from search params; redirect there on success.
+2. Default to `/` (not `/admin/`) when `?next=` is absent — `/` itself routes to wizard or chat appropriately.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `services/idun_agent_standalone_ui/__tests__/login.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import LoginPage from "@/app/login/page";
+
+const replace = vi.fn();
+const useSearchParamsMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => useSearchParamsMock(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      login: vi.fn(),
+    },
+  };
+});
+
+import { api, ApiError } from "@/lib/api";
+import { toast } from "sonner";
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    replace.mockReset();
+    useSearchParamsMock.mockReturnValue(new URLSearchParams(""));
+    (api.login as ReturnType<typeof vi.fn>).mockReset();
+    (toast.error as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("on success without ?next, redirects to /", async () => {
+    (api.login as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/admin password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+  });
+
+  it("on success with ?next=/onboarding, redirects there", async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams("next=/onboarding"));
+    (api.login as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/admin password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
+  });
+
+  it("on 401, fires toast.error and does not redirect", async () => {
+    (api.login as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiError(401, null),
+    );
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/admin password/i), {
+      target: { value: "wrong" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(replace).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+pnpm test __tests__/login.test.tsx
+```
+
+Expected: the `useSearchParams` mock isn't honored by the current page (it doesn't read it), and the default redirect is `/admin/` not `/`.
+
+- [ ] **Step 3: Update the login page**
+
+Replace `services/idun_agent_standalone_ui/app/login/page.tsx` with:
+
+```typescript
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { ApiError, api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  return (
+    <div className="grid place-items-center min-h-screen bg-background p-6">
+      <Card className="w-full max-w-sm p-6 space-y-4">
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">Sign in</h1>
+          <p className="text-xs text-muted-foreground mt-1">
+            Enter the admin password configured for this deployment.
+          </p>
+        </div>
+        <form
+          className="space-y-3"
+          onSubmit={async (e) => {
+            e.preventDefault();
+            setBusy(true);
+            try {
+              await api.login(password);
+              const next = params?.get("next") ?? "/";
+              router.replace(next);
+            } catch (err) {
+              const status = err instanceof ApiError ? err.status : 0;
+              toast.error(
+                status === 401 ? "Invalid credentials" : "Sign-in failed",
+              );
+              setPassword("");
+            } finally {
+              setBusy(false);
+            }
+          }}
+        >
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground" htmlFor="pw">
+              Admin password
+            </Label>
+            <Input
+              id="pw"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <Button type="submit" disabled={busy} className="w-full">
+            {busy ? "Signing in…" : "Sign in"}
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests — must pass**
+
+```bash
+pnpm test __tests__/login.test.tsx
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/app/login/page.tsx \
+        services/idun_agent_standalone_ui/__tests__/login.test.tsx
+git commit -m "feat(standalone-ui): login honors ?next= and defaults to /"
+```
+
+---
+
+## Task 4: Chat root — redirect to `/onboarding` on agent 404
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/app/page.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx`
+
+The chat root page currently mounts a chat layout unconditionally. We add a `getAgent` probe on mount; on 404, replace the route with `/onboarding`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import Home from "@/app/page";
+
+const replace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getAgent: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/components/chat/BrandedLayout", () => ({
+  BrandedLayout: () => <div data-testid="branded-layout" />,
+}));
+
+vi.mock("@/components/chat/MinimalLayout", () => ({
+  MinimalLayout: () => <div data-testid="minimal-layout" />,
+}));
+
+vi.mock("@/components/chat/InspectorLayout", () => ({
+  InspectorLayout: () => <div data-testid="inspector-layout" />,
+}));
+
+import { api, ApiError } from "@/lib/api";
+
+describe("Home (chat root)", () => {
+  beforeEach(() => {
+    replace.mockReset();
+    (api.getAgent as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it("renders chat when getAgent returns 200", async () => {
+    (api.getAgent as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: "x",
+      name: "Foo",
+    });
+    const { findByTestId } = render(<Home />);
+    await findByTestId("branded-layout");
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /onboarding when getAgent returns 404", async () => {
+    (api.getAgent as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiError(404, null),
+    );
+    render(<Home />);
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
+  });
+
+  it("does not redirect on non-404 errors (e.g. transient 500)", async () => {
+    (api.getAgent as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiError(500, null),
+    );
+    render(<Home />);
+    // Wait one tick to make sure no redirect happens.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(replace).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+pnpm test __tests__/page-redirect.test.tsx
+```
+
+Expected: the current page doesn't call `getAgent`, so the redirect tests fail and the chat-render test passes only because the layout renders unconditionally.
+
+- [ ] **Step 3: Update the chat root**
+
+Replace `services/idun_agent_standalone_ui/app/page.tsx` with:
+
+```typescript
+"use client";
+
+import { Suspense, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { getRuntimeConfig } from "@/lib/runtime-config";
+import { ApiError, api } from "@/lib/api";
+import { BrandedLayout } from "@/components/chat/BrandedLayout";
+import { MinimalLayout } from "@/components/chat/MinimalLayout";
+import { InspectorLayout } from "@/components/chat/InspectorLayout";
+
+function ChatHome() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const threadId = useMemo(
+    () => params.get("session") ?? crypto.randomUUID(),
+    [params],
+  );
+  const [layout, setLayout] = useState<"branded" | "minimal" | "inspector">(
+    "branded",
+  );
+  const [agentReady, setAgentReady] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setLayout(getRuntimeConfig().layout);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getAgent()
+      .then(() => {
+        if (!cancelled) setAgentReady(true);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof ApiError && err.status === 404) {
+          router.replace("/onboarding");
+        } else {
+          // Non-404 errors don't block chat from rendering — let the chat
+          // layouts surface their own loading/error state on the next API
+          // call. Treat as "ready" so the user sees something.
+          setAgentReady(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  if (agentReady !== true) {
+    return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
+  }
+
+  if (layout === "minimal") return <MinimalLayout threadId={threadId} />;
+  if (layout === "inspector") return <InspectorLayout threadId={threadId} />;
+  return <BrandedLayout threadId={threadId} />;
+}
+
+export default function Home() {
+  return (
+    <Suspense fallback={<div className="p-8 text-sm">Loading…</div>}>
+      <ChatHome />
+    </Suspense>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests — must pass**
+
+```bash
+pnpm test __tests__/page-redirect.test.tsx
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Run full test suite — no regressions**
+
+```bash
+pnpm test
+```
+
+Expected: all pre-existing tests still pass (the chat root change is additive — chat still renders the same layouts when an agent exists).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/app/page.tsx \
+        services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx
+git commit -m "feat(standalone-ui): chat root redirects to /onboarding when no agent"
+```
+
+---
+
+## Task 5: Wizard layout + page skeleton + WizardScanning
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/app/onboarding/layout.tsx`
+- Create: `services/idun_agent_standalone_ui/app/onboarding/page.tsx`
+- Create: `services/idun_agent_standalone_ui/components/onboarding/WizardScanning.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/onboarding/WizardScanning.test.tsx`
+
+This task lands the wizard's bare bones: a layout, a page that calls `scan()` and dispatches on `kind: "scanning"`, and the scanning screen. Other screens land in subsequent tasks. The page handles the ALREADY_CONFIGURED branch (auto-redirect to `/`) and shows a placeholder for unhandled steps so we can land each subsequent task incrementally without rewriting the page.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/idun_agent_standalone_ui/__tests__/onboarding/WizardScanning.test.tsx`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WizardScanning } from "@/components/onboarding/WizardScanning";
+
+describe("WizardScanning", () => {
+  it("renders the loading caption", () => {
+    render(<WizardScanning />);
+    expect(screen.getByText(/scanning your project/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — must fail**
+
+```bash
+pnpm test __tests__/onboarding/WizardScanning.test.tsx
+```
+
+Expected: ImportError on `@/components/onboarding/WizardScanning`.
+
+- [ ] **Step 3: Create the WizardScanning component**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/WizardScanning.tsx`:
+
+```typescript
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function WizardScanning() {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardContent className="p-6 space-y-4">
+        <p className="text-sm text-muted-foreground">Scanning your project…</p>
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Create the wizard layout**
+
+Create `services/idun_agent_standalone_ui/app/onboarding/layout.tsx`:
+
+```typescript
+import type { ReactNode } from "react";
+
+export default function OnboardingLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <header className="px-6 py-4">
+        <span className="text-sm font-semibold text-foreground">Idun</span>
+      </header>
+      <main className="flex-1 grid place-items-center px-6 pb-12">
+        {children}
+      </main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Create the wizard page (skeleton)**
+
+Create `services/idun_agent_standalone_ui/app/onboarding/page.tsx`:
+
+```typescript
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { WizardScanning } from "@/components/onboarding/WizardScanning";
+
+const SCAN_QUERY_KEY = ["onboarding-scan"] as const;
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { data, isLoading, error } = useQuery({
+    queryKey: SCAN_QUERY_KEY,
+    queryFn: () => api.scan(),
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (data?.state === "ALREADY_CONFIGURED") {
+      router.replace("/");
+    }
+  }, [data, router]);
+
+  if (isLoading || data?.state === "ALREADY_CONFIGURED") {
+    return <WizardScanning />;
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Could not scan project. Please refresh.
+      </div>
+    );
+  }
+
+  // Subsequent tasks (6–9) replace this with screen dispatch.
+  return (
+    <div className="text-sm text-muted-foreground">
+      State: {data?.state} (screens not yet implemented)
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Run tests — must pass**
+
+```bash
+pnpm test __tests__/onboarding/WizardScanning.test.tsx
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 7: TypeScript check**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no new errors. (Pre-existing errors are tolerated; only block on new ones.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/app/onboarding/ \
+        services/idun_agent_standalone_ui/components/onboarding/WizardScanning.tsx \
+        services/idun_agent_standalone_ui/__tests__/onboarding/WizardScanning.test.tsx
+git commit -m "feat(standalone-ui): wizard layout + scan loading screen"
+```
+
+---
+
+## Task 6: WizardEmpty + WizardNoSupported (framework picker)
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/components/onboarding/WizardEmpty.tsx`
+- Create: `services/idun_agent_standalone_ui/components/onboarding/WizardNoSupported.tsx`
+- Modify: `services/idun_agent_standalone_ui/app/onboarding/page.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/onboarding/WizardEmpty.test.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/onboarding/WizardNoSupported.test.tsx`
+
+Both screens share a framework picker. We extract the picker into a shared `FrameworkPicker` component used by both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `services/idun_agent_standalone_ui/__tests__/onboarding/WizardEmpty.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardEmpty } from "@/components/onboarding/WizardEmpty";
+
+describe("WizardEmpty", () => {
+  it("renders the title and both framework options", () => {
+    render(<WizardEmpty onContinue={vi.fn()} onRescan={vi.fn()} />);
+    expect(screen.getByText(/let's create your first idun agent/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/langgraph/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/adk/i)).toBeInTheDocument();
+    expect(screen.getByText(/recommended/i)).toBeInTheDocument();
+  });
+
+  it("Continue is disabled until a framework is selected", () => {
+    render(<WizardEmpty onContinue={vi.fn()} onRescan={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+  });
+
+  it("calls onContinue with the selected framework", () => {
+    const onContinue = vi.fn();
+    render(<WizardEmpty onContinue={onContinue} onRescan={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText(/langgraph/i));
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onContinue).toHaveBeenCalledWith("LANGGRAPH");
+  });
+
+  it("calls onRescan when re-scan link is clicked", () => {
+    const onRescan = vi.fn();
+    render(<WizardEmpty onContinue={vi.fn()} onRescan={onRescan} />);
+    fireEvent.click(screen.getByText(/re-scan/i));
+    expect(onRescan).toHaveBeenCalled();
+  });
+});
+```
+
+Create `services/idun_agent_standalone_ui/__tests__/onboarding/WizardNoSupported.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardNoSupported } from "@/components/onboarding/WizardNoSupported";
+
+describe("WizardNoSupported", () => {
+  it("renders the no-supported framing copy", () => {
+    render(<WizardNoSupported onContinue={vi.fn()} onRescan={vi.fn()} />);
+    expect(
+      screen.getByText(/we found python code, but no supported agent/i),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onContinue with the selected framework", () => {
+    const onContinue = vi.fn();
+    render(<WizardNoSupported onContinue={onContinue} onRescan={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText(/adk/i));
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onContinue).toHaveBeenCalledWith("ADK");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+pnpm test __tests__/onboarding/WizardEmpty.test.tsx __tests__/onboarding/WizardNoSupported.test.tsx
+```
+
+Expected: ImportError on both modules.
+
+- [ ] **Step 3: Create the shared FrameworkPicker component**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/FrameworkPicker.tsx`:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import type { Framework } from "@/lib/api";
+
+interface FrameworkPickerProps {
+  onContinue: (framework: Framework) => void;
+  onRescan: () => void;
+}
+
+export function FrameworkPicker({ onContinue, onRescan }: FrameworkPickerProps) {
+  const [selected, setSelected] = useState<Framework | "">("");
+
+  return (
+    <div className="space-y-6">
+      <RadioGroup
+        value={selected}
+        onValueChange={(value) => setSelected(value as Framework)}
+        className="space-y-3"
+      >
+        <div className="flex items-start space-x-3 rounded-md border border-border p-4">
+          <RadioGroupItem value="LANGGRAPH" id="fw-langgraph" />
+          <div className="flex-1">
+            <Label htmlFor="fw-langgraph" className="flex items-center gap-2">
+              LangGraph
+              <Badge variant="secondary">Recommended</Badge>
+            </Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              StateGraph-based agents from the LangGraph Python SDK.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-3 rounded-md border border-border p-4">
+          <RadioGroupItem value="ADK" id="fw-adk" />
+          <div className="flex-1">
+            <Label htmlFor="fw-adk">Google ADK</Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              Google Agent Development Kit (Gemini-based).
+            </p>
+          </div>
+        </div>
+      </RadioGroup>
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onRescan}
+          className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+        >
+          Re-scan
+        </button>
+        <Button
+          onClick={() => selected && onContinue(selected)}
+          disabled={!selected}
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Create WizardEmpty**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/WizardEmpty.tsx`:
+
+```typescript
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Framework } from "@/lib/api";
+import { FrameworkPicker } from "./FrameworkPicker";
+
+interface WizardEmptyProps {
+  onContinue: (framework: Framework) => void;
+  onRescan: () => void;
+}
+
+export function WizardEmpty({ onContinue, onRescan }: WizardEmptyProps) {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Let's create your first Idun agent</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          We didn't find any Python files in this folder. Pick a framework and
+          we'll scaffold a starter for you.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <FrameworkPicker onContinue={onContinue} onRescan={onRescan} />
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 5: Create WizardNoSupported**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/WizardNoSupported.tsx`:
+
+```typescript
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Framework } from "@/lib/api";
+import { FrameworkPicker } from "./FrameworkPicker";
+
+interface WizardNoSupportedProps {
+  onContinue: (framework: Framework) => void;
+  onRescan: () => void;
+}
+
+export function WizardNoSupported({
+  onContinue,
+  onRescan,
+}: WizardNoSupportedProps) {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>We found Python code, but no supported agent</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Idun supports LangGraph and Google ADK. Pick one to scaffold a
+          starter alongside your existing code, or re-scan if you just added
+          an agent.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <FrameworkPicker onContinue={onContinue} onRescan={onRescan} />
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 6: Wire the screens into the page**
+
+Modify `services/idun_agent_standalone_ui/app/onboarding/page.tsx`. Replace the entire file contents with:
+
+```typescript
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { Framework, ScanResponse } from "@/lib/api";
+import { WizardScanning } from "@/components/onboarding/WizardScanning";
+import { WizardEmpty } from "@/components/onboarding/WizardEmpty";
+import { WizardNoSupported } from "@/components/onboarding/WizardNoSupported";
+
+const SCAN_QUERY_KEY = ["onboarding-scan"] as const;
+
+type WizardStep =
+  | { kind: "scanning" }
+  | { kind: "scan-result"; data: ScanResponse }
+  | { kind: "starter-confirm"; framework: Framework; name: string };
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { data, isLoading, error } = useQuery({
+    queryKey: SCAN_QUERY_KEY,
+    queryFn: () => api.scan(),
+    retry: false,
+  });
+
+  const [step, setStep] = useState<WizardStep>({ kind: "scanning" });
+
+  useEffect(() => {
+    if (isLoading) {
+      setStep({ kind: "scanning" });
+      return;
+    }
+    if (data) {
+      if (data.state === "ALREADY_CONFIGURED") {
+        router.replace("/");
+        return;
+      }
+      setStep({ kind: "scan-result", data });
+    }
+  }, [data, isLoading, router]);
+
+  const onRescan = () => {
+    queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+  };
+
+  if (error) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Could not scan project. Please refresh.
+      </div>
+    );
+  }
+
+  if (step.kind === "scanning") {
+    return <WizardScanning />;
+  }
+
+  if (step.kind === "scan-result") {
+    const onPickFramework = (framework: Framework) => {
+      setStep({ kind: "starter-confirm", framework, name: "" });
+    };
+    if (step.data.state === "EMPTY") {
+      return <WizardEmpty onContinue={onPickFramework} onRescan={onRescan} />;
+    }
+    if (step.data.state === "NO_SUPPORTED") {
+      return (
+        <WizardNoSupported onContinue={onPickFramework} onRescan={onRescan} />
+      );
+    }
+    // ONE_DETECTED / MANY_DETECTED land in Task 7.
+    return (
+      <div className="text-sm text-muted-foreground">
+        State: {step.data.state} (screen lands in Task 7)
+      </div>
+    );
+  }
+
+  // starter-confirm screen lands in Task 8.
+  return (
+    <div className="text-sm text-muted-foreground">
+      Starter confirm (screen lands in Task 8)
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Run tests — must pass**
+
+```bash
+pnpm test __tests__/onboarding/WizardEmpty.test.tsx __tests__/onboarding/WizardNoSupported.test.tsx
+```
+
+Expected: 6 tests pass (4 in WizardEmpty + 2 in WizardNoSupported).
+
+- [ ] **Step 8: TypeScript check**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no new errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/components/onboarding/ \
+        services/idun_agent_standalone_ui/app/onboarding/page.tsx \
+        services/idun_agent_standalone_ui/__tests__/onboarding/
+git commit -m "feat(standalone-ui): wizard EMPTY + NO_SUPPORTED framework picker"
+```
+
+---
+
+## Task 7: WizardOneDetected + WizardManyDetected
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/components/onboarding/WizardOneDetected.tsx`
+- Create: `services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx`
+- Create: `services/idun_agent_standalone_ui/components/onboarding/DetectionRow.tsx`
+- Modify: `services/idun_agent_standalone_ui/app/onboarding/page.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/onboarding/WizardOneDetected.test.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/onboarding/WizardManyDetected.test.tsx`
+
+`DetectionRow` is the shared visual unit for displaying a single detection (used as the body of OneDetected, and as a row inside ManyDetected's RadioGroup).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `services/idun_agent_standalone_ui/__tests__/onboarding/WizardOneDetected.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardOneDetected } from "@/components/onboarding/WizardOneDetected";
+import type { DetectedAgent } from "@/lib/api";
+
+const HIGH: DetectedAgent = {
+  framework: "LANGGRAPH",
+  filePath: "agent.py",
+  variableName: "graph",
+  inferredName: "My Agent",
+  confidence: "HIGH",
+  source: "source",
+};
+
+const MEDIUM: DetectedAgent = { ...HIGH, confidence: "MEDIUM" };
+
+describe("WizardOneDetected", () => {
+  it("renders the framework, name, and path", () => {
+    render(
+      <WizardOneDetected
+        detection={HIGH}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/found your agent/i)).toBeInTheDocument();
+    expect(screen.getByText("My Agent")).toBeInTheDocument();
+    expect(screen.getByText("agent.py:graph")).toBeInTheDocument();
+    expect(screen.getByText(/langgraph/i)).toBeInTheDocument();
+  });
+
+  it("hides the confidence pill for HIGH detections", () => {
+    render(
+      <WizardOneDetected
+        detection={HIGH}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/medium/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the confidence pill for MEDIUM detections", () => {
+    render(
+      <WizardOneDetected
+        detection={MEDIUM}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/medium confidence/i)).toBeInTheDocument();
+  });
+
+  it("calls onConfirm with the detection when CTA clicked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <WizardOneDetected
+        detection={HIGH}
+        onConfirm={onConfirm}
+        onRescan={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /use this agent/i }));
+    expect(onConfirm).toHaveBeenCalledWith(HIGH);
+  });
+});
+```
+
+Create `services/idun_agent_standalone_ui/__tests__/onboarding/WizardManyDetected.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardManyDetected } from "@/components/onboarding/WizardManyDetected";
+import type { DetectedAgent } from "@/lib/api";
+
+const detections: DetectedAgent[] = [
+  {
+    framework: "ADK",
+    filePath: "main_adk.py",
+    variableName: "agent",
+    inferredName: "B Agent",
+    confidence: "MEDIUM",
+    source: "source",
+  },
+  {
+    framework: "LANGGRAPH",
+    filePath: "agent.py",
+    variableName: "graph",
+    inferredName: "A Agent",
+    confidence: "HIGH",
+    source: "source",
+  },
+];
+
+describe("WizardManyDetected", () => {
+  it("renders the title with the count", () => {
+    render(
+      <WizardManyDetected
+        detections={detections}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/pick your agent/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 agents/i)).toBeInTheDocument();
+  });
+
+  it("sorts: HIGH confidence first, then LANGGRAPH first, then by name", () => {
+    render(
+      <WizardManyDetected
+        detections={detections}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    const rows = screen.getAllByRole("radio");
+    // First row should be the LANGGRAPH HIGH detection ("A Agent").
+    expect(rows[0]).toHaveAttribute("value", "0");
+    const aAgentText = screen.getByText("A Agent");
+    const bAgentText = screen.getByText("B Agent");
+    // A Agent should appear before B Agent in the document order.
+    expect(
+      aAgentText.compareDocumentPosition(bAgentText) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("Use selected agent is disabled until a row is picked", () => {
+    render(
+      <WizardManyDetected
+        detections={detections}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /use selected/i }),
+    ).toBeDisabled();
+  });
+
+  it("calls onConfirm with the picked detection", () => {
+    const onConfirm = vi.fn();
+    render(
+      <WizardManyDetected
+        detections={detections}
+        onConfirm={onConfirm}
+        onRescan={vi.fn()}
+      />,
+    );
+    // Click the radio for "B Agent" (the second in sorted order).
+    fireEvent.click(screen.getByLabelText(/B Agent/));
+    fireEvent.click(screen.getByRole("button", { name: /use selected/i }));
+    // B Agent is the ADK MEDIUM detection.
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ inferredName: "B Agent" }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+pnpm test __tests__/onboarding/WizardOneDetected.test.tsx __tests__/onboarding/WizardManyDetected.test.tsx
+```
+
+Expected: ImportError on both.
+
+- [ ] **Step 3: Create DetectionRow**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/DetectionRow.tsx`:
+
+```typescript
+import { Badge } from "@/components/ui/badge";
+import type { DetectedAgent } from "@/lib/api";
+
+interface DetectionRowProps {
+  detection: DetectedAgent;
+  large?: boolean;
+}
+
+export function DetectionRow({ detection, large = false }: DetectionRowProps) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <Badge variant="secondary">{detection.framework}</Badge>
+        <span className={large ? "text-base font-medium" : "text-sm font-medium"}>
+          {detection.inferredName}
+        </span>
+        {detection.confidence === "MEDIUM" && (
+          <Badge variant="outline" className="text-xs">
+            Medium confidence
+          </Badge>
+        )}
+      </div>
+      <code className="text-xs text-muted-foreground font-mono">
+        {detection.filePath}:{detection.variableName}
+      </code>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Create WizardOneDetected**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/WizardOneDetected.tsx`:
+
+```typescript
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { DetectedAgent } from "@/lib/api";
+import { DetectionRow } from "./DetectionRow";
+
+interface WizardOneDetectedProps {
+  detection: DetectedAgent;
+  onConfirm: (detection: DetectedAgent) => void;
+  onRescan: () => void;
+}
+
+export function WizardOneDetected({
+  detection,
+  onConfirm,
+  onRescan,
+}: WizardOneDetectedProps) {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Found your agent</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          We detected one agent in this folder.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="rounded-md border border-border p-4">
+          <DetectionRow detection={detection} large />
+        </div>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onRescan}
+            className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          >
+            Re-scan
+          </button>
+          <Button onClick={() => onConfirm(detection)}>Use this agent</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 5: Create WizardManyDetected**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx`:
+
+```typescript
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import type { DetectedAgent } from "@/lib/api";
+import { DetectionRow } from "./DetectionRow";
+
+interface WizardManyDetectedProps {
+  detections: DetectedAgent[];
+  onConfirm: (detection: DetectedAgent) => void;
+  onRescan: () => void;
+}
+
+const CONFIDENCE_RANK: Record<DetectedAgent["confidence"], number> = {
+  HIGH: 0,
+  MEDIUM: 1,
+};
+const FRAMEWORK_RANK: Record<DetectedAgent["framework"], number> = {
+  LANGGRAPH: 0,
+  ADK: 1,
+};
+
+export function WizardManyDetected({
+  detections,
+  onConfirm,
+  onRescan,
+}: WizardManyDetectedProps) {
+  const sorted = useMemo(
+    () =>
+      [...detections].sort((a, b) => {
+        const c = CONFIDENCE_RANK[a.confidence] - CONFIDENCE_RANK[b.confidence];
+        if (c !== 0) return c;
+        const f = FRAMEWORK_RANK[a.framework] - FRAMEWORK_RANK[b.framework];
+        if (f !== 0) return f;
+        return a.inferredName.localeCompare(b.inferredName);
+      }),
+    [detections],
+  );
+  const [selectedIndex, setSelectedIndex] = useState<string>("");
+
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Pick your agent</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          We found {sorted.length} agents in this folder. Choose one — Idun runs
+          one agent per install.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <RadioGroup
+          value={selectedIndex}
+          onValueChange={setSelectedIndex}
+          className="space-y-3"
+        >
+          {sorted.map((d, i) => (
+            <div
+              key={`${d.filePath}:${d.variableName}`}
+              className="flex items-start space-x-3 rounded-md border border-border p-4"
+            >
+              <RadioGroupItem value={String(i)} id={`det-${i}`} />
+              <Label htmlFor={`det-${i}`} className="flex-1 cursor-pointer">
+                <DetectionRow detection={d} />
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onRescan}
+            className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          >
+            Re-scan
+          </button>
+          <Button
+            onClick={() => {
+              const idx = parseInt(selectedIndex, 10);
+              if (!Number.isNaN(idx) && sorted[idx]) {
+                onConfirm(sorted[idx]);
+              }
+            }}
+            disabled={selectedIndex === ""}
+          >
+            Use selected agent
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 6: Wire ONE_DETECTED + MANY_DETECTED into the page**
+
+Modify `services/idun_agent_standalone_ui/app/onboarding/page.tsx`. Add the imports and replace the `if (step.kind === "scan-result")` branch.
+
+Add to the imports at the top (alongside the existing onboarding component imports):
+
+```typescript
+import type { DetectedAgent, Framework, ScanResponse } from "@/lib/api";
+import { WizardOneDetected } from "@/components/onboarding/WizardOneDetected";
+import { WizardManyDetected } from "@/components/onboarding/WizardManyDetected";
+```
+
+Replace the entire `if (step.kind === "scan-result")` block with:
+
+```typescript
+  if (step.kind === "scan-result") {
+    const onPickFramework = (framework: Framework) => {
+      setStep({ kind: "starter-confirm", framework, name: "" });
+    };
+    const onPickDetection = (_detection: DetectedAgent) => {
+      // Materialize lands in Task 8 (advances to "materializing" step).
+      // For now, this is a no-op placeholder.
+    };
+    if (step.data.state === "EMPTY") {
+      return <WizardEmpty onContinue={onPickFramework} onRescan={onRescan} />;
+    }
+    if (step.data.state === "NO_SUPPORTED") {
+      return (
+        <WizardNoSupported onContinue={onPickFramework} onRescan={onRescan} />
+      );
+    }
+    if (step.data.state === "ONE_DETECTED") {
+      return (
+        <WizardOneDetected
+          detection={step.data.scanResult.detected[0]}
+          onConfirm={onPickDetection}
+          onRescan={onRescan}
+        />
+      );
+    }
+    if (step.data.state === "MANY_DETECTED") {
+      return (
+        <WizardManyDetected
+          detections={step.data.scanResult.detected}
+          onConfirm={onPickDetection}
+          onRescan={onRescan}
+        />
+      );
+    }
+  }
+```
+
+- [ ] **Step 7: Run tests — must pass**
+
+```bash
+pnpm test __tests__/onboarding/WizardOneDetected.test.tsx __tests__/onboarding/WizardManyDetected.test.tsx
+```
+
+Expected: 8 tests pass (4 + 4).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/components/onboarding/ \
+        services/idun_agent_standalone_ui/app/onboarding/page.tsx \
+        services/idun_agent_standalone_ui/__tests__/onboarding/
+git commit -m "feat(standalone-ui): wizard ONE_DETECTED + MANY_DETECTED screens"
+```
+
+---
+
+## Task 8: WizardStarterConfirm + WizardMaterializing + materialize wiring
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/components/onboarding/WizardStarterConfirm.tsx`
+- Create: `services/idun_agent_standalone_ui/components/onboarding/WizardMaterializing.tsx`
+- Modify: `services/idun_agent_standalone_ui/app/onboarding/page.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/onboarding/WizardStarterConfirm.test.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/onboarding/WizardMaterializing.test.tsx`
+
+This task lands the starter flow's screen 2 + the loading state, and wires both materialize calls (`createFromDetection` and `createStarter`) into the page using `useMutation`. The Done and Error screens land in Task 9.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `services/idun_agent_standalone_ui/__tests__/onboarding/WizardStarterConfirm.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardStarterConfirm } from "@/components/onboarding/WizardStarterConfirm";
+
+describe("WizardStarterConfirm", () => {
+  it("renders the 5 file preview rows", () => {
+    render(
+      <WizardStarterConfirm
+        framework="LANGGRAPH"
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    for (const filename of [
+      "agent.py",
+      "requirements.txt",
+      ".env.example",
+      "README.md",
+      ".gitignore",
+    ]) {
+      expect(screen.getByText(filename)).toBeInTheDocument();
+    }
+  });
+
+  it("name input has the Starter Agent placeholder", () => {
+    render(
+      <WizardStarterConfirm
+        framework="LANGGRAPH"
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.getByPlaceholderText(/starter agent/i)).toBeInTheDocument();
+  });
+
+  it("calls onConfirm with the typed name when set", () => {
+    const onConfirm = vi.fn();
+    render(
+      <WizardStarterConfirm
+        framework="ADK"
+        onConfirm={onConfirm}
+        onBack={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText(/starter agent/i), {
+      target: { value: "My Bot" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create starter/i }));
+    expect(onConfirm).toHaveBeenCalledWith({ framework: "ADK", name: "My Bot" });
+  });
+
+  it("calls onConfirm with name omitted when input is blank", () => {
+    const onConfirm = vi.fn();
+    render(
+      <WizardStarterConfirm
+        framework="LANGGRAPH"
+        onConfirm={onConfirm}
+        onBack={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /create starter/i }));
+    expect(onConfirm).toHaveBeenCalledWith({ framework: "LANGGRAPH" });
+  });
+
+  it("calls onBack when Back is clicked", () => {
+    const onBack = vi.fn();
+    render(
+      <WizardStarterConfirm
+        framework="LANGGRAPH"
+        onConfirm={vi.fn()}
+        onBack={onBack}
+        onRescan={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});
+```
+
+Create `services/idun_agent_standalone_ui/__tests__/onboarding/WizardMaterializing.test.tsx`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WizardMaterializing } from "@/components/onboarding/WizardMaterializing";
+
+describe("WizardMaterializing", () => {
+  it("renders the loading caption", () => {
+    render(<WizardMaterializing />);
+    expect(screen.getByText(/creating your agent/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+pnpm test __tests__/onboarding/WizardStarterConfirm.test.tsx __tests__/onboarding/WizardMaterializing.test.tsx
+```
+
+Expected: ImportError on both.
+
+- [ ] **Step 3: Create WizardMaterializing**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/WizardMaterializing.tsx`:
+
+```typescript
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function WizardMaterializing() {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardContent className="p-6 space-y-4">
+        <p className="text-sm text-muted-foreground">Creating your agent…</p>
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Create WizardStarterConfirm**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/WizardStarterConfirm.tsx`:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import { File } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { Framework } from "@/lib/api";
+
+const STARTER_FILES = [
+  "agent.py",
+  "requirements.txt",
+  ".env.example",
+  "README.md",
+  ".gitignore",
+];
+
+interface WizardStarterConfirmProps {
+  framework: Framework;
+  onConfirm: (input: { framework: Framework; name?: string }) => void;
+  onBack: () => void;
+  onRescan: () => void;
+}
+
+export function WizardStarterConfirm({
+  framework,
+  onConfirm,
+  onBack,
+  onRescan,
+}: WizardStarterConfirmProps) {
+  const [name, setName] = useState("");
+
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Confirm your starter</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          We'll create the following files in your project:
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <ul className="space-y-2">
+          {STARTER_FILES.map((filename) => (
+            <li key={filename} className="flex items-center gap-2 text-sm">
+              <File className="h-4 w-4 text-muted-foreground" />
+              <code className="font-mono text-xs">{filename}</code>
+            </li>
+          ))}
+        </ul>
+        <div className="space-y-1">
+          <Label htmlFor="agent-name" className="text-xs text-muted-foreground">
+            Agent name (optional)
+          </Label>
+          <Input
+            id="agent-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Starter Agent"
+            maxLength={80}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={onBack}
+              className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={onRescan}
+              className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+            >
+              Re-scan
+            </button>
+          </div>
+          <Button
+            onClick={() => {
+              const trimmed = name.trim();
+              onConfirm(
+                trimmed ? { framework, name: trimmed } : { framework },
+              );
+            }}
+          >
+            Create starter
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 5: Wire materialize calls into the page**
+
+Modify `services/idun_agent_standalone_ui/app/onboarding/page.tsx`. Add the new imports and update the page to handle the materialize flow.
+
+Replace the entire file contents with:
+
+```typescript
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError, api } from "@/lib/api";
+import type {
+  AgentRead,
+  CreateFromDetectionBody,
+  CreateStarterBody,
+  DetectedAgent,
+  Framework,
+  ScanResponse,
+} from "@/lib/api";
+import { WizardScanning } from "@/components/onboarding/WizardScanning";
+import { WizardEmpty } from "@/components/onboarding/WizardEmpty";
+import { WizardNoSupported } from "@/components/onboarding/WizardNoSupported";
+import { WizardOneDetected } from "@/components/onboarding/WizardOneDetected";
+import { WizardManyDetected } from "@/components/onboarding/WizardManyDetected";
+import { WizardStarterConfirm } from "@/components/onboarding/WizardStarterConfirm";
+import { WizardMaterializing } from "@/components/onboarding/WizardMaterializing";
+
+const SCAN_QUERY_KEY = ["onboarding-scan"] as const;
+
+type WizardStep =
+  | { kind: "scanning" }
+  | { kind: "scan-result"; data: ScanResponse }
+  | { kind: "starter-confirm"; framework: Framework }
+  | { kind: "materializing" };
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { data, isLoading, error } = useQuery({
+    queryKey: SCAN_QUERY_KEY,
+    queryFn: () => api.scan(),
+    retry: false,
+  });
+
+  const [step, setStep] = useState<WizardStep>({ kind: "scanning" });
+
+  useEffect(() => {
+    if (isLoading) {
+      setStep({ kind: "scanning" });
+      return;
+    }
+    if (data) {
+      if (data.state === "ALREADY_CONFIGURED") {
+        router.replace("/");
+        return;
+      }
+      // Only sync to scan-result if we're not in the middle of a downstream step.
+      setStep((prev) => {
+        if (
+          prev.kind === "scanning" ||
+          prev.kind === "scan-result" ||
+          // After a 409 (handled below) we re-fetch and want to show the new state.
+          prev.kind === "materializing"
+        ) {
+          return { kind: "scan-result", data };
+        }
+        return prev;
+      });
+    }
+  }, [data, isLoading, router]);
+
+  const onRescan = () => {
+    queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+  };
+
+  const detectionMutation = useMutation({
+    mutationFn: (body: CreateFromDetectionBody) => api.createFromDetection(body),
+    onSuccess: () => {
+      // Done screen lands in Task 9 — for now, navigate home.
+      router.replace("/");
+    },
+    onError: (err) => {
+      handleMutationError(err);
+    },
+  });
+
+  const starterMutation = useMutation({
+    mutationFn: (body: CreateStarterBody) => api.createStarter(body),
+    onSuccess: () => {
+      router.replace("/");
+    },
+    onError: (err) => {
+      handleMutationError(err);
+    },
+  });
+
+  function handleMutationError(err: unknown) {
+    if (err instanceof ApiError && err.status === 409) {
+      const message =
+        (err.detail as { error?: { message?: string } } | null)?.error
+          ?.message ?? "Conflict";
+      toast.error(message);
+      queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+      setStep({ kind: "scanning" });
+      return;
+    }
+    // Error screen lands in Task 9 — for now, just toast.
+    const message =
+      (err as ApiError | undefined)?.detail !== undefined
+        ? ((err as ApiError).detail as { error?: { message?: string } } | null)
+            ?.error?.message ?? "Something went wrong"
+        : "Something went wrong";
+    toast.error(message);
+    queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+    setStep({ kind: "scanning" });
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Could not scan project. Please refresh.
+      </div>
+    );
+  }
+
+  if (step.kind === "scanning") {
+    return <WizardScanning />;
+  }
+
+  if (step.kind === "materializing") {
+    return <WizardMaterializing />;
+  }
+
+  if (step.kind === "starter-confirm") {
+    return (
+      <WizardStarterConfirm
+        framework={step.framework}
+        onConfirm={(body) => {
+          setStep({ kind: "materializing" });
+          starterMutation.mutate(body);
+        }}
+        onBack={() => {
+          if (data) setStep({ kind: "scan-result", data });
+        }}
+        onRescan={onRescan}
+      />
+    );
+  }
+
+  if (step.kind === "scan-result") {
+    const onPickFramework = (framework: Framework) => {
+      setStep({ kind: "starter-confirm", framework });
+    };
+    const onPickDetection = (detection: DetectedAgent) => {
+      setStep({ kind: "materializing" });
+      detectionMutation.mutate({
+        framework: detection.framework,
+        filePath: detection.filePath,
+        variableName: detection.variableName,
+      });
+    };
+    if (step.data.state === "EMPTY") {
+      return <WizardEmpty onContinue={onPickFramework} onRescan={onRescan} />;
+    }
+    if (step.data.state === "NO_SUPPORTED") {
+      return (
+        <WizardNoSupported onContinue={onPickFramework} onRescan={onRescan} />
+      );
+    }
+    if (step.data.state === "ONE_DETECTED") {
+      return (
+        <WizardOneDetected
+          detection={step.data.scanResult.detected[0]}
+          onConfirm={onPickDetection}
+          onRescan={onRescan}
+        />
+      );
+    }
+    if (step.data.state === "MANY_DETECTED") {
+      return (
+        <WizardManyDetected
+          detections={step.data.scanResult.detected}
+          onConfirm={onPickDetection}
+          onRescan={onRescan}
+        />
+      );
+    }
+  }
+
+  return null;
+}
+```
+
+The temporary `router.replace("/")` on success is overwritten by Task 9 with proper Done-screen handling. The Error/Done states are stubbed via toast in this slice.
+
+The unused `AgentRead` import will be removed in Task 9 when WizardDone consumes it. Leave it imported now so Task 9 doesn't have to re-edit the import list. Actually — drop it for now to keep ruff happy:
+
+Replace the import line `import type { AgentRead, ...` with the version that excludes `AgentRead`:
+
+```typescript
+import type {
+  CreateFromDetectionBody,
+  CreateStarterBody,
+  DetectedAgent,
+  Framework,
+  ScanResponse,
+} from "@/lib/api";
+```
+
+- [ ] **Step 6: Run tests — must pass**
+
+```bash
+pnpm test __tests__/onboarding/WizardStarterConfirm.test.tsx __tests__/onboarding/WizardMaterializing.test.tsx
+```
+
+Expected: 6 tests pass (5 + 1).
+
+- [ ] **Step 7: Run the full UI test suite — no regressions**
+
+```bash
+pnpm test
+```
+
+Expected: all tests still pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/components/onboarding/ \
+        services/idun_agent_standalone_ui/app/onboarding/page.tsx \
+        services/idun_agent_standalone_ui/__tests__/onboarding/
+git commit -m "feat(standalone-ui): wizard starter-confirm + materialize wiring"
+```
+
+---
+
+## Task 9: WizardDone + WizardError
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx`
+- Create: `services/idun_agent_standalone_ui/components/onboarding/WizardError.tsx`
+- Modify: `services/idun_agent_standalone_ui/app/onboarding/page.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/onboarding/WizardDone.test.tsx`
+- Test: `services/idun_agent_standalone_ui/__tests__/onboarding/WizardError.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `services/idun_agent_standalone_ui/__tests__/onboarding/WizardDone.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardDone } from "@/components/onboarding/WizardDone";
+import type { AgentRead } from "@/lib/api";
+
+const AGENT: AgentRead = {
+  id: "x",
+  slug: null,
+  name: "Foo",
+  description: null,
+  version: null,
+  status: "draft",
+  baseUrl: null,
+  baseEngineConfig: {},
+  createdAt: "2026-04-29T00:00:00Z",
+  updatedAt: "2026-04-29T00:00:00Z",
+};
+
+describe("WizardDone", () => {
+  it("renders the agent name", () => {
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="LANGGRAPH"
+        mode="starter"
+        onGoToChat={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Foo is ready/i)).toBeInTheDocument();
+  });
+
+  it("starter + LANGGRAPH shows OPENAI_API_KEY reminder", () => {
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="LANGGRAPH"
+        mode="starter"
+        onGoToChat={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/OPENAI_API_KEY/)).toBeInTheDocument();
+  });
+
+  it("starter + ADK shows GOOGLE_API_KEY reminder", () => {
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="ADK"
+        mode="starter"
+        onGoToChat={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/GOOGLE_API_KEY/)).toBeInTheDocument();
+  });
+
+  it("detection mode shows the generic env reminder", () => {
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="LANGGRAPH"
+        mode="detection"
+        onGoToChat={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/make sure your agent's environment variables are set/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/OPENAI_API_KEY/)).not.toBeInTheDocument();
+  });
+
+  it("calls onGoToChat when CTA clicked", () => {
+    const onGoToChat = vi.fn();
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="LANGGRAPH"
+        mode="starter"
+        onGoToChat={onGoToChat}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /go to chat/i }));
+    expect(onGoToChat).toHaveBeenCalled();
+  });
+});
+```
+
+Create `services/idun_agent_standalone_ui/__tests__/onboarding/WizardError.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardError } from "@/components/onboarding/WizardError";
+
+describe("WizardError", () => {
+  it("renders the error message verbatim", () => {
+    render(
+      <WizardError
+        message="Engine init failed: bad import"
+        code="reload_failed"
+        onRetry={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/engine init failed: bad import/i),
+    ).toBeInTheDocument();
+  });
+
+  it("appends recovery hint when code is reload_failed", () => {
+    render(
+      <WizardError
+        message="boom"
+        code="reload_failed"
+        onRetry={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/edit your `?agent\.py`? to fix the issue/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the recovery hint for other codes", () => {
+    render(
+      <WizardError
+        message="boom"
+        code="other"
+        onRetry={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByText(/edit your `?agent\.py`?/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onRetry when retry clicked", () => {
+    const onRetry = vi.fn();
+    render(
+      <WizardError
+        message="boom"
+        code="reload_failed"
+        onRetry={onRetry}
+        onBack={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("calls onBack when back link clicked", () => {
+    const onBack = vi.fn();
+    render(
+      <WizardError
+        message="boom"
+        code="reload_failed"
+        onRetry={vi.fn()}
+        onBack={onBack}
+      />,
+    );
+    fireEvent.click(screen.getByText(/back to wizard/i));
+    expect(onBack).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — must fail**
+
+```bash
+pnpm test __tests__/onboarding/WizardDone.test.tsx __tests__/onboarding/WizardError.test.tsx
+```
+
+Expected: ImportError on both.
+
+- [ ] **Step 3: Create WizardDone**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx`:
+
+```typescript
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { AgentRead, Framework } from "@/lib/api";
+
+type Mode = "starter" | "detection";
+
+interface WizardDoneProps {
+  agent: AgentRead;
+  framework: Framework;
+  mode: Mode;
+  onGoToChat: () => void;
+}
+
+function envReminder(framework: Framework, mode: Mode): string {
+  if (mode === "detection") {
+    return "Make sure your agent's environment variables are set before chatting.";
+  }
+  if (framework === "LANGGRAPH") {
+    return "Set `OPENAI_API_KEY` in your environment before chatting. Copy `.env.example` to `.env` and fill it in, then restart `idun-standalone`.";
+  }
+  return "Set `GOOGLE_API_KEY` in your environment before chatting. Copy `.env.example` to `.env` and fill it in, then restart `idun-standalone`.";
+}
+
+export function WizardDone({
+  agent,
+  framework,
+  mode,
+  onGoToChat,
+}: WizardDoneProps) {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>{agent.name} is ready</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2 text-sm">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Framework</span>
+            <Badge variant="secondary">{framework}</Badge>
+          </div>
+        </div>
+        <Alert>
+          <AlertTitle>Set up your model credentials</AlertTitle>
+          <AlertDescription>{envReminder(framework, mode)}</AlertDescription>
+        </Alert>
+        <div className="flex justify-end">
+          <Button onClick={onGoToChat}>Go to chat</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Create WizardError**
+
+Create `services/idun_agent_standalone_ui/components/onboarding/WizardError.tsx`:
+
+```typescript
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface WizardErrorProps {
+  message: string;
+  code: string;
+  onRetry: () => void;
+  onBack: () => void;
+}
+
+export function WizardError({
+  message,
+  code,
+  onRetry,
+  onBack,
+}: WizardErrorProps) {
+  const isReloadFailed = code === "reload_failed";
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Something went wrong</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Alert variant="destructive">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription className="space-y-2">
+            <p>{message}</p>
+            {isReloadFailed && (
+              <p>
+                Edit your <code>agent.py</code> to fix the issue, then click
+                Retry.
+              </p>
+            )}
+          </AlertDescription>
+        </Alert>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onBack}
+            className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          >
+            Back to wizard
+          </button>
+          <Button onClick={onRetry}>Retry</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 5: Wire Done + Error into the page**
+
+Modify `services/idun_agent_standalone_ui/app/onboarding/page.tsx`. Replace the entire file contents with:
+
+```typescript
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError, api } from "@/lib/api";
+import type {
+  AgentRead,
+  CreateFromDetectionBody,
+  CreateStarterBody,
+  DetectedAgent,
+  Framework,
+  ScanResponse,
+} from "@/lib/api";
+import { WizardScanning } from "@/components/onboarding/WizardScanning";
+import { WizardEmpty } from "@/components/onboarding/WizardEmpty";
+import { WizardNoSupported } from "@/components/onboarding/WizardNoSupported";
+import { WizardOneDetected } from "@/components/onboarding/WizardOneDetected";
+import { WizardManyDetected } from "@/components/onboarding/WizardManyDetected";
+import { WizardStarterConfirm } from "@/components/onboarding/WizardStarterConfirm";
+import { WizardMaterializing } from "@/components/onboarding/WizardMaterializing";
+import { WizardDone } from "@/components/onboarding/WizardDone";
+import { WizardError } from "@/components/onboarding/WizardError";
+
+const SCAN_QUERY_KEY = ["onboarding-scan"] as const;
+
+type WizardStep =
+  | { kind: "scanning" }
+  | { kind: "scan-result"; data: ScanResponse }
+  | { kind: "starter-confirm"; framework: Framework }
+  | { kind: "materializing" }
+  | {
+      kind: "done";
+      agent: AgentRead;
+      framework: Framework;
+      mode: "starter" | "detection";
+    }
+  | {
+      kind: "error";
+      message: string;
+      code: string;
+      retry: () => void;
+    };
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { data, isLoading, error } = useQuery({
+    queryKey: SCAN_QUERY_KEY,
+    queryFn: () => api.scan(),
+    retry: false,
+  });
+
+  const [step, setStep] = useState<WizardStep>({ kind: "scanning" });
+
+  // The framework / mode of the most recent materialize call. Used by the
+  // Done screen to render the correct env reminder, and by the Error screen
+  // to know what to retry.
+  const lastFrameworkRef = useRef<Framework>("LANGGRAPH");
+  const lastModeRef = useRef<"starter" | "detection">("starter");
+
+  useEffect(() => {
+    if (isLoading) {
+      setStep({ kind: "scanning" });
+      return;
+    }
+    if (data) {
+      if (data.state === "ALREADY_CONFIGURED") {
+        router.replace("/");
+        return;
+      }
+      setStep((prev) => {
+        // Only sync to scan-result when we're returning from a 409 conflict
+        // (which routes through "scanning") or on first load. Don't clobber
+        // done/error/starter-confirm with a stale scan refetch.
+        if (prev.kind === "scanning" || prev.kind === "scan-result") {
+          return { kind: "scan-result", data };
+        }
+        return prev;
+      });
+    }
+  }, [data, isLoading, router]);
+
+  const onRescan = () => {
+    queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+    setStep({ kind: "scanning" });
+  };
+
+  function extractMessage(err: unknown): string {
+    if (err instanceof ApiError) {
+      const detail = err.detail as { error?: { message?: string } } | null;
+      return detail?.error?.message ?? `Request failed (${err.status})`;
+    }
+    return "Something went wrong";
+  }
+
+  function extractCode(err: unknown): string {
+    if (err instanceof ApiError) {
+      const detail = err.detail as { error?: { code?: string } } | null;
+      return detail?.error?.code ?? "unknown";
+    }
+    return "unknown";
+  }
+
+  const detectionMutation = useMutation({
+    mutationFn: (body: CreateFromDetectionBody) => api.createFromDetection(body),
+    onSuccess: (response) => {
+      setStep({
+        kind: "done",
+        agent: response.data,
+        framework: lastFrameworkRef.current,
+        mode: "detection",
+      });
+    },
+    onError: (err) => {
+      handleMutationError(err, () => {
+        // Re-trigger the same mutation. The body is captured in the closure.
+        // We grab it from the previous mutation's variables.
+        const body = detectionMutation.variables;
+        if (body) {
+          setStep({ kind: "materializing" });
+          detectionMutation.mutate(body);
+        }
+      });
+    },
+  });
+
+  const starterMutation = useMutation({
+    mutationFn: (body: CreateStarterBody) => api.createStarter(body),
+    onSuccess: (response) => {
+      setStep({
+        kind: "done",
+        agent: response.data,
+        framework: lastFrameworkRef.current,
+        mode: "starter",
+      });
+    },
+    onError: (err) => {
+      handleMutationError(err, () => {
+        const body = starterMutation.variables;
+        if (body) {
+          setStep({ kind: "materializing" });
+          starterMutation.mutate(body);
+        }
+      });
+    },
+  });
+
+  function handleMutationError(err: unknown, retry: () => void) {
+    if (err instanceof ApiError && err.status === 409) {
+      // Conflict — return to scan and let the user see the new state.
+      toast.error(extractMessage(err));
+      queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+      setStep({ kind: "scanning" });
+      return;
+    }
+    setStep({
+      kind: "error",
+      message: extractMessage(err),
+      code: extractCode(err),
+      retry,
+    });
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Could not scan project. Please refresh.
+      </div>
+    );
+  }
+
+  if (step.kind === "scanning") {
+    return <WizardScanning />;
+  }
+
+  if (step.kind === "materializing") {
+    return <WizardMaterializing />;
+  }
+
+  if (step.kind === "done") {
+    return (
+      <WizardDone
+        agent={step.agent}
+        framework={step.framework}
+        mode={step.mode}
+        onGoToChat={() => router.push("/")}
+      />
+    );
+  }
+
+  if (step.kind === "error") {
+    return (
+      <WizardError
+        message={step.message}
+        code={step.code}
+        onRetry={step.retry}
+        onBack={() => {
+          if (data) setStep({ kind: "scan-result", data });
+          else setStep({ kind: "scanning" });
+        }}
+      />
+    );
+  }
+
+  if (step.kind === "starter-confirm") {
+    return (
+      <WizardStarterConfirm
+        framework={step.framework}
+        onConfirm={(body) => {
+          lastFrameworkRef.current = body.framework;
+          lastModeRef.current = "starter";
+          setStep({ kind: "materializing" });
+          starterMutation.mutate(body);
+        }}
+        onBack={() => {
+          if (data) setStep({ kind: "scan-result", data });
+        }}
+        onRescan={onRescan}
+      />
+    );
+  }
+
+  if (step.kind === "scan-result") {
+    const onPickFramework = (framework: Framework) => {
+      setStep({ kind: "starter-confirm", framework });
+    };
+    const onPickDetection = (detection: DetectedAgent) => {
+      lastFrameworkRef.current = detection.framework;
+      lastModeRef.current = "detection";
+      setStep({ kind: "materializing" });
+      detectionMutation.mutate({
+        framework: detection.framework,
+        filePath: detection.filePath,
+        variableName: detection.variableName,
+      });
+    };
+    if (step.data.state === "EMPTY") {
+      return <WizardEmpty onContinue={onPickFramework} onRescan={onRescan} />;
+    }
+    if (step.data.state === "NO_SUPPORTED") {
+      return (
+        <WizardNoSupported onContinue={onPickFramework} onRescan={onRescan} />
+      );
+    }
+    if (step.data.state === "ONE_DETECTED") {
+      return (
+        <WizardOneDetected
+          detection={step.data.scanResult.detected[0]}
+          onConfirm={onPickDetection}
+          onRescan={onRescan}
+        />
+      );
+    }
+    if (step.data.state === "MANY_DETECTED") {
+      return (
+        <WizardManyDetected
+          detections={step.data.scanResult.detected}
+          onConfirm={onPickDetection}
+          onRescan={onRescan}
+        />
+      );
+    }
+  }
+
+  return null;
+}
+```
+
+- [ ] **Step 6: Run tests — must pass**
+
+```bash
+pnpm test __tests__/onboarding/
+```
+
+Expected: all 9 onboarding test files pass (~22 tests total — Scanning 1 + Empty 4 + NoSupported 2 + OneDetected 4 + ManyDetected 4 + StarterConfirm 5 + Materializing 1 + Done 5 + Error 5).
+
+- [ ] **Step 7: Run the full UI test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: TypeScript check**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no new errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/components/onboarding/ \
+        services/idun_agent_standalone_ui/app/onboarding/page.tsx \
+        services/idun_agent_standalone_ui/__tests__/onboarding/
+git commit -m "feat(standalone-ui): wizard done + error screens, full state machine"
+```
+
+---
+
+## Task 10: E2E tests + final pass
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/e2e/onboarding.spec.ts`
+
+This task adds Playwright E2E tests for the seven flows from the spec. They run against route mocks (no real backend), exercising the wizard end-to-end through the browser.
+
+- [ ] **Step 1: Write the E2E tests**
+
+Create `services/idun_agent_standalone_ui/e2e/onboarding.spec.ts`:
+
+```typescript
+import { test, expect, type Route } from "@playwright/test";
+
+const ADMIN = "/admin/api/v1";
+
+interface MockState {
+  scan: () => unknown;
+  agent?: () => unknown;
+  createStarter?: () => { status: number; body: unknown };
+  createFromDetection?: () => { status: number; body: unknown };
+}
+
+async function setupMocks(page: import("@playwright/test").Page, state: MockState) {
+  await page.route("**/admin/api/v1/agent", async (route: Route) => {
+    if (state.agent) {
+      await route.fulfill({ status: 200, body: JSON.stringify(state.agent()) });
+    } else {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "not_found" } }),
+      });
+    }
+  });
+  await page.route("**/admin/api/v1/onboarding/scan", async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(state.scan()),
+    });
+  });
+  if (state.createStarter) {
+    await page.route(
+      "**/admin/api/v1/onboarding/create-starter",
+      async (route: Route) => {
+        const r = state.createStarter!();
+        await route.fulfill({
+          status: r.status,
+          contentType: "application/json",
+          body: JSON.stringify(r.body),
+        });
+      },
+    );
+  }
+  if (state.createFromDetection) {
+    await page.route(
+      "**/admin/api/v1/onboarding/create-from-detection",
+      async (route: Route) => {
+        const r = state.createFromDetection!();
+        await route.fulfill({
+          status: r.status,
+          contentType: "application/json",
+          body: JSON.stringify(r.body),
+        });
+      },
+    );
+  }
+}
+
+const EMPTY_SCAN = {
+  state: "EMPTY",
+  scanResult: {
+    root: "/tmp",
+    detected: [],
+    hasPythonFiles: false,
+    hasIdunConfig: false,
+    scanDurationMs: 1,
+  },
+  currentAgent: null,
+};
+
+const ONE_LANGGRAPH_DETECTION = {
+  framework: "LANGGRAPH" as const,
+  filePath: "agent.py",
+  variableName: "graph",
+  inferredName: "My Agent",
+  confidence: "HIGH" as const,
+  source: "source" as const,
+};
+
+const ONE_DETECTED_SCAN = {
+  state: "ONE_DETECTED",
+  scanResult: {
+    root: "/tmp",
+    detected: [ONE_LANGGRAPH_DETECTION],
+    hasPythonFiles: true,
+    hasIdunConfig: false,
+    scanDurationMs: 1,
+  },
+  currentAgent: null,
+};
+
+const STARTER_AGENT_RESPONSE = {
+  data: {
+    id: "x",
+    slug: null,
+    name: "Starter Agent",
+    description: null,
+    version: null,
+    status: "draft",
+    baseUrl: null,
+    baseEngineConfig: { agent: { type: "LANGGRAPH" } },
+    createdAt: "2026-04-29T00:00:00Z",
+    updatedAt: "2026-04-29T00:00:00Z",
+  },
+  reload: { status: "reloaded", message: "Reloaded." },
+};
+
+test("EMPTY → user picks LangGraph → confirms → done shows OPENAI_API_KEY", async ({
+  page,
+}) => {
+  await setupMocks(page, {
+    scan: () => EMPTY_SCAN,
+    createStarter: () => ({ status: 200, body: STARTER_AGENT_RESPONSE }),
+  });
+  await page.goto("/onboarding");
+  await expect(page.getByText(/let's create your first idun agent/i)).toBeVisible();
+  await page.getByLabel(/langgraph/i).click();
+  await page.getByRole("button", { name: /continue/i }).click();
+  await expect(page.getByText(/confirm your starter/i)).toBeVisible();
+  await page.getByRole("button", { name: /create starter/i }).click();
+  await expect(page.getByText(/Starter Agent is ready/i)).toBeVisible();
+  await expect(page.getByText(/OPENAI_API_KEY/)).toBeVisible();
+});
+
+test("ONE_DETECTED → user clicks Use → done shows generic env reminder", async ({
+  page,
+}) => {
+  await setupMocks(page, {
+    scan: () => ONE_DETECTED_SCAN,
+    createFromDetection: () => ({
+      status: 200,
+      body: {
+        ...STARTER_AGENT_RESPONSE,
+        data: { ...STARTER_AGENT_RESPONSE.data, name: "My Agent" },
+      },
+    }),
+  });
+  await page.goto("/onboarding");
+  await expect(page.getByText(/found your agent/i)).toBeVisible();
+  await page.getByRole("button", { name: /use this agent/i }).click();
+  await expect(page.getByText(/My Agent is ready/i)).toBeVisible();
+  await expect(
+    page.getByText(/make sure your agent's environment variables are set/i),
+  ).toBeVisible();
+});
+
+test("MANY_DETECTED → user picks the second → confirms → done", async ({
+  page,
+}) => {
+  const SECOND = {
+    framework: "ADK" as const,
+    filePath: "main_adk.py",
+    variableName: "agent",
+    inferredName: "B Agent",
+    confidence: "HIGH" as const,
+    source: "source" as const,
+  };
+  await setupMocks(page, {
+    scan: () => ({
+      ...ONE_DETECTED_SCAN,
+      state: "MANY_DETECTED",
+      scanResult: {
+        ...ONE_DETECTED_SCAN.scanResult,
+        detected: [ONE_LANGGRAPH_DETECTION, SECOND],
+      },
+    }),
+    createFromDetection: () => ({
+      status: 200,
+      body: {
+        ...STARTER_AGENT_RESPONSE,
+        data: { ...STARTER_AGENT_RESPONSE.data, name: "B Agent" },
+      },
+    }),
+  });
+  await page.goto("/onboarding");
+  await expect(page.getByText(/pick your agent/i)).toBeVisible();
+  await page.getByLabel(/B Agent/).click();
+  await page.getByRole("button", { name: /use selected/i }).click();
+  await expect(page.getByText(/B Agent is ready/i)).toBeVisible();
+});
+
+test("ALREADY_CONFIGURED → wizard auto-redirects to /", async ({ page }) => {
+  await setupMocks(page, {
+    scan: () => ({
+      ...EMPTY_SCAN,
+      state: "ALREADY_CONFIGURED",
+      currentAgent: STARTER_AGENT_RESPONSE.data,
+    }),
+    agent: () => STARTER_AGENT_RESPONSE.data,
+  });
+  await page.goto("/onboarding");
+  await page.waitForURL("**/");
+});
+
+test("Reload failure → error screen shows diagnostic + Retry → second attempt 200 → done", async ({
+  page,
+}) => {
+  let attempts = 0;
+  await setupMocks(page, {
+    scan: () => EMPTY_SCAN,
+    createStarter: () => {
+      attempts++;
+      if (attempts === 1) {
+        return {
+          status: 500,
+          body: {
+            error: {
+              code: "reload_failed",
+              message: "Engine init failed: bad import in agent.py.",
+            },
+          },
+        };
+      }
+      return { status: 200, body: STARTER_AGENT_RESPONSE };
+    },
+  });
+  await page.goto("/onboarding");
+  await page.getByLabel(/langgraph/i).click();
+  await page.getByRole("button", { name: /continue/i }).click();
+  await page.getByRole("button", { name: /create starter/i }).click();
+  await expect(page.getByText(/something went wrong/i)).toBeVisible();
+  await expect(page.getByText(/bad import in agent\.py/i)).toBeVisible();
+  await expect(page.getByText(/edit your `?agent\.py`?/i)).toBeVisible();
+  await page.getByRole("button", { name: /retry/i }).click();
+  await expect(page.getByText(/Starter Agent is ready/i)).toBeVisible();
+});
+
+test("Re-scan: EMPTY → user clicks Re-scan → backend returns ONE_DETECTED → screen flips", async ({
+  page,
+}) => {
+  let calls = 0;
+  await setupMocks(page, {
+    scan: () => {
+      calls++;
+      return calls === 1 ? EMPTY_SCAN : ONE_DETECTED_SCAN;
+    },
+  });
+  await page.goto("/onboarding");
+  await expect(page.getByText(/let's create your first idun agent/i)).toBeVisible();
+  await page.getByText(/re-scan/i).click();
+  await expect(page.getByText(/found your agent/i)).toBeVisible();
+});
+
+test("Login redirect (password mode): /onboarding 401 → /login → submit → back to /onboarding", async ({
+  page,
+}) => {
+  let scanAttempts = 0;
+  await page.route("**/admin/api/v1/onboarding/scan", async (route: Route) => {
+    scanAttempts++;
+    if (scanAttempts === 1) {
+      await route.fulfill({ status: 401, body: JSON.stringify({}) });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_SCAN),
+      });
+    }
+  });
+  await page.route("**/admin/api/v1/auth/login", async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+  await page.goto("/onboarding");
+  await page.waitForURL(/\/login\/\?next=/);
+  await page.getByLabel(/admin password/i).fill("hunter2");
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.waitForURL(/\/onboarding/);
+  await expect(page.getByText(/let's create your first idun agent/i)).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run E2E tests**
+
+```bash
+cd services/idun_agent_standalone_ui
+pnpm test:e2e e2e/onboarding.spec.ts
+```
+
+Expected: 7 E2E tests pass. If the existing playwright config requires the dev server running, follow the existing convention from `e2e/admin-shell.spec.ts` or whatever harness is in use.
+
+If route mocking doesn't fire because the existing `e2e/boot-standalone.sh` boots a real backend, check the existing E2E tests to see whether route mocking works (it's a Playwright primitive — should work everywhere). If the existing E2E suite shells out to a real backend, this onboarding suite can either:
+- Mock at the network layer (current approach — should still work since `page.route` short-circuits the real request).
+- Skip these in CI and document a limitation.
+
+- [ ] **Step 3: Run the full UI test suite (unit + e2e)**
+
+```bash
+pnpm test
+pnpm test:e2e
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
+git commit -m "test(standalone-ui): E2E coverage for the onboarding wizard"
+```
+
+---
+
+## Spec coverage check
+
+| Spec section | Implementing task |
+|---|---|
+| §4 Locked decisions (Q1-Q12) | Tasks 4–9 collectively |
+| §5 State machine | Tasks 5–9 (incremental: scanning in 5, scan-result branches in 6/7, starter-confirm + materializing in 8, done + error in 9) |
+| §6 Module layout | All tasks |
+| §7 API client additions | Task 1 |
+| §8 Per-screen UX | Tasks 5–9 |
+| §9 Login page | Task 3 (+ apiFetch enhancement in Task 2) |
+| §10 Routing flow | Tasks 4 (chat root) + 5 (onboarding mount) + 3 (login) |
+| §11 Theming | Task 5 (layout inherits ThemeLoader) |
+| §12 Concurrency edge cases | Task 8/9 (mutation conflict handling) |
+| §13 Testing strategy | Each task includes its tests; Task 10 covers E2E |
+| §14–§15 Future work / open questions | Out of scope — explicitly deferred |
+
+## Test count summary
+
+- API + client: 6 + 2 = 8
+- Login: 3
+- Page-redirect: 3
+- Wizard screens: 1 + 4 + 2 + 4 + 4 + 5 + 1 + 5 + 5 = 31
+- E2E: 7
+
+**Total new tests: 52** (45 unit + 7 E2E).

--- a/docs/superpowers/specs/2026-04-28-onboarding-scanner-design.md
+++ b/docs/superpowers/specs/2026-04-28-onboarding-scanner-design.md
@@ -1,0 +1,194 @@
+# Onboarding scanner — design
+
+Date: 2026-04-28
+
+Status: Locked through brainstorming. Implementation plan to follow via `writing-plans`.
+
+Parent product spec: [`2026-04-27-idun-onboarding-ux-design.md`](./2026-04-27-idun-onboarding-ux-design.md). This document narrows scope to **sub-project A: the filesystem scanner** that the onboarding wizard consumes through an admin REST endpoint.
+
+## Scope
+
+The scanner is a pure-Python library that walks a folder, detects supported agents (LangGraph and Google ADK), and returns a structured result. It owns no IO beyond filesystem reads and never mutates the filesystem.
+
+In scope:
+- Detect LangGraph agents from `.py` source, from `langgraph.json`, and from an Idun `config.yaml`.
+- Detect Google ADK agents from `.py` source and from an Idun `config.yaml`.
+- Infer a human-friendly agent name.
+- Surface enough state for the API layer to classify the folder into the spec's five wizard states.
+
+Out of scope:
+- HTTP / API surface (sub-project B).
+- Wizard UI (sub-project C).
+- Detection of other frameworks (Haystack, CrewAI, Custom). The product spec locks LangGraph and ADK only.
+- Notebooks (`.ipynb`). Not parsed.
+- Auto-conversion of arbitrary code into agents (explicit non-goal in the parent spec).
+
+## Module location and public API
+
+Lives in `libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py`.
+
+Public surface:
+
+```python
+async def scan_folder(root: Path) -> ScanResult: ...
+```
+
+`scan_folder` is async because the parent spec wraps it in a 5-second `asyncio.wait_for` budget at the API layer; the function itself does not need true async IO, but the signature keeps the call site idiomatic.
+
+The result types live in `idun_agent_schema.standalone.onboarding` so both backend and UI consumers share the same shape:
+
+```python
+class DetectedAgent(_CamelModel):
+    framework: Literal["LANGGRAPH", "ADK"]
+    file_path: str           # POSIX-style relative path from scan root
+    variable_name: str       # top-level binding inside file_path
+    inferred_name: str
+    confidence: Literal["HIGH", "MEDIUM"]
+    source: Literal["config", "source", "langgraph_json"]
+
+
+class ScanResult(_CamelModel):
+    root: str                # absolute path of the scanned folder
+    detected: list[DetectedAgent]
+    has_python_files: bool   # at least one .py file under the walk
+    has_idun_config: bool    # at least one config.yaml with valid agent.type
+    scan_duration_ms: int
+```
+
+The five-state classification (EMPTY / NO_SUPPORTED / ONE_DETECTED / MANY_DETECTED / ALREADY_CONFIGURED) is **not** computed by the scanner. The API layer in sub-project B combines `ScanResult` with the standalone DB state (does an agent row already exist?) to derive the wizard state. This split keeps the scanner stateless and reusable from CLIs or tests.
+
+## Walk strategy
+
+`os.walk(root)` with a fixed skip list — no `.gitignore` parsing, no extra dependency.
+
+Skipped directory names (matched by basename):
+
+```
+.git, __pycache__, node_modules, .venv, venv, env, dist, build, target
+```
+
+Plus any directory whose basename starts with `.`.
+
+Depth limit: 4. The walk truncates at `len(rel_parts) > 4` to keep monorepo scans bounded.
+
+File filters:
+- Only `.py` files are parsed. `.ipynb` notebooks are ignored entirely.
+- Files larger than 1 MB are skipped (binary-ish, unlikely to be agent source).
+
+## Detection sources
+
+The scanner runs three detection paths and unions their results. A single file may surface in multiple paths (e.g. listed in `langgraph.json` and also imported as source); the scanner deduplicates on `(file_path, variable_name)` and keeps the entry with the highest confidence.
+
+### Path 1 — Idun `config.yaml`
+
+For each `config.yaml` / `config.yml` at depth 0–2 under the scan root:
+
+1. Parse with PyYAML inside a try/except. Any parse error: skip the file silently.
+2. Read `agent.type`. If the value is `"LANGGRAPH"` or `"ADK"`, continue. Other values are ignored.
+3. Read `agent.config.graph_definition` (LangGraph) or `agent.config.agent` (ADK). If absent or not in `path:variable` shape, skip.
+4. Emit a `DetectedAgent` with `confidence="HIGH"` and `source="config"`.
+5. Set `has_idun_config = True` on the overall result.
+
+### Path 2 — `langgraph.json`
+
+Only at depth 0 (scan root). The `langgraph.json` is a top-level project config, not a per-agent file.
+
+1. Parse with `json.load` inside a try/except.
+2. Read the `graphs` object. For each entry `key: value`:
+   - `value` must be in `path:variable` shape.
+   - Emit a `DetectedAgent` with `framework="LANGGRAPH"`, `confidence="HIGH"`, `source="langgraph_json"`.
+   - Use `key` as the `inferred_name` candidate at priority 2 in the inference cascade (see below).
+3. `has_idun_config` is **not** set by this path. `langgraph.json` is not an Idun config.
+
+### Path 3 — `.py` source
+
+For each `.py` file under the walk:
+
+1. **Regex pre-filter** on the file's text. Cheap reject if none of these patterns match:
+   - LangGraph: `(?m)^\s*(from\s+langgraph[\s.]|import\s+langgraph)`
+   - ADK: `(?m)^\s*(from\s+google\.adk|import\s+google\.adk)`
+2. If the regex matches, set `has_python_files = True` and continue. (`has_python_files` is also set by walking any `.py` file, regardless of imports — see below.)
+3. `ast.parse()` the file inside a try/except. SyntaxError or any parse failure: skip the file.
+4. Walk the module-level body. For each `Assign` or `AnnAssign` node where the LHS is a single `Name`:
+   - LangGraph match: RHS is a `Call` whose callable resolves (lexically) to `StateGraph(...)` or `<expr>.compile(...)` where the receiver is a `StateGraph` instance lexically traceable in the same file.
+   - ADK match: RHS is a `Call` whose callable name is one of `Agent`, `LlmAgent`, `SequentialAgent`, `ParallelAgent`, `LoopAgent` (the public ADK agent classes).
+5. Emit `DetectedAgent` with the framework, `confidence="MEDIUM"`, `source="source"`, `variable_name = LHS name`.
+
+The "lexically traceable" rule for `compile()` is best-effort: if `graph.compile()` is the assignment and `graph = StateGraph(...)` exists at module level above it, treat as a LangGraph agent. If we cannot trace the receiver, skip — better to miss a detection than to false-positive a generic `something.compile()` call.
+
+When both an intermediate `StateGraph(...)` binding and a downstream `.compile()` binding exist in the same file (e.g. `g = StateGraph(...)` then `graph = g.compile()`), the scanner emits **one** detection only, picking the compiled binding (`graph`) as `variable_name`. The compiled form is what `idun_agent_engine` ultimately runs, so the wizard pre-fills the right `graph_definition`.
+
+`has_python_files` separately: the walk sets this `True` for **any** `.py` file encountered, regardless of imports. This drives the spec's state-1 vs state-4 distinction (empty folder vs code-but-no-supported-agent).
+
+## Name inference cascade
+
+For each `DetectedAgent`, `inferred_name` is computed by the first matching rule:
+
+1. `source == "config"` and the YAML has `agent.config.name` → use it verbatim.
+2. `source == "langgraph_json"` → use the dict key (the graph name).
+3. `pyproject.toml` at scan root has `[project].name` → title-case it (`my-agent` → "My Agent", `my_agent` → "My Agent").
+4. The parent directory of `file_path` (skipping `src/` if present) → title-case it.
+5. The filename without extension, stripped of trailing `_agent` or leading `agent` → title-case.
+6. Fallback: `"My Agent"`.
+
+Rules 3–5 reuse the standalone `services.slugs.normalize_slug` lowercase + ASCII fold logic in reverse: the inferred name is humanized, the wizard later normalizes it back to a slug when writing the row.
+
+## Performance and safety
+
+- Total scan budget: 5 seconds, enforced by the **caller** via `asyncio.wait_for`. The scanner does not enforce this internally — it returns whatever it has when interrupted.
+- AST parse failures are non-fatal. The scanner logs at DEBUG level and continues. The spec's error surface is "fewer detections than possible", never an exception.
+- YAML and JSON parse failures are non-fatal in the same way.
+- `scan_duration_ms` is always populated, even on partial walks.
+- The scanner does not follow symlinks (`os.walk` default).
+
+## Testing
+
+Test file: `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`.
+
+Each test uses `pytest`'s `tmp_path` fixture to materialize a fake folder.
+
+Required test cases:
+
+| Case | Expected |
+|---|---|
+| Empty folder | `detected=[]`, `has_python_files=False`, `has_idun_config=False` |
+| Folder with one `dummy.py` containing a string only | `detected=[]`, `has_python_files=True` |
+| Minimal LangGraph: `agent.py` with `from langgraph.graph import StateGraph` + `graph = StateGraph(...).compile()` | 1 detection, `framework=LANGGRAPH`, `confidence=MEDIUM`, `source=source`, `variable_name=graph` |
+| Minimal ADK: `agent.py` with `from google.adk.agents import Agent` + `root_agent = Agent(...)` | 1 detection, `framework=ADK`, `confidence=MEDIUM` |
+| LangGraph but uncompiled: `graph = StateGraph(...)` direct | Detected (StateGraph constructor counts) |
+| LangGraph with intermediate var: `g = StateGraph(...); graph = g.compile()` | Detected, `variable_name=graph` (the compiled binding wins) |
+| Generic `something.compile()` with no traceable StateGraph receiver | Not detected (no false positive) |
+| ADK with `LlmAgent` instead of `Agent` | Detected |
+| `config.yaml` with valid LangGraph block | 1 detection, `confidence=HIGH`, `source=config`, `has_idun_config=True` |
+| `config.yaml` referencing the same file as `agent.py` source detection | 1 detection (HIGH confidence wins, dedup on `(file_path, variable_name)`) |
+| `langgraph.json` with two entries in `graphs` | 2 detections, both HIGH, both `source=langgraph_json` |
+| `langgraph.json` malformed JSON | Skip silently, no crash |
+| `config.yaml` malformed YAML | Skip silently |
+| `.py` file with `SyntaxError` | Skip silently, scan continues |
+| Directory tree with `.venv/` containing a fake graph | `.venv/` skipped, no detection from inside it |
+| Depth-5 nested file with a graph | Not detected (depth limit) |
+| `pyproject.toml` `[project].name = "my-bot"` + a graph in `agent.py:graph` | `inferred_name = "My Bot"` |
+| Same setup but no pyproject, parent dir is `chat_assistant/` | `inferred_name = "Chat Assistant"` |
+| Same setup but file is `chatbot_agent.py` | `inferred_name = "Chatbot"` (strip `_agent`) |
+| `langgraph.json` with `"graphs": {"helpdesk": "./agent.py:graph"}` | `inferred_name = "helpdesk"` (verbatim) |
+| `.ipynb` file with a graph definition | Ignored entirely |
+| 2 MB `.py` file with a graph | Skipped (size limit) |
+
+The scanner is pure Python — no fixture needs network, DB, or asyncio plumbing. Tests run in <1s in aggregate.
+
+## Implementation notes for the planner
+
+- Add `pyyaml` is already a dep of `idun-agent-standalone`. No new dep for YAML.
+- `tomllib` (stdlib in 3.12) for `pyproject.toml`. No new dep.
+- The regex pre-filter avoids parsing every `.py` in a repo as AST. For a repo of 5000 files where 5 import langgraph, the pre-filter rejects 4995 in microseconds.
+- The schema additions live in `idun_agent_schema/standalone/onboarding.py` with corresponding exports from `idun_agent_schema/standalone/__init__.py`.
+
+## Non-goals (recap)
+
+- No `.gitignore` parsing.
+- No detection of frameworks beyond LangGraph and ADK.
+- No parsing of `.ipynb`.
+- No auto-conversion of code.
+- No filesystem mutation.
+- No HTTP, no DB, no global state.
+- No five-state classification — that lives in sub-project B.

--- a/docs/superpowers/specs/2026-04-29-onboarding-http-api-design.md
+++ b/docs/superpowers/specs/2026-04-29-onboarding-http-api-design.md
@@ -1,0 +1,404 @@
+# Onboarding HTTP API Design
+
+> **Sub-project:** B (of A–E from `2026-04-27-idun-onboarding-ux-design.md`)
+> **Status:** Locked — ready for implementation plan
+> **Depends on:** Sub-project A (`2026-04-28-onboarding-scanner-design.md`, PR #538)
+> **Branch:** `feat/onboarding-scanner` (extending the same branch — no rebase, additive only)
+
+---
+
+## 1. Goal
+
+Build the HTTP layer that the onboarding wizard talks to. Three endpoints under `/admin/api/v1/onboarding/` that:
+
+1. Scan the user's project and classify it into one of 5 onboarding states.
+2. Materialize an agent from a detection picked by the user.
+3. Scaffold a fresh starter project (multi-file) when no detection is usable.
+
+The wizard UI is not in this spec (sub-project C). The `idun init` CLI is not in this spec (sub-project D), but the scaffolder is built here as a shared service that D will reuse.
+
+## 2. Why
+
+The standalone runtime today boots with no agent if the user hasn't placed a `config.yaml`. `GET /agent` returns 404, the chat UI has nothing to render, and the user is stuck. Sub-project A built a scanner that finds existing LangGraph/ADK agents and infers their wiring — this sub-project turns that scanner output into a wizard-driven flow that can either adopt an existing agent or scaffold a new one, all without leaving the browser.
+
+## 3. Out of scope
+
+- Wizard UI (Next.js pages, mockups, copy) — sub-project C
+- `idun init` CLI command — sub-project D (reuses the scaffolder built here)
+- Driver.js guided tour — sub-project E
+- `DELETE /agent` endpoint (called out as a future need; not implemented here)
+- Writing `config.yaml` to disk from materialize endpoints (DB is canonical)
+- Switching agents post-configuration (handled later via DELETE + re-wizard)
+- Trial-import / pre-flight validation of user code (we let reload do the validation)
+
+## 4. State machine
+
+The wizard's UI logic switches on a 5-state classification computed server-side. States are derived from `(scanner_output, agent_row_exists)`:
+
+| State | Condition | UI behavior |
+|---|---|---|
+| `EMPTY` | `not has_python_files` and `not has_idun_config` | Show "Start fresh" button → `create-starter` |
+| `NO_SUPPORTED` | `has_python_files` but `len(detected) == 0` | Show "We didn't find an agent — start fresh" → `create-starter` |
+| `ONE_DETECTED` | `len(detected) == 1` | Auto-suggest the one detection → `create-from-detection` |
+| `MANY_DETECTED` | `len(detected) >= 2` | List detections, let user pick → `create-from-detection` |
+| `ALREADY_CONFIGURED` | `StandaloneAgentRow` exists | UI never mounts the wizard — goes straight to chat |
+
+`ALREADY_CONFIGURED` is reachable from `/scan` only as a defensive case (race / direct curl). The UI side detects this earlier via `GET /agent` returning 200.
+
+### Why classification on the server
+
+- One round trip for the wizard (scan + state + current agent in a single payload)
+- One source of truth for state — server-side validation in materialize endpoints uses the same logic
+- Avoids leaking state-machine logic into TypeScript
+
+## 5. Endpoint contracts
+
+All endpoints sit under `/admin/api/v1/onboarding/`. All require auth via the existing `Depends(require_auth)` dependency (PR #537 strict-minimum auth).
+
+### 5.1 `POST /admin/api/v1/onboarding/scan`
+
+**Body:** none. **Response:** `ScanResponse`.
+
+Flow:
+1. Read `StandaloneAgentRow` (singleton, `id = "singleton"`).
+2. If row exists → return `{ state: "ALREADY_CONFIGURED", scanResult: <empty>, currentAgent: <row> }`. Skip scanner invocation.
+3. Otherwise call `scanner.scan_folder(Path.cwd())`.
+4. Classify per the table in §4.
+5. Return `{ state, scanResult, currentAgent: null }`.
+
+**Why `Path.cwd()`:** The user runs `idun standalone` from their project root. Using CWD decouples scan root from `settings.config_path` (which may live in `./idun-config/config.yaml` while the agent code is at `./`). Per Q1 in the brainstorm.
+
+### 5.2 `POST /admin/api/v1/onboarding/create-from-detection`
+
+**Body:** `CreateFromDetectionBody`. **Response:** `MutationResponse[AgentRead]`.
+
+Flow:
+1. **Pre-check:** if `StandaloneAgentRow` exists → `409 agent_already_configured`.
+2. Re-scan: `scanner.scan_folder(Path.cwd())`.
+3. Find the detection where `(framework, file_path, variable_name)` matches the body exactly.
+4. **If no match → `409 detection_not_found`** with `{ filePath, variableName }` echoed back. (TOCTOU: file changed between scan and click.)
+5. Build `EngineConfig` from the **server's** `DetectedAgent` (not the body):
+   - LangGraph: `agent.type = "langgraph"`, `agent.config.graph_path = "{file_path}:{variable_name}"`
+   - ADK: `agent.type = "adk"`, `agent.config.agent_path = "{file_path}:{variable_name}"`
+   - `memory`: omitted (engine default in-memory checkpoint)
+   - `observability`: omitted
+6. Insert `StandaloneAgentRow(id="singleton", name=detection.inferred_name, base_engine_config=...)`.
+7. Trigger reload via existing `reload_orchestrator`.
+8. Return `MutationResponse { data: AgentRead, reload: { status, ... } }`.
+
+**Why re-scan:** Q4 in the brainstorm. Scan is cheap (sub-100ms typical), and re-scanning gives free TOCTOU protection, prevents client tampering with `inferred_name`/`file_path`, and keeps the body small + stable.
+
+**Reload failure:** Row stays. UI shows the diagnostic; user fixes their code and PATCH /agent retries reload.
+
+### 5.3 `POST /admin/api/v1/onboarding/create-starter`
+
+**Body:** `CreateStarterBody`. **Response:** `MutationResponse[AgentRead]`.
+
+Flow:
+1. **Pre-check:** if `StandaloneAgentRow` exists → `409 agent_already_configured` (zero files written).
+2. Call `scaffold.create_starter_project(root=Path.cwd(), framework=body.framework)`. Scaffolder atomically writes 5 files (`agent.py`, `requirements.txt`, `.env.example`, `README.md`, `.gitignore`) or raises `ScaffoldConflictError` (zero files written). Router translates the exception to `409 scaffold_conflict` with `{ paths: [...] }`.
+3. Build `EngineConfig`:
+   - LangGraph: `agent.config.graph_path = "agent.py:graph"`
+   - ADK: `agent.config.agent_path = "agent.py:agent"`
+4. Insert row with `name = body.name or "Starter Agent"`.
+5. Trigger reload.
+6. Return envelope.
+
+**Reload failure:** Files + row both stay. User edits `agent.py`, PATCH /agent retries.
+
+## 6. Schema additions
+
+File: `libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py` (already exists from sub-project A).
+
+Add:
+
+```python
+from typing import Literal
+from pydantic import Field
+from idun_agent_schema._base import _CamelModel
+from idun_agent_schema.standalone.agent import AgentRead
+
+OnboardingState = Literal[
+    "EMPTY",
+    "NO_SUPPORTED",
+    "ONE_DETECTED",
+    "MANY_DETECTED",
+    "ALREADY_CONFIGURED",
+]
+
+class ScanResponse(_CamelModel):
+    state: OnboardingState
+    scan_result: ScanResult            # already defined in this module
+    current_agent: AgentRead | None = None
+
+class CreateFromDetectionBody(_CamelModel):
+    framework: Literal["LANGGRAPH", "ADK"]
+    file_path: str
+    variable_name: str
+
+class CreateStarterBody(_CamelModel):
+    framework: Literal["LANGGRAPH", "ADK"]
+    name: str | None = Field(default=None, min_length=1, max_length=80)
+```
+
+Existing exports kept: `DetectedAgent`, `ScanResult`. The materialize endpoints reuse the existing `MutationResponse` envelope from `idun_agent_schema.standalone.common`.
+
+## 7. Module layout
+
+```
+libs/idun_agent_standalone/src/idun_agent_standalone/
+├── services/
+│   ├── scanner.py              ← exists (PR #538)
+│   ├── scaffold.py             ← NEW
+│   └── onboarding.py           ← NEW
+├── api/v1/routers/
+│   └── onboarding.py           ← NEW
+└── api/v1/deps.py              ← exists (require_auth, reload_disabled)
+```
+
+Wiring: `app.py` adds `app.include_router(onboarding_router, dependencies=[Depends(require_auth)])`.
+
+### Why the split
+
+- `scaffold.py` is a pure side-effect module (template strings + atomic file writes). No DB, no FastAPI, no SQLAlchemy. Sub-project D's CLI imports it directly.
+- `onboarding.py` (service) owns the parts that touch DB + reload: state classification, building `EngineConfig` from a detection, calling `reload_orchestrator`. Stays out of the scaffolder so the scaffolder can be unit-tested without an event loop.
+- `routers/onboarding.py` is thin — body validation, dependency injection, calls services.
+
+## 8. Scaffolder (`services/scaffold.py`)
+
+### Public API
+
+```python
+class ScaffoldConflictError(Exception):
+    """Raised when target files already exist."""
+    def __init__(self, paths: list[Path]) -> None:
+        self.paths = paths
+        super().__init__(f"Scaffold conflict: {[str(p) for p in paths]}")
+
+def create_starter_project(
+    root: Path,
+    framework: Literal["LANGGRAPH", "ADK"],
+) -> list[Path]:
+    """Atomically write 5 starter files. Returns paths in write order."""
+```
+
+### File set (per framework)
+
+Both frameworks emit 5 files:
+
+| Path | LangGraph content | ADK content |
+|---|---|---|
+| `agent.py` | Hello-world `StateGraph` | Hello-world `Agent(...)` |
+| `requirements.txt` | `idun-agent-standalone`, `langgraph>=0.2.0`, `langchain-core>=0.3.0`, `langchain-openai>=0.2.0` | `idun-agent-standalone`, `google-adk>=0.1.0` |
+| `.env.example` | `OPENAI_API_KEY=` | `GOOGLE_API_KEY=` |
+| `README.md` | Identical 4-step quick-start (copy `.env.example`, install, run, edit) | Identical |
+| `.gitignore` | Identical: `.env`, `__pycache__/`, `*.pyc`, `.venv/`, `.idun/` | Identical |
+
+Templates are stored as module-level `Final[str]` constants — not as files in a `templates/` directory. Keeps the package self-contained and avoids `importlib.resources` ceremony.
+
+### Atomic write algorithm
+
+```python
+def create_starter_project(root, framework):
+    files = _build_file_map(root, framework)   # dict[Path, str]: 5 entries
+
+    conflicts = [p for p in files if p.exists()]
+    if conflicts:
+        raise ScaffoldConflictError(conflicts)
+
+    written: list[Path] = []
+    try:
+        for path, content in files.items():
+            tmp = path.with_suffix(path.suffix + ".idun-tmp")
+            tmp.write_text(content)
+            tmp.rename(path)              # atomic on POSIX
+            written.append(path)
+    except Exception:
+        for p in written:
+            p.unlink(missing_ok=True)
+        raise
+
+    return written
+```
+
+The conflict pre-check is the only thing that prevents partial writes in the happy path. The cleanup loop handles mid-write disk failures (full disk, permissions). Atomicity guarantee: if the function raises, the directory state is unchanged.
+
+### Generated `agent.py` shape (LangGraph)
+
+```python
+"""Minimal LangGraph hello-world agent."""
+from langgraph.graph import StateGraph, END
+from typing import TypedDict
+
+class State(TypedDict):
+    message: str
+
+def echo(state: State) -> State:
+    return {"message": f"You said: {state['message']}"}
+
+graph = StateGraph(State)
+graph.add_node("echo", echo)
+graph.set_entry_point("echo")
+graph.add_edge("echo", END)
+graph = graph.compile()
+```
+
+### Generated `agent.py` shape (ADK)
+
+```python
+"""Minimal Google ADK hello-world agent."""
+from google.adk.agents import Agent
+
+agent = Agent(
+    name="starter",
+    model="gemini-2.0-flash",
+    description="A minimal starter agent.",
+    instruction="You are a helpful assistant. Respond concisely.",
+)
+```
+
+Both files import the variable that the scanner will detect on next run (`graph` for LangGraph, `agent` for ADK), so a re-scan after starter creation would correctly classify the project as `ALREADY_CONFIGURED` (because the row exists by then) and otherwise `ONE_DETECTED`.
+
+## 9. Onboarding service (`services/onboarding.py`)
+
+### Public surface
+
+```python
+async def get_scan_response(
+    session: AsyncSession,
+    settings: StandaloneSettings,
+) -> ScanResponse: ...
+
+async def materialize_from_detection(
+    session: AsyncSession,
+    body: CreateFromDetectionBody,
+    settings: StandaloneSettings,
+    reload_orchestrator: ReloadOrchestrator,
+) -> MutationResponse[AgentRead]: ...
+
+async def materialize_starter(
+    session: AsyncSession,
+    body: CreateStarterBody,
+    settings: StandaloneSettings,
+    reload_orchestrator: ReloadOrchestrator,
+) -> MutationResponse[AgentRead]: ...
+```
+
+### Errors
+
+Service-layer exceptions (router translates to HTTP):
+
+```python
+class AgentAlreadyConfiguredError(Exception): ...
+class DetectionNotFoundError(Exception):
+    def __init__(self, file_path: str, variable_name: str) -> None: ...
+```
+
+Plus `ScaffoldConflictError` from `scaffold.py`.
+
+Router translation table:
+
+| Exception | HTTP | Body |
+|---|---|---|
+| `AgentAlreadyConfiguredError` | 409 | `{ "error": "agent_already_configured" }` |
+| `DetectionNotFoundError` | 409 | `{ "error": "detection_not_found", "filePath": ..., "variableName": ... }` |
+| `ScaffoldConflictError` | 409 | `{ "error": "scaffold_conflict", "paths": [...] }` |
+
+### State classification helper
+
+```python
+def classify_state(scan_result: ScanResult, agent_row_exists: bool) -> OnboardingState:
+    if agent_row_exists:
+        return "ALREADY_CONFIGURED"
+    if not scan_result.has_python_files:
+        return "EMPTY"
+    if not scan_result.detected:
+        return "NO_SUPPORTED"
+    if len(scan_result.detected) == 1:
+        return "ONE_DETECTED"
+    return "MANY_DETECTED"
+```
+
+`has_idun_config` from `ScanResult` is **not** a classification input — it's surfaced in the response for the UI to optionally show "we found a config.yaml" but doesn't change the state. (The `seed.py` boot path already handles config.yaml; if it had successfully seeded, an agent row would exist and state would be `ALREADY_CONFIGURED`. So `has_idun_config=true` + `agent_row_exists=false` only happens if the yaml is malformed — that's a different error class, surfaced via boot-time logs, not the wizard.)
+
+## 10. Concurrency + idempotency
+
+- `StandaloneAgentRow` has `id = "singleton"` as PRIMARY KEY. Two concurrent inserts: second one gets `IntegrityError`, translated to `409 agent_already_configured`. No application-level locking required.
+- `/scan` is read-only — safe to call concurrently.
+- `/create-starter` scaffolder is not safe under concurrent calls in the same CWD: two workers could both pass the conflict check, then both try to `rename` to the same path. Mitigation: `StandaloneAgentRow` insert serializes via the DB constraint, so even if file writes interleave, only one materialize succeeds. The losing call sees `IntegrityError` → 409 → cleanup runs (loser's files removed). Acceptable for MVP given uvicorn's default single-process posture for standalone.
+
+## 11. Auth + reload
+
+- All three endpoints carry `Depends(require_auth)` from `api/v1/deps.py`. Same gate as every other admin route.
+- `reload_orchestrator` is the existing dependency injected via `Depends(get_reload_orchestrator)`. Materialize endpoints call `await reload_orchestrator.reload()` and pass the returned `ReloadStatus` into the `MutationResponse` envelope.
+
+## 12. Testing strategy
+
+### Unit tests
+
+`tests/unit/services/test_scaffold.py` (~12 tests)
+- Writes 5 expected files (LangGraph)
+- Writes 5 expected files (ADK)
+- Returned paths are in deterministic write order
+- Raises `ScaffoldConflictError` listing all conflicting paths
+- Atomicity: zero files written on conflict
+- Cleanup: simulated `OSError` mid-write removes already-written files
+- Generated `agent.py` parses with `ast.parse` (LangGraph + ADK)
+- Generated `requirements.txt` has no garbage lines
+- `.env.example` contains the framework-appropriate API key variable
+- `.gitignore` covers `.env`
+
+`tests/unit/services/test_onboarding.py` (~10 tests)
+- `classify_state` returns each of the 5 states for the right inputs (5 tests)
+- `build_engine_config_from_detection` produces correct LangGraph config
+- `build_engine_config_from_detection` produces correct ADK config
+- Singleton row check raises `AgentAlreadyConfiguredError` before scan in `materialize_from_detection`
+- Singleton row check raises `AgentAlreadyConfiguredError` before scan in `materialize_starter`
+
+### Integration tests
+
+`tests/integration/api/v1/test_onboarding_flow.py` (~14 tests)
+
+`/scan` (5 tests):
+- EMPTY: empty tmp_path → state EMPTY
+- NO_SUPPORTED: tmp_path with non-agent .py file → state NO_SUPPORTED
+- ONE_DETECTED: tmp_path with one LangGraph agent → state ONE_DETECTED
+- MANY_DETECTED: tmp_path with two agents → state MANY_DETECTED
+- ALREADY_CONFIGURED: agent row pre-seeded → state + currentAgent populated
+
+`/create-from-detection` (4 tests):
+- Happy LangGraph: detect → materialize → reload triggered → 200 + envelope
+- Happy ADK: same
+- Stale detection: file deleted between scan and call → 409 detection_not_found
+- Already configured → 409 agent_already_configured
+
+`/create-starter` (5 tests):
+- Happy LangGraph: 5 files written, row created, reload status returned
+- Happy ADK: same
+- Conflict (e.g., `agent.py` already exists) → 409 scaffold_conflict, zero files written
+- Already configured → 409 agent_already_configured, zero files written
+- Reload failure surfaces in envelope (mock reload to fail), row + files persist
+
+### Test infrastructure
+
+- Async session fixture: existing pattern from `test_observability_flow.py`
+- `monkeypatch.chdir(tmp_path)` per test to isolate scan root
+- `tmp_path` fixtures for scaffolding tests — never touch the repo
+
+### What we're NOT testing here
+
+- Scanner internals (PR #538 — 39 tests)
+- Reload orchestrator (Wagon 1's tests)
+- Auth gate (PR #537's tests)
+- Pydantic body validation (FastAPI's job)
+
+## 13. Future work (deferred — not in this sub-project)
+
+- `DELETE /admin/api/v1/agent` — explicit "clear agent" path so the user can re-run the wizard without manual DB editing. Required if we want to support agent switching.
+- `idun init` CLI (sub-project D) — wraps `scaffold.create_starter_project` in a typer/click command, also writes a `config.yaml` (CLI is YAML-based, runtime is DB-based — they meet at first boot).
+- Wizard UI (sub-project C) — Next.js pages that consume these endpoints.
+- Driver.js guided tour (sub-project E) — post-wizard hand-off.
+
+## 14. Open questions
+
+None at time of locking. All architectural decisions pinned via the brainstorm Q1–Q11.

--- a/docs/superpowers/specs/2026-04-29-onboarding-http-api-design.md
+++ b/docs/superpowers/specs/2026-04-29-onboarding-http-api-design.md
@@ -60,7 +60,7 @@ All endpoints sit under `/admin/api/v1/onboarding/`. All require auth via the ex
 **Body:** none. **Response:** `ScanResponse`.
 
 Flow:
-1. Read `StandaloneAgentRow` (singleton, `id = "singleton"`).
+1. Read `StandaloneAgentRow` (singleton — at most one row, app-level invariant; see §10).
 2. If row exists → return `{ state: "ALREADY_CONFIGURED", scanResult: <empty>, currentAgent: <row> }`. Skip scanner invocation.
 3. Otherwise call `scanner.scan_folder(Path.cwd())`.
 4. Classify per the table in §4.
@@ -82,7 +82,7 @@ Flow:
    - ADK: `agent.type = "ADK"`, `agent.config.agent = "{file_path}:{variable_name}"`, `agent.config.name = inferred_name`
    - `memory`: omitted (engine default in-memory checkpoint)
    - `observability`: omitted
-6. Insert `StandaloneAgentRow(id="singleton", name=detection.inferred_name, base_engine_config=...)`.
+6. Insert `StandaloneAgentRow(name=detection.inferred_name, base_engine_config=...)` (id defaults to a fresh UUID; see §10).
 7. Trigger reload via existing `reload_orchestrator`.
 8. Return `MutationResponse { data: AgentRead, reload: { status, ... } }`.
 
@@ -323,9 +323,20 @@ def classify_state(scan_result: ScanResult, agent_row_exists: bool) -> Onboardin
 
 ## 10. Concurrency + idempotency
 
-- `StandaloneAgentRow` has `id = "singleton"` as PRIMARY KEY. Two concurrent inserts: second one gets `IntegrityError`, translated to `409 agent_already_configured`. No application-level locking required.
-- `/scan` is read-only — safe to call concurrently.
-- `/create-starter` scaffolder is not safe under concurrent calls in the same CWD: two workers could both pass the conflict check, then both try to `rename` to the same path. Mitigation: `StandaloneAgentRow` insert serializes via the DB constraint, so even if file writes interleave, only one materialize succeeds. The losing call sees `IntegrityError` → 409 → cleanup runs (loser's files removed). Acceptable for MVP given uvicorn's default single-process posture for standalone.
+`StandaloneAgentRow` is a singleton **by app-level invariant**, not a DB constraint. The row uses a UUID primary key (`String(36)`, default `_new_uuid`) — the same shape as every other admin row in the schema — so the database does not, on its own, prevent two rows from existing. The "first-agent-only" semantic is enforced by the materialize coroutines.
+
+Two-stage check in each materialize coroutine (`materialize_from_detection`, `materialize_starter`):
+
+1. **Outer pre-check** (cheap, before scan / scaffold): if a row already exists, raise `409 agent_already_configured` immediately. Avoids running the scanner or writing 5 files for a doomed request.
+2. **Inner re-check** (correctness, inside `services.reload._reload_mutex`): repeat the row lookup just before `session.add(row)`. The mutex is a process-wide `asyncio.Lock` that already serializes admin mutations through `commit_with_reload`; the re-check closes the TOCTOU window between the outer check and the insert.
+
+Concurrency posture per endpoint:
+
+- `/scan` is read-only — safe to call concurrently. Reads the agent row, runs the scanner (no DB write), classifies state. No mutex.
+- `/create-from-detection` and `/create-starter` serialize through `_reload_mutex`. Two concurrent calls: one wins, the other gets `409 agent_already_configured` from the inner re-check.
+- `/create-starter` scaffolder runs **before** the mutex (so disk IO doesn't span the lock). Two concurrent calls may both pass the outer pre-check and both write 5 files; the loser's files persist on disk because rolling back disk state from inside a mutex re-check is gnarly. Recovery: operator can move/delete the loser's files and re-run the wizard, or use `PATCH /agent` to redirect the existing agent at the new files. Acceptable for MVP given uvicorn's default single-process posture for standalone.
+
+**Why no DB constraint:** adding `id = "singleton"` as a fixed PK would diverge `StandaloneAgentRow` from every sibling resource (memory, observability, mcp_servers, etc., all UUID-keyed). The mutex pattern is shared with the rest of the admin surface, and the singleton invariant is enforced at exactly the layer that owns the lifecycle (the materialize coroutines), so the DB layer doesn't need to know anything about it.
 
 ## 11. Auth + reload
 

--- a/docs/superpowers/specs/2026-04-29-onboarding-http-api-design.md
+++ b/docs/superpowers/specs/2026-04-29-onboarding-http-api-design.md
@@ -78,8 +78,8 @@ Flow:
 3. Find the detection where `(framework, file_path, variable_name)` matches the body exactly.
 4. **If no match → `409 detection_not_found`** with `{ filePath, variableName }` echoed back. (TOCTOU: file changed between scan and click.)
 5. Build `EngineConfig` from the **server's** `DetectedAgent` (not the body):
-   - LangGraph: `agent.type = "langgraph"`, `agent.config.graph_path = "{file_path}:{variable_name}"`
-   - ADK: `agent.type = "adk"`, `agent.config.agent_path = "{file_path}:{variable_name}"`
+   - LangGraph: `agent.type = "LANGGRAPH"`, `agent.config.graph_definition = "{file_path}:{variable_name}"`, `agent.config.name = inferred_name`
+   - ADK: `agent.type = "ADK"`, `agent.config.agent = "{file_path}:{variable_name}"`, `agent.config.name = inferred_name`
    - `memory`: omitted (engine default in-memory checkpoint)
    - `observability`: omitted
 6. Insert `StandaloneAgentRow(id="singleton", name=detection.inferred_name, base_engine_config=...)`.
@@ -98,8 +98,8 @@ Flow:
 1. **Pre-check:** if `StandaloneAgentRow` exists → `409 agent_already_configured` (zero files written).
 2. Call `scaffold.create_starter_project(root=Path.cwd(), framework=body.framework)`. Scaffolder atomically writes 5 files (`agent.py`, `requirements.txt`, `.env.example`, `README.md`, `.gitignore`) or raises `ScaffoldConflictError` (zero files written). Router translates the exception to `409 scaffold_conflict` with `{ paths: [...] }`.
 3. Build `EngineConfig`:
-   - LangGraph: `agent.config.graph_path = "agent.py:graph"`
-   - ADK: `agent.config.agent_path = "agent.py:agent"`
+   - LangGraph: `agent.config.graph_definition = "agent.py:graph"`, `agent.config.name` = sanitized form of `body.name` or `"starter"`
+   - ADK: `agent.config.agent = "agent.py:agent"`, `agent.config.name` = sanitized form of `body.name` or `"starter"`
 4. Insert row with `name = body.name or "Starter Agent"`.
 5. Trigger reload.
 6. Return envelope.

--- a/docs/superpowers/specs/2026-04-29-onboarding-wizard-ui-design.md
+++ b/docs/superpowers/specs/2026-04-29-onboarding-wizard-ui-design.md
@@ -1,0 +1,401 @@
+# Onboarding Wizard UI Design
+
+> **Sub-project:** C (of A–E from `2026-04-27-idun-onboarding-ux-design.md`)
+> **Status:** Locked — ready for implementation plan
+> **Depends on:** Sub-project A (`2026-04-28-onboarding-scanner-design.md`, PR #538) and sub-project B (`2026-04-29-onboarding-http-api-design.md`, this branch)
+> **Branch:** `feat/onboarding-scanner` (extending the same branch — additive only)
+
+---
+
+## 1. Goal
+
+Build the Next.js wizard UI that consumes sub-project B's three onboarding endpoints. The wizard runs at `/onboarding`, drives the user through the 5-state classification, and lands them on chat with a working agent.
+
+In scope: the wizard pages, the chat-root redirect that triggers it, and the minimal `/login` page that makes password-mode work end-to-end.
+
+Out of scope: the `idun init` CLI (sub-project D), the Driver.js guided tour (sub-project E), the change-password UI, and any traces / logs / settings pages.
+
+## 2. Why
+
+Sub-project B shipped the HTTP layer the wizard needs. Without a UI consumer, the endpoints are unreachable from the browser. The standalone runtime today drops users on `/` with no agent and nothing rendered — this sub-project makes that path successful by guiding the user from "I just ran `idun-standalone`" to "my agent works in the chat UI."
+
+## 3. Out of scope
+
+- `idun init` CLI scaffolder (sub-project D)
+- Driver.js post-wizard guided tour (sub-project E)
+- Change-password UI (deferred — backend exists, no admin route consumes it yet)
+- Logout button (lands with future settings work)
+- Theme picker (uses runtime-config theme as-is)
+- Active LLM-readiness probe (honor-system reminder text on the done screen — see §4 Q4)
+
+## 4. Locked decisions
+
+These came from brainstorming questions Q1–Q12 and are the foundation for everything below.
+
+| # | Decision |
+|---|----------|
+| 1 | `/onboarding` dedicated route; chat root redirects on `GET /agent` 404 |
+| 2 | Single-page, state-driven wizard (no per-step routes) |
+| 3 | MANY_DETECTED uses radio list + separate confirm CTA |
+| 4 | LLM readiness: final confirmation screen with honor-system .env reminder; no active probe |
+| 5 | Reload-failure: full diagnostic + retry button |
+| 6 | Chat root calls `GET /agent`; 404 → `router.replace('/onboarding')` |
+| 7 | Password mode → standard `/login` redirect (no auth carveout for onboarding) |
+| 8 | Land minimal `/login` UI (form + `?next=` redirect) as part of this sub-project |
+| 9 | EMPTY/NO_SUPPORTED: 2 screens (framework picker → name + file-preview confirm) |
+| 10 | ONE/MANY_DETECTED: 1 screen each (no second confirm — DB-only writes) |
+| 11 | "Re-scan" button on every wizard screen except final Done/error |
+| 12 | Bare wizard layout, no chat chrome, themed via runtime config |
+
+## 5. State machine
+
+The wizard is one component holding a step enum and dispatches on it:
+
+```typescript
+type WizardStep =
+  | { kind: "scanning" }
+  | { kind: "scan-result"; data: ScanResponse }
+  | { kind: "starter-confirm"; framework: Framework; name: string }
+  | { kind: "materializing" }
+  | { kind: "done"; agent: AgentRead; framework: Framework; mode: "starter" | "detection" }
+  | { kind: "error"; message: string; retry: () => void };
+```
+
+Transitions:
+
+```
+scanning ──(scan ok, ALREADY_CONFIGURED)──► router.replace('/')
+        ──(scan ok, any other state)──► scan-result
+        ──(scan 401)──► /login redirect via apiFetch's existing 401 handling
+
+scan-result (EMPTY | NO_SUPPORTED) ──(framework picked)──► starter-confirm
+scan-result (ONE_DETECTED | MANY_DETECTED) ──(detection picked)──► materializing
+scan-result (any) ──(rescan clicked)──► scanning
+
+starter-confirm ──(confirm clicked)──► materializing
+starter-confirm ──(back clicked)──► scan-result (cached scan reused)
+
+materializing ──(2xx)──► done
+            ──(409)──► scan-result (toast surfaces the conflict reason)
+            ──(500 reload_failed)──► error
+            ──(other)──► error
+
+error ──(retry clicked)──► materializing (re-runs same call)
+done ──(go-to-chat clicked)──► router.push('/')
+```
+
+The tagged union ensures each screen renders only with the data it needs — TypeScript narrows on `kind`.
+
+`mode` on the `done` step is set by the materialize call site so the LLM-readiness reminder picks the right copy: starter mode knows the framework's expected env var name; detection mode falls back to a generic reminder because we don't know which keys the user's code requires.
+
+## 6. Module layout
+
+```
+services/idun_agent_standalone_ui/
+├── app/
+│   ├── page.tsx                          MODIFY: add GET /agent gate; 404 → router.replace('/onboarding')
+│   ├── login/page.tsx                    REWRITE: minimal form + ?next= redirect
+│   └── onboarding/
+│       ├── layout.tsx                    NEW: bare themed shell (logo + step content)
+│       └── page.tsx                      NEW: wizard state machine
+├── components/
+│   └── onboarding/
+│       ├── WizardScanning.tsx            NEW: initial scan loading
+│       ├── WizardEmpty.tsx               NEW: EMPTY → framework picker (screen 1 of starter flow)
+│       ├── WizardNoSupported.tsx         NEW: NO_SUPPORTED → framework picker
+│       ├── WizardOneDetected.tsx         NEW: ONE_DETECTED → single-card confirm
+│       ├── WizardManyDetected.tsx        NEW: MANY_DETECTED → radio list
+│       ├── WizardStarterConfirm.tsx      NEW: screen 2 of starter flow
+│       ├── WizardMaterializing.tsx       NEW: loading state during create-* call
+│       ├── WizardDone.tsx                NEW: success + .env reminder + Go to chat
+│       └── WizardError.tsx               NEW: reload failure + retry
+└── lib/api/
+    ├── index.ts                          MODIFY: add scan, createFromDetection, createStarter
+    └── types/
+        └── onboarding.ts                 NEW: wire types
+```
+
+### Why the split
+
+- The wizard page owns the state machine; each screen is a presentational component that takes props (the relevant slice of the step plus callbacks). Screens don't reach back into the parent for state.
+- `WizardEmpty` and `WizardNoSupported` are separate components even though their forms are similar — the framing copy is different and putting both behind a single conditional adds branching where presentational simplicity matters more.
+- The 2-screen starter flow puts the file-preview confirmation in its own component (`WizardStarterConfirm`) so the picker components stay focused.
+
+## 7. API client additions
+
+New file `lib/api/types/onboarding.ts`:
+
+```typescript
+import type { AgentRead } from "./agent";
+
+export type OnboardingState =
+  | "EMPTY"
+  | "NO_SUPPORTED"
+  | "ONE_DETECTED"
+  | "MANY_DETECTED"
+  | "ALREADY_CONFIGURED";
+
+export type Framework = "LANGGRAPH" | "ADK";
+export type DetectionConfidence = "HIGH" | "MEDIUM";
+export type DetectionSource = "config" | "source" | "langgraph_json";
+
+export interface DetectedAgent {
+  framework: Framework;
+  filePath: string;
+  variableName: string;
+  inferredName: string;
+  confidence: DetectionConfidence;
+  source: DetectionSource;
+}
+
+export interface ScanResult {
+  root: string;
+  detected: DetectedAgent[];
+  hasPythonFiles: boolean;
+  hasIdunConfig: boolean;
+  scanDurationMs: number;
+}
+
+export interface ScanResponse {
+  state: OnboardingState;
+  scanResult: ScanResult;
+  currentAgent: AgentRead | null;
+}
+
+export interface CreateFromDetectionBody {
+  framework: Framework;
+  filePath: string;
+  variableName: string;
+}
+
+export interface CreateStarterBody {
+  framework: Framework;
+  name?: string;
+}
+```
+
+Add three methods to `lib/api/index.ts`:
+
+```typescript
+scan: () =>
+  apiFetch<ScanResponse>(`${ADMIN}/onboarding/scan`, {
+    method: "POST",
+  }),
+createFromDetection: (body: CreateFromDetectionBody) =>
+  apiFetch<MutationResponse<AgentRead>>(
+    `${ADMIN}/onboarding/create-from-detection`,
+    { method: "POST", body: j(body) },
+  ),
+createStarter: (body: CreateStarterBody) =>
+  apiFetch<MutationResponse<AgentRead>>(`${ADMIN}/onboarding/create-starter`, {
+    method: "POST",
+    body: j(body),
+  }),
+```
+
+Re-export the new types from `lib/api/index.ts`'s `export * from "./types"` chain (or add an explicit `export * from "./types/onboarding"` if the existing chain doesn't cover it).
+
+## 8. Per-screen UX
+
+All screens share a centered Card on a themed background. Idun logo top-left of the page (in the wizard layout). "Re-scan" link in the card footer except where noted.
+
+### `WizardScanning`
+Card with `Skeleton` rows + caption "Scanning your project…". Mounted while `api.scan()` is in flight via TanStack Query.
+
+### `WizardEmpty` (state: EMPTY)
+- Title: "Let's create your first Idun agent"
+- Body: "We didn't find any Python files in this folder. Pick a framework and we'll scaffold a starter for you."
+- Form: shadcn `RadioGroup` with two card-styled radios (LangGraph with "Recommended" badge, ADK)
+- Footer: "Continue" (primary, disabled until selection) advances to `starter-confirm`. "Re-scan" link.
+
+### `WizardNoSupported` (state: NO_SUPPORTED)
+- Title: "We found Python code, but no supported agent"
+- Body: "Idun supports LangGraph and Google ADK. Pick one to scaffold a starter alongside your existing code, or re-scan if you just added an agent."
+- Form: same `RadioGroup` shape as WizardEmpty
+- Footer: same as WizardEmpty
+
+### `WizardOneDetected` (state: ONE_DETECTED)
+- Title: "Found your agent"
+- Body: "We detected one agent in this folder."
+- Detection card: framework badge, inferred name (large), `filePath:variableName` (mono, smaller), confidence pill if MEDIUM (HIGH stays quiet)
+- Footer: "Use this agent" (primary) → `materializing`. "Re-scan" link.
+
+### `WizardManyDetected` (state: MANY_DETECTED)
+- Title: "Pick your agent"
+- Body: "We found {N} agents in this folder. Choose one — Idun runs one agent per install."
+- Form: `RadioGroup` with one row per detection. Each row: framework badge, inferred name, `filePath:variableName` (mono), MEDIUM-confidence pill if applicable.
+- Sort: `confidence` desc → `framework` (LANGGRAPH first) → `inferredName` asc.
+- Footer: "Use selected agent" (primary, disabled until selection) → `materializing`. "Re-scan" link.
+
+### `WizardStarterConfirm` (starter flow screen 2)
+- Title: "Confirm your starter"
+- Body: "We'll create the following files in your project:"
+- File list: `agent.py`, `requirements.txt`, `.env.example`, `README.md`, `.gitignore`. Each row has a small `lucide-react` File icon and a mono name.
+- Form: `Input` for agent name (optional, placeholder "Starter Agent"). Validation: 1-80 chars if provided.
+- Footer: "Create starter" (primary) → `materializing`. "Back" link → returns to `scan-result`. "Re-scan" link.
+
+### `WizardMaterializing`
+Card with `Skeleton` + caption "Creating your agent…". Re-scan link hidden during the call to prevent stale clicks. Typical duration: 1-3s (DB write + reload pipeline).
+
+### `WizardDone`
+- Title: `"{agentName} is ready"`
+- Body: two-row readout — Framework (badge), Source (`baseEngineConfig.agent.config.{graph_definition|agent}` mono).
+- Reload status: small line "Reload: reloaded" (or "restart_required" with a hint about restart).
+- `Alert` (warn-tone) — env reminder text varies by mode:
+  - **starter + LANGGRAPH:** "Set `OPENAI_API_KEY` in your environment before chatting. Copy `.env.example` to `.env` and fill it in, then restart `idun-standalone`."
+  - **starter + ADK:** same with `GOOGLE_API_KEY`.
+  - **detection (any framework):** "Make sure your agent's environment variables are set before chatting."
+- Footer: "Go to chat" (primary) → `router.push('/')`.
+
+### `WizardError`
+- Title: "Something went wrong"
+- `Alert` (destructive-tone): echoes `error.message` verbatim. If `error.code === "reload_failed"`, append: "Edit your `agent.py` to fix the issue, then click Retry."
+- Footer: "Retry" (primary) re-runs the same materialize call. "Back to wizard" link returns to `scan-result`.
+
+### Re-scan behavior
+
+The "Re-scan" link invalidates the `["onboarding-scan"]` TanStack Query key. The wizard page sees the query reset to loading state and re-mounts `WizardScanning`. Any user input on the previous screen (a picked detection, a typed name) is discarded — a re-scan is a hard refresh.
+
+## 9. Login page
+
+Single page, single form. Same bare themed shell as the wizard.
+
+- Title: "Sign in"
+- Body: "Enter the admin password to manage this Idun deployment."
+- Form (react-hook-form + zod):
+  - `password: z.string().min(1, "Required")`
+  - Submit calls `api.login(password)`.
+  - Success → `router.replace(searchParams.get('next') ?? '/')`.
+  - 401 → `toast.error("Wrong password")`, clear field. No detail leak — backend already collapses bad-password and missing-row to the same 401 (per anti-enumeration design).
+  - Network/other error → generic toast.
+- Footer: "Sign in" button (primary, full-width).
+
+The shared `apiFetch` wrapper at `lib/api/client.ts` already redirects to `/login` on 401 and includes `?next=` carrying the originally-requested path. No new logic needed in the wizard page itself; the redirect just happens.
+
+## 10. Routing flow
+
+```
+User runs idun-standalone, browser hits /
+└─ app/page.tsx mounts
+   └─ calls api.getAgent()
+      ├─ 200 → render existing chat layouts (BrandedLayout / MinimalLayout / InspectorLayout per runtime config)
+      ├─ 404 → router.replace('/onboarding')
+      └─ 401 → apiFetch redirects to /login?next=%2F (then loops back here)
+
+/onboarding mounts
+└─ app/onboarding/page.tsx mounts
+   └─ TanStack Query fires api.scan()
+      ├─ 200, state ALREADY_CONFIGURED → router.replace('/')
+      ├─ 200, other state → render screen
+      └─ 401 → apiFetch redirects to /login?next=%2Fonboarding
+
+/login mounts
+└─ user submits password
+   └─ api.login(password)
+      ├─ 200 → router.replace(?next ?? '/')
+      └─ 401 → toast + retry
+```
+
+Auth is handled identically to every other admin route: the dependency in `apiFetch` redirects on 401, no per-page logic.
+
+## 11. Theming
+
+The wizard layout (`app/onboarding/layout.tsx`) wraps the page in the same `ThemeLoader`-driven shell that the chat root already uses for runtime-config-driven CSS variables. No theme-mutation UI in this sub-project — the wizard inherits whatever the runtime-config bootstrap provides.
+
+The bare layout means: no sidebar, no top-bar nav, no chat-related chrome. Just the logo, the centered card, and the themed background. Login uses the same shell.
+
+## 12. Concurrency and edge cases
+
+### Re-scan after partial materialize
+
+Not reachable in the happy path because the wizard transitions to `materializing` (which hides re-scan). If a user manages to trigger a re-scan after a successful materialize (e.g., browser back from `done`), the next scan returns ALREADY_CONFIGURED and the wizard auto-redirects to `/`. Handled.
+
+### Already-configured race
+
+Two browser tabs run the wizard concurrently:
+1. Both call `/scan` → both see EMPTY.
+2. Tab A picks a starter, advances to `materializing`, succeeds.
+3. Tab B is still on the picker, picks LangGraph, advances to `materializing`, fails with 409 conflict.
+4. Per the state machine, 409 routes Tab B back to `scan-result` (with a toast).
+5. The next `/scan` (on tab B's automatic re-mount or manual click) returns ALREADY_CONFIGURED → tab B redirects to `/`.
+
+Acceptable. The backend's two-stage check (outer pre-check + inner mutex re-check from sub-project B's T6 fix) prevents both inserts from succeeding.
+
+### Reload failure recovery
+
+`/create-starter` writes 5 files BEFORE the reload step. If reload fails, the files persist but the agent row is rolled back (per spec §5.3 of sub-project B). The wizard's error screen shows the diagnostic; on Retry, the materialize call re-runs:
+- For starter: the scaffolder pre-check sees existing files and returns 409 `scaffold_conflict` → wizard goes back to scan-result. The user must manually reconcile (delete or edit the partial files) before re-trying.
+- For detection: the materialize is idempotent against re-scan, so Retry just runs again. If the underlying issue (e.g., import error in `agent.py`) is unfixed, it'll fail the same way.
+
+The `WizardError` screen's "Back to wizard" link is the escape hatch for both cases.
+
+### Browser refresh mid-wizard
+
+The user refreshes during `starter-confirm` (after picking a framework, before clicking Create). The page re-mounts, re-scans, and lands on whatever state the project is in now. The user's framework pick is lost; they re-pick. Acceptable for a 30-second flow.
+
+## 13. Testing strategy
+
+### Unit tests (Vitest + React Testing Library)
+
+`__tests__/lib/api/onboarding.test.ts` (~6 tests):
+- `api.scan()` calls the right endpoint with no body.
+- `api.createFromDetection` and `api.createStarter` post typed bodies, parse `MutationResponse<AgentRead>`.
+- 401 from any onboarding endpoint triggers the existing `/login` redirect (smoke test against the shared client wrapper).
+- 409 envelope parses to `ApiError` with the right code.
+- 500 reload_failed envelope parses to `ApiError` with `code: "reload_failed"`.
+
+`__tests__/components/onboarding/Wizard*.test.tsx` (~16 tests across 9 components):
+- Each picker-style screen: renders options, "Continue/Use" disabled until selection, fires the right callback with the selected value.
+- Confidence pill rules: HIGH hides, MEDIUM shows.
+- Sort order in MANY_DETECTED.
+- File-preview list in StarterConfirm matches the 5 expected files.
+- Done screen: framework-correct env reminder for starter mode; generic reminder for detection mode.
+- Error screen: reload_failed appends recovery hint; other errors don't.
+
+`__tests__/app/login.test.tsx` (~4 tests):
+- Renders form; submit calls `api.login` with the typed password.
+- Success → redirects to `?next=` (default `/`).
+- 401 → toast.error fires, field cleared.
+- Empty submit shows validation error, doesn't call API.
+
+`__tests__/app/page-redirect.test.tsx` (~2 tests):
+- 200 from `getAgent` → renders chat layout (smoke).
+- 404 from `getAgent` → calls `router.replace('/onboarding')`.
+
+Total unit tests: ~28.
+
+### E2E tests (Playwright)
+
+`e2e/onboarding.spec.ts` — 7 flows:
+1. Empty project → user picks LangGraph → confirms scaffold → done shows OPENAI_API_KEY reminder.
+2. One detection → user clicks "Use this" → done shows generic env reminder.
+3. Many detections → user picks the second → confirms → done.
+4. Already configured → wizard auto-redirects to `/`.
+5. Reload failure → error screen with diagnostic + Retry → second attempt 200 → done.
+6. Re-scan: EMPTY → user clicks Re-scan → backend returns ONE_DETECTED → screen flips.
+7. Login redirect (password mode): `/onboarding` 401 → `/login` → submit → back to `/onboarding`.
+
+### Test infrastructure
+
+- Component tests: standard `render(<Wizard... />)` with mocked props. No router needed; the parent owns transitions.
+- Page-redirect test: mock `next/navigation`'s `useRouter`, assert on `router.replace` calls.
+- E2E: route mocking via Playwright (matches existing `e2e/` pattern).
+- Reuse the existing `vitest.config.ts` and `playwright.config.ts` — no new config.
+
+### Out of scope for this layer's tests
+
+- Backend behavior (sub-project B's 47 tests cover it).
+- TanStack Query internals (trust the library).
+- Theme application (existing `ThemeLoader` covers it).
+- Chat flow post-wizard (chat already works; no regression risk introduced here).
+
+## 14. Future work (deferred)
+
+- Driver.js post-wizard guided tour (sub-project E) — kicks off after the user clicks "Go to chat" once.
+- Logout button + change-password UI — settings work, separate sub-project.
+- Active LLM-readiness probe — would replace the honor-system reminder on Done with a real "we tested your key" check. Needs a new backend endpoint.
+- Theme picker on login — currently inherits runtime-config theme.
+
+## 15. Open questions
+
+None at time of locking.

--- a/libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py
@@ -58,6 +58,10 @@ from .observability import (  # noqa: F401
     StandaloneObservabilityPatch,
     StandaloneObservabilityRead,
 )
+from .onboarding import (  # noqa: F401
+    DetectedAgent,
+    ScanResult,
+)
 from .prompts import (  # noqa: F401
     StandalonePromptCreate,
     StandalonePromptPatch,

--- a/libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/standalone/__init__.py
@@ -59,7 +59,11 @@ from .observability import (  # noqa: F401
     StandaloneObservabilityRead,
 )
 from .onboarding import (  # noqa: F401
+    CreateFromDetectionBody,
+    CreateStarterBody,
     DetectedAgent,
+    OnboardingState,
+    ScanResponse,
     ScanResult,
 )
 from .prompts import (  # noqa: F401

--- a/libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py
@@ -1,0 +1,35 @@
+"""Wire schema for the onboarding scanner.
+
+These models are shared by the standalone backend (which produces them)
+and the standalone UI (which consumes them through the onboarding API).
+The five-state wizard classification is *not* in this schema — it is
+derived at the API layer by combining a ``ScanResult`` with the DB
+state of the singleton agent row.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ._base import _CamelModel
+
+
+class DetectedAgent(_CamelModel):
+    """One agent the scanner found in the target folder."""
+
+    framework: Literal["LANGGRAPH", "ADK"]
+    file_path: str
+    variable_name: str
+    inferred_name: str
+    confidence: Literal["HIGH", "MEDIUM"]
+    source: Literal["config", "source", "langgraph_json"]
+
+
+class ScanResult(_CamelModel):
+    """Aggregate result of a single ``scan_folder`` call."""
+
+    root: str
+    detected: list[DetectedAgent]
+    has_python_files: bool
+    has_idun_config: bool
+    scan_duration_ms: int

--- a/libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/standalone/onboarding.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 from typing import Literal
 
+from pydantic import Field
+
 from ._base import _CamelModel
+from .agent import StandaloneAgentRead
 
 
 class DetectedAgent(_CamelModel):
@@ -33,3 +36,50 @@ class ScanResult(_CamelModel):
     has_python_files: bool
     has_idun_config: bool
     scan_duration_ms: int
+
+
+OnboardingState = Literal[
+    "EMPTY",
+    "NO_SUPPORTED",
+    "ONE_DETECTED",
+    "MANY_DETECTED",
+    "ALREADY_CONFIGURED",
+]
+
+
+class ScanResponse(_CamelModel):
+    """Response for ``POST /admin/api/v1/onboarding/scan``.
+
+    The five-state classification is computed server-side from the
+    scan result plus the agent row's existence. ``current_agent`` is
+    only populated when ``state == "ALREADY_CONFIGURED"``.
+    """
+
+    state: OnboardingState
+    scan_result: ScanResult
+    current_agent: StandaloneAgentRead | None = None
+
+
+class CreateFromDetectionBody(_CamelModel):
+    """Body for ``POST /admin/api/v1/onboarding/create-from-detection``.
+
+    The triple ``(framework, file_path, variable_name)`` is the lookup
+    key for re-validation against a fresh scan inside the handler.
+    ``inferred_name`` is intentionally not on the wire — the server
+    computes it from the fresh scan, not from the body.
+    """
+
+    framework: Literal["LANGGRAPH", "ADK"]
+    file_path: str
+    variable_name: str
+
+
+class CreateStarterBody(_CamelModel):
+    """Body for ``POST /admin/api/v1/onboarding/create-starter``.
+
+    ``name`` is optional. When omitted the server uses
+    ``"Starter Agent"``. Empty string is rejected.
+    """
+
+    framework: Literal["LANGGRAPH", "ADK"]
+    name: str | None = Field(default=None, min_length=1, max_length=80)

--- a/libs/idun_agent_schema/tests/standalone/test_observability.py
+++ b/libs/idun_agent_schema/tests/standalone/test_observability.py
@@ -3,13 +3,8 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from uuid import uuid4
-
-import pytest
-from pydantic import ValidationError
 
 from idun_agent_schema.standalone import (
-    StandaloneObservabilityCreate,
     StandaloneObservabilityPatch,
     StandaloneObservabilityRead,
 )
@@ -28,14 +23,8 @@ def _sample_observability() -> dict:
 
 
 def test_observability_read_round_trip() -> None:
-    rid = uuid4()
     payload = {
-        "id": str(rid),
-        "slug": "langfuse",
-        "name": "Langfuse",
-        "enabled": True,
         "observability": _sample_observability(),
-        "createdAt": datetime.now(UTC).isoformat(),
         "updatedAt": datetime.now(UTC).isoformat(),
     }
     parsed = StandaloneObservabilityRead.model_validate(payload)
@@ -43,15 +32,26 @@ def test_observability_read_round_trip() -> None:
     reparsed = StandaloneObservabilityRead.model_validate(dumped)
     assert reparsed == parsed
     assert "observability" in dumped
+    assert "updatedAt" in dumped
 
 
-def test_observability_create_default_enabled_true() -> None:
-    payload = {"name": "Langfuse", "observability": _sample_observability()}
-    parsed = StandaloneObservabilityCreate.model_validate(payload)
-    assert parsed.enabled is True
+def test_observability_read_snake_case_inbound() -> None:
+    payload = {
+        "observability": _sample_observability(),
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    parsed = StandaloneObservabilityRead.model_validate(payload)
+    assert parsed.observability.provider.value == "LANGFUSE"
 
 
-def test_observability_patch_explicit_null_name_rejects() -> None:
-    with pytest.raises(ValidationError) as exc_info:
-        StandaloneObservabilityPatch.model_validate({"name": None})
-    assert "name cannot be null" in str(exc_info.value)
+def test_observability_patch_accepts_partial() -> None:
+    patch = StandaloneObservabilityPatch.model_validate(
+        {"observability": _sample_observability()}
+    )
+    assert patch.observability is not None
+    assert patch.observability.provider.value == "LANGFUSE"
+
+
+def test_observability_patch_accepts_empty() -> None:
+    patch = StandaloneObservabilityPatch.model_validate({})
+    assert patch.observability is None

--- a/libs/idun_agent_schema/tests/standalone/test_onboarding.py
+++ b/libs/idun_agent_schema/tests/standalone/test_onboarding.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from idun_agent_schema.standalone import DetectedAgent, ScanResult
+from idun_agent_schema.standalone import (
+    CreateFromDetectionBody,
+    CreateStarterBody,
+    DetectedAgent,
+    ScanResponse,
+    ScanResult,
+)
 
 
 def test_detected_agent_camelcase_roundtrip() -> None:
@@ -57,3 +63,84 @@ def test_detected_agent_rejects_unknown_framework() -> None:
             confidence="HIGH",
             source="config",
         )
+
+
+def test_scan_response_camel_case_serialization() -> None:
+    response = ScanResponse(
+        state="EMPTY",
+        scan_result=ScanResult(
+            root="/tmp/foo",
+            detected=[],
+            has_python_files=False,
+            has_idun_config=False,
+            scan_duration_ms=12,
+        ),
+        current_agent=None,
+    )
+    dumped = response.model_dump(by_alias=True)
+    assert dumped["state"] == "EMPTY"
+    assert dumped["scanResult"]["hasPythonFiles"] is False
+    assert dumped["currentAgent"] is None
+
+
+def test_scan_response_already_configured_carries_current_agent() -> None:
+    """When state == ALREADY_CONFIGURED the UI needs the current agent payload."""
+    response = ScanResponse.model_validate(
+        {
+            "state": "ALREADY_CONFIGURED",
+            "scanResult": {
+                "root": "/tmp/foo",
+                "detected": [],
+                "hasPythonFiles": True,
+                "hasIdunConfig": False,
+                "scanDurationMs": 0,
+            },
+            "currentAgent": None,
+        }
+    )
+    assert response.state == "ALREADY_CONFIGURED"
+
+
+def test_create_from_detection_body_accepts_camel_case() -> None:
+    body = CreateFromDetectionBody.model_validate(
+        {
+            "framework": "LANGGRAPH",
+            "filePath": "agent.py",
+            "variableName": "graph",
+        }
+    )
+    assert body.file_path == "agent.py"
+    assert body.variable_name == "graph"
+
+
+def test_create_from_detection_body_rejects_unknown_framework() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateFromDetectionBody(
+            framework="HAYSTACK",  # type: ignore[arg-type]
+            file_path="agent.py",
+            variable_name="graph",
+        )
+
+
+def test_create_starter_body_default_name_is_none() -> None:
+    body = CreateStarterBody(framework="LANGGRAPH")
+    assert body.name is None
+
+
+def test_create_starter_body_rejects_empty_name() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateStarterBody(framework="LANGGRAPH", name="")
+
+
+def test_create_starter_body_rejects_overlong_name() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateStarterBody(framework="LANGGRAPH", name="x" * 81)

--- a/libs/idun_agent_schema/tests/standalone/test_onboarding.py
+++ b/libs/idun_agent_schema/tests/standalone/test_onboarding.py
@@ -1,0 +1,59 @@
+"""Wire-shape tests for the onboarding schema."""
+
+from __future__ import annotations
+
+from idun_agent_schema.standalone import DetectedAgent, ScanResult
+
+
+def test_detected_agent_camelcase_roundtrip() -> None:
+    """Snake-case input + camelCase output by default."""
+    agent = DetectedAgent(
+        framework="LANGGRAPH",
+        file_path="agent.py",
+        variable_name="graph",
+        inferred_name="My Agent",
+        confidence="HIGH",
+        source="config",
+    )
+    dumped = agent.model_dump(by_alias=True)
+    assert dumped == {
+        "framework": "LANGGRAPH",
+        "filePath": "agent.py",
+        "variableName": "graph",
+        "inferredName": "My Agent",
+        "confidence": "HIGH",
+        "source": "config",
+    }
+
+
+def test_scan_result_camelcase_roundtrip() -> None:
+    result = ScanResult(
+        root="/tmp/x",
+        detected=[],
+        has_python_files=False,
+        has_idun_config=False,
+        scan_duration_ms=42,
+    )
+    dumped = result.model_dump(by_alias=True)
+    assert dumped == {
+        "root": "/tmp/x",
+        "detected": [],
+        "hasPythonFiles": False,
+        "hasIdunConfig": False,
+        "scanDurationMs": 42,
+    }
+
+
+def test_detected_agent_rejects_unknown_framework() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        DetectedAgent(
+            framework="HAYSTACK",
+            file_path="x.py",
+            variable_name="x",
+            inferred_name="X",
+            confidence="HIGH",
+            source="config",
+        )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py
@@ -26,7 +26,6 @@ from idun_agent_schema.standalone import (
     CreateFromDetectionBody,
     CreateStarterBody,
     ScanResponse,
-    ScanResult,
     StandaloneAgentRead,
     StandaloneMutationResponse,
 )
@@ -60,29 +59,30 @@ def _scan_root(request: Request) -> Path:
 async def scan(request: Request, session: SessionDep) -> ScanResponse:
     """Classify the project and return the scanner result.
 
-    When an agent row already exists the scanner walk is skipped — the
-    UI shouldn't be calling ``/scan`` in that state, and surfacing the
-    existing agent helps direct-curl callers.
+    Always runs the scanner so the response carries truthful
+    ``has_python_files`` / ``has_idun_config`` / ``detected`` values
+    even when an agent row already exists — useful for direct-curl
+    callers inspecting state. When the row exists, ``current_agent``
+    is populated so the UI can short-circuit to chat without a
+    follow-up ``GET /agent`` call.
     """
     row = (await session.execute(select(StandaloneAgentRow))).scalar_one_or_none()
     agent_row_exists = row is not None
-    current_agent: StandaloneAgentRead | None = None
 
-    if agent_row_exists:
-        scan_result = ScanResult(
-            root=str(_scan_root(request)),
-            detected=[],
-            has_python_files=False,
-            has_idun_config=False,
-            scan_duration_ms=0,
-        )
-        current_agent = StandaloneAgentRead.model_validate(row)
-    else:
-        scan_result = await scanner.scan_folder(_scan_root(request))
-
+    scan_result = await scanner.scan_folder(_scan_root(request))
     state = onboarding.classify_state(
         scan_result, agent_row_exists=agent_row_exists
     )
+
+    current_agent: StandaloneAgentRead | None = (
+        StandaloneAgentRead.model_validate(row) if row is not None else None
+    )
+
+    # Coupling invariant: current_agent is populated iff state is
+    # ALREADY_CONFIGURED. Tripping this means classify_state and the
+    # row-presence branch have diverged.
+    assert current_agent is None or state == "ALREADY_CONFIGURED"
+
     logger.info(
         "admin.onboarding.scan state=%s detections=%d duration_ms=%d",
         state,

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py
@@ -70,9 +70,7 @@ async def scan(request: Request, session: SessionDep) -> ScanResponse:
     agent_row_exists = row is not None
 
     scan_result = await scanner.scan_folder(_scan_root(request))
-    state = onboarding.classify_state(
-        scan_result, agent_row_exists=agent_row_exists
-    )
+    state = onboarding.classify_state(scan_result, agent_row_exists=agent_row_exists)
 
     current_agent: StandaloneAgentRead | None = (
         StandaloneAgentRead.model_validate(row) if row is not None else None

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/onboarding.py
@@ -1,0 +1,132 @@
+"""``/admin/api/v1/onboarding`` router.
+
+Three endpoints:
+
+  - ``POST /scan``: classify the user's project + return scanner output.
+  - ``POST /create-from-detection``: materialize an agent the user picked.
+  - ``POST /create-starter``: scaffold a fresh starter project.
+
+Materialize endpoints flow through the same ``commit_with_reload``
+pipeline as ``/admin/api/v1/agent``. Failure modes:
+
+  - 409 ``conflict`` when an agent row already exists.
+  - 409 ``conflict`` when a re-scan can no longer find the picked detection.
+  - 409 ``conflict`` when a scaffold target file already exists.
+
+Auth is wired at ``app.include_router`` level via the shared
+``admin_auth`` dependency in ``app.py``, not per-endpoint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from idun_agent_schema.standalone import (
+    CreateFromDetectionBody,
+    CreateStarterBody,
+    ScanResponse,
+    ScanResult,
+    StandaloneAgentRead,
+    StandaloneMutationResponse,
+)
+from sqlalchemy import select
+
+from idun_agent_standalone.api.v1.deps import ReloadCallableDep, SessionDep
+from idun_agent_standalone.core.logging import get_logger
+from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.services import onboarding, scanner
+
+router = APIRouter(prefix="/admin/api/v1/onboarding", tags=["admin"])
+
+logger = get_logger(__name__)
+
+
+def _scan_root(request: Request) -> Path:
+    """Resolve the scan / scaffold root.
+
+    Default: ``Path.cwd()``. Tests override via
+    ``app.state.onboarding_scan_root`` so the integration suite can
+    isolate per-test ``tmp_path`` directories without leaking ``chdir``
+    across asyncio tasks.
+    """
+    override = getattr(request.app.state, "onboarding_scan_root", None)
+    if override is not None:
+        return Path(override)
+    return Path.cwd()
+
+
+@router.post("/scan", response_model=ScanResponse)
+async def scan(request: Request, session: SessionDep) -> ScanResponse:
+    """Classify the project and return the scanner result.
+
+    When an agent row already exists the scanner walk is skipped — the
+    UI shouldn't be calling ``/scan`` in that state, and surfacing the
+    existing agent helps direct-curl callers.
+    """
+    row = (await session.execute(select(StandaloneAgentRow))).scalar_one_or_none()
+    agent_row_exists = row is not None
+    current_agent: StandaloneAgentRead | None = None
+
+    if agent_row_exists:
+        scan_result = ScanResult(
+            root=str(_scan_root(request)),
+            detected=[],
+            has_python_files=False,
+            has_idun_config=False,
+            scan_duration_ms=0,
+        )
+        current_agent = StandaloneAgentRead.model_validate(row)
+    else:
+        scan_result = await scanner.scan_folder(_scan_root(request))
+
+    state = onboarding.classify_state(
+        scan_result, agent_row_exists=agent_row_exists
+    )
+    logger.info(
+        "admin.onboarding.scan state=%s detections=%d duration_ms=%d",
+        state,
+        len(scan_result.detected),
+        scan_result.scan_duration_ms,
+    )
+    return ScanResponse(
+        state=state, scan_result=scan_result, current_agent=current_agent
+    )
+
+
+@router.post(
+    "/create-from-detection",
+    response_model=StandaloneMutationResponse[StandaloneAgentRead],
+)
+async def create_from_detection(
+    body: CreateFromDetectionBody,
+    request: Request,
+    session: SessionDep,
+    reload_callable: ReloadCallableDep,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    """Materialize a detection picked by the wizard."""
+    return await onboarding.materialize_from_detection(
+        session,
+        body,
+        scan_root=_scan_root(request),
+        reload_callable=reload_callable,
+    )
+
+
+@router.post(
+    "/create-starter",
+    response_model=StandaloneMutationResponse[StandaloneAgentRead],
+)
+async def create_starter(
+    body: CreateStarterBody,
+    request: Request,
+    session: SessionDep,
+    reload_callable: ReloadCallableDep,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    """Scaffold a starter project + register the singleton agent row."""
+    return await onboarding.materialize_starter(
+        session,
+        body,
+        scaffold_root=_scan_root(request),
+        reload_callable=reload_callable,
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -38,6 +38,9 @@ from idun_agent_standalone.api.v1.routers.memory import router as memory_router
 from idun_agent_standalone.api.v1.routers.observability import (
     router as observability_router,
 )
+from idun_agent_standalone.api.v1.routers.onboarding import (
+    router as onboarding_router,
+)
 from idun_agent_standalone.api.v1.routers.prompts import (
     router as prompts_router,
 )
@@ -136,6 +139,7 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
     app.include_router(guardrails_router, dependencies=admin_auth)
     app.include_router(prompts_router, dependencies=admin_auth)
     app.include_router(integrations_router, dependencies=admin_auth)
+    app.include_router(onboarding_router, dependencies=admin_auth)
     app.include_router(runtime_config_router)
 
     ui_dir = _resolve_ui_dir(settings)

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
@@ -235,9 +235,11 @@ async def materialize_starter(
 
     On any pre-check failure (existing agent, scaffold conflict) nothing
     is written to disk and no row is inserted. After a successful
-    scaffold + row insert, reload failures leave both the files and the
-    row in place; the user's recovery path is to edit ``agent.py`` and
-    re-trigger reload via ``PATCH /agent``.
+    scaffold + row insert, a reload failure rolls back the DB row but
+    leaves the scaffolded files on disk (per spec §5.3 — disk state is
+    independent of DB rollback). Recovery: edit ``agent.py`` and
+    re-trigger the wizard, which will re-create the row pointing at
+    the existing files.
     """
     if await _agent_row(session) is not None:
         raise _conflict(

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
@@ -15,13 +15,38 @@ Task 6 alongside the corresponding HTTP integration tests.
 from __future__ import annotations
 
 import re
+from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any, Literal
 
+from fastapi import status as http_status
+from idun_agent_schema.engine.engine import EngineConfig
 from idun_agent_schema.standalone import (
+    CreateFromDetectionBody,
+    CreateStarterBody,
     DetectedAgent,
     OnboardingState,
     ScanResult,
+    StandaloneAdminError,
+    StandaloneAgentRead,
+    StandaloneErrorCode,
+    StandaloneMutationResponse,
 )
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from idun_agent_standalone.api.v1.errors import AdminAPIError
+from idun_agent_standalone.core.logging import get_logger
+from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.services import reload as reload_service
+from idun_agent_standalone.services import scaffold, scanner
+from idun_agent_standalone.services.reload import commit_with_reload
+
+logger = get_logger(__name__)
+
+ReloadCallable = Callable[[EngineConfig], Awaitable[None]]
+
+_STARTER_DEFAULT_NAME = "Starter Agent"
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
@@ -113,3 +138,130 @@ def engine_config_dict_for_starter(
         "server": {"api": {"port": 8000}},
         "agent": agent_block,
     }
+
+
+async def _agent_row(session: AsyncSession) -> StandaloneAgentRow | None:
+    """Return the singleton agent row, or None if absent."""
+    return (await session.execute(select(StandaloneAgentRow))).scalar_one_or_none()
+
+
+def _conflict(message: str) -> AdminAPIError:
+    """Build a 409 admin error envelope."""
+    return AdminAPIError(
+        status_code=http_status.HTTP_409_CONFLICT,
+        error=StandaloneAdminError(
+            code=StandaloneErrorCode.CONFLICT,
+            message=message,
+        ),
+    )
+
+
+async def materialize_from_detection(
+    session: AsyncSession,
+    body: CreateFromDetectionBody,
+    *,
+    scan_root: Path,
+    reload_callable: ReloadCallable,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    """Materialize a detection picked by the wizard.
+
+    Re-scans inside the handler so the detection's ``inferred_name`` and
+    confidence come from the authoritative server-side scan, not from
+    anything the client could tamper with. The triple
+    ``(framework, file_path, variable_name)`` is the lookup key. If the
+    file moved between the original scan and this call, returns 409 so
+    the wizard can re-scan.
+    """
+    if await _agent_row(session) is not None:
+        raise _conflict("Agent already configured.")
+
+    scan_result = await scanner.scan_folder(scan_root)
+    match: DetectedAgent | None = None
+    for detection in scan_result.detected:
+        if (
+            detection.framework == body.framework
+            and detection.file_path == body.file_path
+            and detection.variable_name == body.variable_name
+        ):
+            match = detection
+            break
+    if match is None:
+        raise _conflict(
+            f"Detection not found: {body.framework} "
+            f"{body.file_path}:{body.variable_name}. "
+            "The project may have changed — re-run the scan."
+        )
+
+    config_dict = engine_config_dict_from_detection(match)
+    row = StandaloneAgentRow(
+        name=match.inferred_name,
+        base_engine_config=config_dict,
+    )
+
+    async with reload_service._reload_mutex:
+        session.add(row)
+        await session.flush()
+        result = await commit_with_reload(session, reload_callable=reload_callable)
+        await session.refresh(row)
+
+    logger.info(
+        "admin.onboarding.create_from_detection framework=%s name=%s status=%s",
+        match.framework,
+        match.inferred_name,
+        result.status.value,
+    )
+    return StandaloneMutationResponse(
+        data=StandaloneAgentRead.model_validate(row),
+        reload=result,
+    )
+
+
+async def materialize_starter(
+    session: AsyncSession,
+    body: CreateStarterBody,
+    *,
+    scaffold_root: Path,
+    reload_callable: ReloadCallable,
+) -> StandaloneMutationResponse[StandaloneAgentRead]:
+    """Scaffold a starter project + insert the singleton agent row.
+
+    On any pre-check failure (existing agent, scaffold conflict) nothing
+    is written to disk and no row is inserted. After a successful
+    scaffold + row insert, reload failures leave both the files and the
+    row in place; the user's recovery path is to edit ``agent.py`` and
+    re-trigger reload via ``PATCH /agent``.
+    """
+    if await _agent_row(session) is not None:
+        raise _conflict("Agent already configured.")
+
+    name = body.name or _STARTER_DEFAULT_NAME
+
+    try:
+        written = scaffold.create_starter_project(
+            scaffold_root, framework=body.framework
+        )
+    except scaffold.ScaffoldConflictError as exc:
+        names = ", ".join(p.name for p in exc.paths)
+        raise _conflict(
+            f"Scaffold target exists: {names}. Move or delete and retry."
+        ) from exc
+
+    config_dict = engine_config_dict_for_starter(framework=body.framework, name=name)
+    row = StandaloneAgentRow(name=name, base_engine_config=config_dict)
+
+    async with reload_service._reload_mutex:
+        session.add(row)
+        await session.flush()
+        result = await commit_with_reload(session, reload_callable=reload_callable)
+        await session.refresh(row)
+
+    logger.info(
+        "admin.onboarding.create_starter framework=%s files=%d status=%s",
+        body.framework,
+        len(written),
+        result.status.value,
+    )
+    return StandaloneMutationResponse(
+        data=StandaloneAgentRead.model_validate(row),
+        reload=result,
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
@@ -173,7 +173,9 @@ async def materialize_from_detection(
     the wizard can re-scan.
     """
     if await _agent_row(session) is not None:
-        raise _conflict("Agent already configured.")
+        raise _conflict(
+            "Agent already configured. Use PATCH /admin/api/v1/agent to update it."
+        )
 
     scan_result = await scanner.scan_folder(scan_root)
     match: DetectedAgent | None = None
@@ -199,6 +201,12 @@ async def materialize_from_detection(
     )
 
     async with reload_service._reload_mutex:
+        # Re-check inside the mutex to close the TOCTOU window between the
+        # initial pre-check and the row insert.
+        if await _agent_row(session) is not None:
+            raise _conflict(
+                "Agent already configured. Use PATCH /admin/api/v1/agent to update it."
+            )
         session.add(row)
         await session.flush()
         result = await commit_with_reload(session, reload_callable=reload_callable)
@@ -232,7 +240,9 @@ async def materialize_starter(
     re-trigger reload via ``PATCH /agent``.
     """
     if await _agent_row(session) is not None:
-        raise _conflict("Agent already configured.")
+        raise _conflict(
+            "Agent already configured. Use PATCH /admin/api/v1/agent to update it."
+        )
 
     name = body.name or _STARTER_DEFAULT_NAME
 
@@ -250,6 +260,13 @@ async def materialize_starter(
     row = StandaloneAgentRow(name=name, base_engine_config=config_dict)
 
     async with reload_service._reload_mutex:
+        # Re-check inside the mutex to close the TOCTOU window. If a concurrent
+        # request already inserted the row, the scaffolded files stay on disk —
+        # the user can move them or DELETE the agent and re-run the wizard.
+        if await _agent_row(session) is not None:
+            raise _conflict(
+                "Agent already configured. Use PATCH /admin/api/v1/agent to update it."
+            )
         session.add(row)
         await session.flush()
         result = await commit_with_reload(session, reload_callable=reload_callable)

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
@@ -1,0 +1,110 @@
+"""Onboarding service: state classification + EngineConfig assembly.
+
+This module is the orchestration layer between the ``/onboarding/*``
+HTTP endpoints, the scanner (read-only), and the scaffolder
+(side-effecting). It owns:
+
+  - The 5-state classification rule.
+  - Building an ``EngineConfig`` dict from a ``DetectedAgent``.
+  - Building an ``EngineConfig`` dict for a starter scaffold.
+
+The two materialize coroutines (DB insert + reload pipeline) land in
+Task 6 alongside the corresponding HTTP integration tests.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+
+from idun_agent_schema.standalone import (
+    DetectedAgent,
+    OnboardingState,
+    ScanResult,
+)
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(name: str) -> str:
+    """Return a slug suitable for ``agent.config.name``.
+
+    The engine's ADK validator derives ``app_name`` from ``name`` by
+    lower-casing and replacing non-alphanumerics with ``_``, so we run
+    the same transformation up-front to keep the value stable across
+    re-validations and avoid surprising round-trip differences.
+    Falls back to ``"agent"`` when the input slugifies to empty.
+    """
+    slug = _SLUG_RE.sub("_", name.lower()).strip("_")
+    return slug or "agent"
+
+
+def classify_state(
+    scan_result: ScanResult,
+    *,
+    agent_row_exists: bool,
+) -> OnboardingState:
+    """Compute the wizard's 5-state classification."""
+    if agent_row_exists:
+        return "ALREADY_CONFIGURED"
+    if not scan_result.has_python_files:
+        return "EMPTY"
+    if not scan_result.detected:
+        return "NO_SUPPORTED"
+    if len(scan_result.detected) == 1:
+        return "ONE_DETECTED"
+    return "MANY_DETECTED"
+
+
+def engine_config_dict_from_detection(detection: DetectedAgent) -> dict[str, Any]:
+    """Build the ``base_engine_config`` dict from a detected agent."""
+    name_slug = _slugify(detection.inferred_name)
+    if detection.framework == "LANGGRAPH":
+        agent_block: dict[str, Any] = {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": name_slug,
+                "graph_definition": f"{detection.file_path}:{detection.variable_name}",
+            },
+        }
+    else:
+        agent_block = {
+            "type": "ADK",
+            "config": {
+                "name": name_slug,
+                "agent": f"{detection.file_path}:{detection.variable_name}",
+            },
+        }
+    return {
+        "server": {"api": {"port": 8000}},
+        "agent": agent_block,
+    }
+
+
+def engine_config_dict_for_starter(
+    *,
+    framework: Literal["LANGGRAPH", "ADK"],
+    name: str,
+) -> dict[str, Any]:
+    """Build the ``base_engine_config`` dict for a starter scaffold."""
+    name_slug = _slugify(name)
+    if framework == "LANGGRAPH":
+        agent_block: dict[str, Any] = {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": name_slug,
+                "graph_definition": "agent.py:graph",
+            },
+        }
+    else:
+        agent_block = {
+            "type": "ADK",
+            "config": {
+                "name": name_slug,
+                "agent": "agent.py:agent",
+            },
+        }
+    return {
+        "server": {"api": {"port": 8000}},
+        "agent": agent_block,
+    }

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/onboarding.py
@@ -29,10 +29,15 @@ _SLUG_RE = re.compile(r"[^a-z0-9]+")
 def _slugify(name: str) -> str:
     """Return a slug suitable for ``agent.config.name``.
 
-    The engine's ADK validator derives ``app_name`` from ``name`` by
-    lower-casing and replacing non-alphanumerics with ``_``, so we run
-    the same transformation up-front to keep the value stable across
-    re-validations and avoid surprising round-trip differences.
+    Mirrors the engine's ADK validator (``AdkAgentConfig._default_app_name_from_name``)
+    so that ``_slugify(x)`` is a fixed point of the engine rule and revalidation is
+    idempotent.
+
+    Non-ASCII characters are stripped (e.g. ``"café"`` → ``"caf"``), matching the
+    engine validator's ASCII-only ``[^a-z0-9]+`` pattern. This is a deliberate
+    non-fold — do NOT add NFKD normalization here, or the standalone slug will
+    diverge from what the engine derives at validation time.
+
     Falls back to ``"agent"`` when the input slugifies to empty.
     """
     slug = _SLUG_RE.sub("_", name.lower()).strip("_")

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py
@@ -63,6 +63,29 @@ langchain-openai>=0.2.0
 _LANGGRAPH_ENV_EXAMPLE: Final[str] = "OPENAI_API_KEY=\n"
 
 
+_ADK_AGENT_PY: Final[str] = '''\
+"""Minimal Google ADK hello-world agent."""
+
+from google.adk.agents import Agent
+
+agent = Agent(
+    name="starter",
+    model="gemini-2.0-flash",
+    description="A minimal starter agent.",
+    instruction="You are a helpful assistant. Respond concisely.",
+)
+'''
+
+
+_ADK_REQUIREMENTS: Final[str] = """\
+idun-agent-standalone
+google-adk>=0.1.0
+"""
+
+
+_ADK_ENV_EXAMPLE: Final[str] = "GOOGLE_API_KEY=\n"
+
+
 _README: Final[str] = """\
 # My Idun Agent
 
@@ -93,9 +116,12 @@ def _build_file_map(
         agent_py = _LANGGRAPH_AGENT_PY
         requirements = _LANGGRAPH_REQUIREMENTS
         env_example = _LANGGRAPH_ENV_EXAMPLE
-    else:
-        # ADK templates land in Task 3.
-        raise NotImplementedError(f"Framework not yet supported: {framework}")
+    elif framework == "ADK":
+        agent_py = _ADK_AGENT_PY
+        requirements = _ADK_REQUIREMENTS
+        env_example = _ADK_ENV_EXAMPLE
+    else:  # pragma: no cover — Literal exhausts at type-check time
+        raise ValueError(f"Unknown framework: {framework}")
     return {
         root / "agent.py": agent_py,
         root / "requirements.txt": requirements,

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py
@@ -70,7 +70,7 @@ from google.adk.agents import Agent
 
 agent = Agent(
     name="starter",
-    model="gemini-2.0-flash",
+    model="gemini-2.5-flash",
     description="A minimal starter agent.",
     instruction="You are a helpful assistant. Respond concisely.",
 )
@@ -79,7 +79,7 @@ agent = Agent(
 
 _ADK_REQUIREMENTS: Final[str] = """\
 idun-agent-standalone
-google-adk>=0.1.0
+google-adk>=1.19.0,<2.0.0
 """
 
 
@@ -93,7 +93,7 @@ Quick start:
 
 1. Copy `.env.example` to `.env` and fill in your API key.
 2. `pip install -r requirements.txt`
-3. `idun standalone`
+3. `idun-standalone`
 
 Edit `agent.py` to customize the agent.
 """

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py
@@ -1,0 +1,137 @@
+"""Starter project scaffolder.
+
+Pure-IO module: emits a fixed set of files into a target directory.
+No DB, no FastAPI, no event loop. Imported by the onboarding HTTP
+endpoint and (later) by sub-project D's ``idun init`` CLI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final, Literal
+
+from idun_agent_standalone.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ScaffoldConflictError(Exception):
+    """Raised when one or more target files already exist.
+
+    Holds ``paths`` so the router can echo them back to the UI for a
+    human-readable conflict message. The scaffolder writes nothing
+    when it raises this, so the user can resolve manually and retry.
+    """
+
+    def __init__(self, paths: list[Path]) -> None:
+        self.paths = paths
+        super().__init__(f"Scaffold conflict: {[str(p) for p in paths]}")
+
+
+_LANGGRAPH_AGENT_PY: Final[str] = '''\
+"""Minimal LangGraph hello-world agent."""
+
+from typing import TypedDict
+
+from langgraph.graph import END, StateGraph
+
+
+class State(TypedDict):
+    message: str
+
+
+def echo(state: State) -> State:
+    return {"message": f"You said: {state['message']}"}
+
+
+_builder = StateGraph(State)
+_builder.add_node("echo", echo)
+_builder.set_entry_point("echo")
+_builder.add_edge("echo", END)
+graph = _builder.compile()
+'''
+
+
+_LANGGRAPH_REQUIREMENTS: Final[str] = """\
+idun-agent-standalone
+langgraph>=0.2.0
+langchain-core>=0.3.0
+langchain-openai>=0.2.0
+"""
+
+
+_LANGGRAPH_ENV_EXAMPLE: Final[str] = "OPENAI_API_KEY=\n"
+
+
+_README: Final[str] = """\
+# My Idun Agent
+
+Quick start:
+
+1. Copy `.env.example` to `.env` and fill in your API key.
+2. `pip install -r requirements.txt`
+3. `idun standalone`
+
+Edit `agent.py` to customize the agent.
+"""
+
+
+_GITIGNORE: Final[str] = """\
+.env
+__pycache__/
+*.pyc
+.venv/
+.idun/
+"""
+
+
+def _build_file_map(
+    root: Path,
+    framework: Literal["LANGGRAPH", "ADK"],
+) -> dict[Path, str]:
+    if framework == "LANGGRAPH":
+        agent_py = _LANGGRAPH_AGENT_PY
+        requirements = _LANGGRAPH_REQUIREMENTS
+        env_example = _LANGGRAPH_ENV_EXAMPLE
+    else:
+        # ADK templates land in Task 3.
+        raise NotImplementedError(f"Framework not yet supported: {framework}")
+    return {
+        root / "agent.py": agent_py,
+        root / "requirements.txt": requirements,
+        root / ".env.example": env_example,
+        root / "README.md": _README,
+        root / ".gitignore": _GITIGNORE,
+    }
+
+
+def create_starter_project(
+    root: Path,
+    framework: Literal["LANGGRAPH", "ADK"],
+) -> list[Path]:
+    """Atomically write the 5-file starter into ``root``.
+
+    Either all files land or none do. On any mid-write IO failure we
+    remove anything we managed to create so the user's working
+    directory is untouched.
+    """
+    files = _build_file_map(root, framework)
+    conflicts = [p for p in files if p.exists()]
+    if conflicts:
+        logger.info("scaffold.conflict count=%d", len(conflicts))
+        raise ScaffoldConflictError(conflicts)
+
+    written: list[Path] = []
+    try:
+        for path, content in files.items():
+            tmp = path.with_suffix(path.suffix + ".idun-tmp")
+            tmp.write_text(content)
+            tmp.replace(path)
+            written.append(path)
+    except Exception:
+        for p in written:
+            p.unlink(missing_ok=True)
+        raise
+
+    logger.info("scaffold.written framework=%s count=%d", framework, len(written))
+    return written

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scaffold.py
@@ -148,13 +148,17 @@ def create_starter_project(
         raise ScaffoldConflictError(conflicts)
 
     written: list[Path] = []
+    current_tmp: Path | None = None
     try:
         for path, content in files.items():
-            tmp = path.with_suffix(path.suffix + ".idun-tmp")
-            tmp.write_text(content)
-            tmp.replace(path)
+            current_tmp = path.with_suffix(path.suffix + ".idun-tmp")
+            current_tmp.write_text(content)
+            current_tmp.replace(path)
+            current_tmp = None
             written.append(path)
     except Exception:
+        if current_tmp is not None:
+            current_tmp.unlink(missing_ok=True)
         for p in written:
             p.unlink(missing_ok=True)
         raise

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -366,20 +366,44 @@ def _iter_idun_config_paths(root: Path, *, max_depth: int):
                 yield path
 
 
+_CONFIDENCE_ORDER = {"HIGH": 2, "MEDIUM": 1}
+
+
+def _dedup(detections: list[DetectedAgent]) -> list[DetectedAgent]:
+    """Collapse entries sharing ``(file_path, variable_name)`` to the highest-confidence one.
+
+    Insertion order is preserved for the surviving entry. Ties on
+    confidence keep the first occurrence (i.e. the order
+    ``_detect_in_idun_config`` → ``_detect_in_langgraph_json`` →
+    ``_detect_in_source`` in ``scan_folder`` defines preference).
+    """
+    by_key: dict[tuple[str, str], DetectedAgent] = {}
+    for d in detections:
+        key = (d.file_path, d.variable_name)
+        existing = by_key.get(key)
+        if existing is None:
+            by_key[key] = d
+            continue
+        if _CONFIDENCE_ORDER[d.confidence] > _CONFIDENCE_ORDER[existing.confidence]:
+            by_key[key] = d
+    return list(by_key.values())
+
+
 async def scan_folder(root: Path) -> ScanResult:
     """Walk ``root`` and return a ``ScanResult``."""
     started = time.monotonic()
     has_python_files = False
-    detected: list[DetectedAgent] = []
+    raw: list[DetectedAgent] = []
 
     config_detections, has_idun_config = _detect_in_idun_config(root)
-    detected.extend(config_detections)
-    detected.extend(_detect_in_langgraph_json(root))
+    raw.extend(config_detections)
+    raw.extend(_detect_in_langgraph_json(root))
 
     for rel, abs_path in _walk(root):
         has_python_files = True
-        detected.extend(_detect_in_source(rel, abs_path))
+        raw.extend(_detect_in_source(rel, abs_path))
 
+    detected = _dedup(raw)
     duration_ms = int((time.monotonic() - started) * 1000)
     return ScanResult(
         root=str(root),

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -13,6 +13,7 @@ stdlib + pydantic + pyyaml. The five-state wizard classification is
 from __future__ import annotations
 
 import ast
+import json
 import os
 import re
 import time
@@ -243,11 +244,53 @@ def _receiver_name(call: ast.AST) -> set[str]:
     return set()
 
 
+def _detect_in_langgraph_json(root: Path) -> list[DetectedAgent]:
+    """Parse ``<root>/langgraph.json`` and emit one detection per graphs entry."""
+    path = root / "langgraph.json"
+    if not path.is_file():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        logger.debug("scanner: skip langgraph.json, parse error")
+        return []
+    if not isinstance(data, dict):
+        return []
+    graphs = data.get("graphs")
+    if not isinstance(graphs, dict):
+        return []
+
+    out: list[DetectedAgent] = []
+    for key, value in graphs.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        if ":" not in value:
+            continue
+        file_part, _, variable = value.partition(":")
+        # Strip leading "./" so the wire shape stays normalized.
+        rel = file_part.removeprefix("./").lstrip("/")
+        if not rel or not variable:
+            continue
+        out.append(
+            DetectedAgent(
+                framework="LANGGRAPH",
+                file_path=rel,
+                variable_name=variable,
+                inferred_name=key,  # langgraph.json key wins inference rule 2
+                confidence="HIGH",
+                source="langgraph_json",
+            )
+        )
+    return out
+
+
 async def scan_folder(root: Path) -> ScanResult:
     """Walk ``root`` and return a ``ScanResult``."""
     started = time.monotonic()
     has_python_files = False
     detected: list[DetectedAgent] = []
+
+    detected.extend(_detect_in_langgraph_json(root))
 
     for rel, abs_path in _walk(root):
         has_python_files = True

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -12,7 +12,9 @@ stdlib + pydantic + pyyaml. The five-state wizard classification is
 
 from __future__ import annotations
 
+import ast
 import os
+import re
 import time
 from pathlib import Path
 
@@ -38,6 +40,16 @@ _SKIP_DIRS = frozenset(
 _MAX_DEPTH = 4
 _MAX_FILE_BYTES = 1_000_000  # 1 MB
 
+_LANGGRAPH_IMPORT_RE = re.compile(
+    r"(?m)^\s*(from\s+langgraph[\s.]|import\s+langgraph)"
+)
+_ADK_IMPORT_RE = re.compile(
+    r"(?m)^\s*(from\s+google\.adk|import\s+google\.adk)"
+)
+_ADK_AGENT_CLASSES = frozenset(
+    {"Agent", "LlmAgent", "SequentialAgent", "ParallelAgent", "LoopAgent"}
+)
+
 
 def _is_skipped(name: str) -> bool:
     return name in _SKIP_DIRS or name.startswith(".")
@@ -53,8 +65,7 @@ def _walk(root: Path):
         rel = os.path.relpath(dirpath, root_str)
         depth = 0 if rel == "." else len(Path(rel).parts)
         if depth >= _MAX_DEPTH:
-            dirnames[:] = []  # do not descend further
-        # Prune skipped subdirs in-place so os.walk does not enter them.
+            dirnames[:] = []
         dirnames[:] = [d for d in dirnames if not _is_skipped(d)]
         for filename in filenames:
             if not filename.endswith(".py"):
@@ -70,19 +81,175 @@ def _walk(root: Path):
             yield posix_rel, abs_path
 
 
-async def scan_folder(root: Path) -> ScanResult:
-    """Walk ``root`` and return a ``ScanResult``.
+def _is_call_to(node: ast.AST, names: frozenset[str]) -> bool:
+    """True if ``node`` is a Call whose callable is a Name in ``names``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in names
+    return False
 
-    Async for caller ergonomics — the parent spec wraps this in a 5s
-    ``asyncio.wait_for`` budget at the API layer. The function itself
-    is CPU-bound and does not need true async IO.
-    """
+
+def _is_state_graph_call(node: ast.AST) -> bool:
+    return _is_call_to(node, frozenset({"StateGraph"}))
+
+
+def _is_adk_agent_call(node: ast.AST) -> bool:
+    return _is_call_to(node, _ADK_AGENT_CLASSES)
+
+
+def _module_compile_target(node: ast.AST, state_graph_bindings: set[str]) -> bool:
+    """True if ``node`` is ``<expr>.compile(...)`` where receiver is a known StateGraph."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr != "compile":
+        return False
+    recv = func.value
+    return (isinstance(recv, ast.Name) and recv.id in state_graph_bindings) or (
+        isinstance(recv, ast.Call) and _is_state_graph_call(recv)
+    )
+
+
+def _detect_in_source(rel_path: str, abs_path: Path) -> list[DetectedAgent]:
+    """Return all source-detected agents from a single ``.py`` file."""
+    try:
+        text = abs_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    has_lg = bool(_LANGGRAPH_IMPORT_RE.search(text))
+    has_adk = bool(_ADK_IMPORT_RE.search(text))
+    if not (has_lg or has_adk):
+        return []
+
+    try:
+        module = ast.parse(text)
+    except SyntaxError:
+        logger.debug("scanner: skip %s, syntax error", rel_path)
+        return []
+
+    found: list[DetectedAgent] = []
+    state_graph_bindings: set[str] = set()
+    compiled_from_binding: set[str] = set()
+
+    # First pass: collect StateGraph bindings so we can resolve `.compile()`.
+    for stmt in module.body:
+        targets = _assign_targets(stmt)
+        if not targets:
+            continue
+        rhs = _assign_rhs(stmt)
+        if rhs is None:
+            continue
+        if has_lg and _is_state_graph_call(rhs):
+            for name in targets:
+                state_graph_bindings.add(name)
+
+    # Second pass: emit detections.
+    for stmt in module.body:
+        targets = _assign_targets(stmt)
+        if not targets:
+            continue
+        rhs = _assign_rhs(stmt)
+        if rhs is None:
+            continue
+        target_name = targets[0]
+
+        if has_lg and _module_compile_target(rhs, state_graph_bindings):
+            # The compiled binding shadows the intermediate StateGraph
+            # binding (we only emit one detection per file/var).
+            compiled_from_binding.update(
+                _receiver_name(rhs)
+            )  # type: ignore[arg-type]
+            found.append(
+                DetectedAgent(
+                    framework="LANGGRAPH",
+                    file_path=rel_path,
+                    variable_name=target_name,
+                    inferred_name="",  # filled by inference cascade later
+                    confidence="MEDIUM",
+                    source="source",
+                )
+            )
+            continue
+
+        if has_lg and _is_state_graph_call(rhs):
+            found.append(
+                DetectedAgent(
+                    framework="LANGGRAPH",
+                    file_path=rel_path,
+                    variable_name=target_name,
+                    inferred_name="",
+                    confidence="MEDIUM",
+                    source="source",
+                )
+            )
+            continue
+
+        if has_adk and _is_adk_agent_call(rhs):
+            found.append(
+                DetectedAgent(
+                    framework="ADK",
+                    file_path=rel_path,
+                    variable_name=target_name,
+                    inferred_name="",
+                    confidence="MEDIUM",
+                    source="source",
+                )
+            )
+
+    # Drop the intermediate StateGraph binding when a compiled form
+    # also exists in the same file pointing at it.
+    if compiled_from_binding:
+        found = [
+            d
+            for d in found
+            if not (
+                d.framework == "LANGGRAPH" and d.variable_name in compiled_from_binding
+            )
+        ]
+    return found
+
+
+def _assign_targets(stmt: ast.AST) -> list[str]:
+    """Return the list of single-Name LHS targets for an Assign / AnnAssign."""
+    if isinstance(stmt, ast.Assign):
+        out: list[str] = []
+        for tgt in stmt.targets:
+            if isinstance(tgt, ast.Name):
+                out.append(tgt.id)
+        return out
+    if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+        return [stmt.target.id]
+    return []
+
+
+def _assign_rhs(stmt: ast.AST) -> ast.AST | None:
+    if isinstance(stmt, ast.Assign):
+        return stmt.value
+    if isinstance(stmt, ast.AnnAssign):
+        return stmt.value
+    return None
+
+
+def _receiver_name(call: ast.Call) -> set[str]:
+    """If call is `<Name>.compile(...)`, return {Name.id}; else empty."""
+    func = call.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return {func.value.id}
+    return set()
+
+
+async def scan_folder(root: Path) -> ScanResult:
+    """Walk ``root`` and return a ``ScanResult``."""
     started = time.monotonic()
     has_python_files = False
     detected: list[DetectedAgent] = []
 
-    for _rel, _abs in _walk(root):
+    for rel, abs_path in _walk(root):
         has_python_files = True
+        detected.extend(_detect_in_source(rel, abs_path))
 
     duration_ms = int((time.monotonic() - started) * 1000)
     return ScanResult(

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -154,50 +154,50 @@ def _detect_in_source(rel_path: str, abs_path: Path) -> list[DetectedAgent]:
         rhs = _assign_rhs(stmt)
         if rhs is None:
             continue
-        target_name = targets[0]
 
         if has_lg and _module_compile_target(rhs, state_graph_bindings):
             # The compiled binding shadows the intermediate StateGraph
             # binding (we only emit one detection per file/var).
-            compiled_from_binding.update(
-                _receiver_name(rhs)
-            )  # type: ignore[arg-type]
-            found.append(
-                DetectedAgent(
-                    framework="LANGGRAPH",
-                    file_path=rel_path,
-                    variable_name=target_name,
-                    inferred_name="",  # filled by inference cascade later
-                    confidence="MEDIUM",
-                    source="source",
+            compiled_from_binding.update(_receiver_name(rhs))
+            for target_name in targets:
+                found.append(
+                    DetectedAgent(
+                        framework="LANGGRAPH",
+                        file_path=rel_path,
+                        variable_name=target_name,
+                        inferred_name="",  # filled by inference cascade later
+                        confidence="MEDIUM",
+                        source="source",
+                    )
                 )
-            )
             continue
 
         if has_lg and _is_state_graph_call(rhs):
-            found.append(
-                DetectedAgent(
-                    framework="LANGGRAPH",
-                    file_path=rel_path,
-                    variable_name=target_name,
-                    inferred_name="",
-                    confidence="MEDIUM",
-                    source="source",
+            for target_name in targets:
+                found.append(
+                    DetectedAgent(
+                        framework="LANGGRAPH",
+                        file_path=rel_path,
+                        variable_name=target_name,
+                        inferred_name="",
+                        confidence="MEDIUM",
+                        source="source",
+                    )
                 )
-            )
             continue
 
         if has_adk and _is_adk_agent_call(rhs):
-            found.append(
-                DetectedAgent(
-                    framework="ADK",
-                    file_path=rel_path,
-                    variable_name=target_name,
-                    inferred_name="",
-                    confidence="MEDIUM",
-                    source="source",
+            for target_name in targets:
+                found.append(
+                    DetectedAgent(
+                        framework="ADK",
+                        file_path=rel_path,
+                        variable_name=target_name,
+                        inferred_name="",
+                        confidence="MEDIUM",
+                        source="source",
+                    )
                 )
-            )
 
     # Drop the intermediate StateGraph binding when a compiled form
     # also exists in the same file pointing at it.
@@ -233,8 +233,10 @@ def _assign_rhs(stmt: ast.AST) -> ast.AST | None:
     return None
 
 
-def _receiver_name(call: ast.Call) -> set[str]:
+def _receiver_name(call: ast.AST) -> set[str]:
     """If call is `<Name>.compile(...)`, return {Name.id}; else empty."""
+    if not isinstance(call, ast.Call):
+        return set()
     func = call.func
     if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
         return {func.value.id}

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -1,0 +1,94 @@
+"""Pure-Python filesystem scanner for the onboarding wizard.
+
+Walks a folder, detects LangGraph and Google ADK agents from three
+sources (Idun config.yaml, langgraph.json, .py source via regex
+pre-filter + AST), and returns a structured ``ScanResult``.
+
+The scanner never mutates the filesystem, never raises on malformed
+input (parse errors are silently skipped), and runs purely off
+stdlib + pydantic + pyyaml. The five-state wizard classification is
+*not* the scanner's responsibility — it is derived at the API layer.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from idun_agent_schema.standalone import DetectedAgent, ScanResult
+
+from idun_agent_standalone.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".venv",
+        "venv",
+        "env",
+        "dist",
+        "build",
+        "target",
+    }
+)
+_MAX_DEPTH = 4
+_MAX_FILE_BYTES = 1_000_000  # 1 MB
+
+
+def _is_skipped(name: str) -> bool:
+    return name in _SKIP_DIRS or name.startswith(".")
+
+
+def _walk(root: Path):
+    """Yield (rel_path, abs_path) for every ``.py`` file under root.
+
+    Honors the skip-list and depth limit. Symlinks are not followed.
+    """
+    root_str = str(root)
+    for dirpath, dirnames, filenames in os.walk(root_str, followlinks=False):
+        rel = os.path.relpath(dirpath, root_str)
+        depth = 0 if rel == "." else len(Path(rel).parts)
+        if depth >= _MAX_DEPTH:
+            dirnames[:] = []  # do not descend further
+        # Prune skipped subdirs in-place so os.walk does not enter them.
+        dirnames[:] = [d for d in dirnames if not _is_skipped(d)]
+        for filename in filenames:
+            if not filename.endswith(".py"):
+                continue
+            abs_path = Path(dirpath) / filename
+            try:
+                if abs_path.stat().st_size > _MAX_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            rel_path = "" if rel == "." else rel
+            posix_rel = (Path(rel_path) / filename).as_posix()
+            yield posix_rel, abs_path
+
+
+async def scan_folder(root: Path) -> ScanResult:
+    """Walk ``root`` and return a ``ScanResult``.
+
+    Async for caller ergonomics — the parent spec wraps this in a 5s
+    ``asyncio.wait_for`` budget at the API layer. The function itself
+    is CPU-bound and does not need true async IO.
+    """
+    started = time.monotonic()
+    has_python_files = False
+    detected: list[DetectedAgent] = []
+
+    for _rel, _abs in _walk(root):
+        has_python_files = True
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    return ScanResult(
+        root=str(root),
+        detected=detected,
+        has_python_files=has_python_files,
+        has_idun_config=False,
+        scan_duration_ms=duration_ms,
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -446,6 +446,7 @@ def _infer_name(detected: DetectedAgent, root: Path) -> str:
     if stripped:
         return _humanize(stripped)
 
+    # Rule 6: stripped stem was empty (e.g. ``agent.py``) — user-visible fallback.
     return "My Agent"
 
 

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -19,6 +19,7 @@ import re
 import time
 from pathlib import Path
 
+import yaml
 from idun_agent_schema.standalone import DetectedAgent, ScanResult
 
 from idun_agent_standalone.core.logging import get_logger
@@ -41,12 +42,8 @@ _SKIP_DIRS = frozenset(
 _MAX_DEPTH = 4
 _MAX_FILE_BYTES = 1_000_000  # 1 MB
 
-_LANGGRAPH_IMPORT_RE = re.compile(
-    r"(?m)^\s*(from\s+langgraph[\s.]|import\s+langgraph)"
-)
-_ADK_IMPORT_RE = re.compile(
-    r"(?m)^\s*(from\s+google\.adk|import\s+google\.adk)"
-)
+_LANGGRAPH_IMPORT_RE = re.compile(r"(?m)^\s*(from\s+langgraph[\s.]|import\s+langgraph)")
+_ADK_IMPORT_RE = re.compile(r"(?m)^\s*(from\s+google\.adk|import\s+google\.adk)")
 _ADK_AGENT_CLASSES = frozenset(
     {"Agent", "LlmAgent", "SequentialAgent", "ParallelAgent", "LoopAgent"}
 )
@@ -284,12 +281,88 @@ def _detect_in_langgraph_json(root: Path) -> list[DetectedAgent]:
     return out
 
 
+def _detect_in_idun_config(
+    root: Path,
+) -> tuple[list[DetectedAgent], bool]:
+    """Walk depth 0–2 for ``config.yaml`` / ``config.yml``.
+
+    Returns the detections plus a boolean ``has_idun_config`` that the
+    caller folds into the ``ScanResult``.
+    """
+    detections: list[DetectedAgent] = []
+    has_idun_config = False
+
+    for path in _iter_idun_config_paths(root, max_depth=2):
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, yaml.YAMLError):
+            logger.debug("scanner: skip %s, yaml error", path)
+            continue
+        if not isinstance(data, dict):
+            continue
+        agent = data.get("agent")
+        if not isinstance(agent, dict):
+            continue
+        agent_type = agent.get("type")
+        if agent_type not in ("LANGGRAPH", "ADK"):
+            continue
+        config = agent.get("config")
+        if not isinstance(config, dict):
+            continue
+
+        target = (
+            config.get("graph_definition")
+            if agent_type == "LANGGRAPH"
+            else config.get("agent")
+        )
+        if not isinstance(target, str) or ":" not in target:
+            continue
+        file_part, _, variable = target.partition(":")
+        rel = file_part.removeprefix("./").lstrip("/")
+        if not rel or not variable:
+            continue
+
+        has_idun_config = True
+        inferred = config.get("name")
+        if not isinstance(inferred, str) or not inferred:
+            inferred = ""  # filled by inference cascade
+        detections.append(
+            DetectedAgent(
+                framework=agent_type,
+                file_path=rel,
+                variable_name=variable,
+                inferred_name=inferred,
+                confidence="HIGH",
+                source="config",
+            )
+        )
+    return detections, has_idun_config
+
+
+def _iter_idun_config_paths(root: Path, *, max_depth: int):
+    """Yield candidate ``config.yaml`` / ``config.yml`` paths up to depth 2."""
+    for dirpath, dirnames, filenames in os.walk(str(root), followlinks=False):
+        rel = os.path.relpath(dirpath, str(root))
+        depth = 0 if rel == "." else len(Path(rel).parts)
+        if depth > max_depth:
+            dirnames[:] = []
+            continue
+        if depth == max_depth:
+            dirnames[:] = []
+        dirnames[:] = [d for d in dirnames if not _is_skipped(d)]
+        for filename in filenames:
+            if filename in ("config.yaml", "config.yml"):
+                yield Path(dirpath) / filename
+
+
 async def scan_folder(root: Path) -> ScanResult:
     """Walk ``root`` and return a ``ScanResult``."""
     started = time.monotonic()
     has_python_files = False
     detected: list[DetectedAgent] = []
 
+    config_detections, has_idun_config = _detect_in_idun_config(root)
+    detected.extend(config_detections)
     detected.extend(_detect_in_langgraph_json(root))
 
     for rel, abs_path in _walk(root):
@@ -301,6 +374,6 @@ async def scan_folder(root: Path) -> ScanResult:
         root=str(root),
         detected=detected,
         has_python_files=has_python_files,
-        has_idun_config=False,
+        has_idun_config=has_idun_config,
         scan_duration_ms=duration_ms,
     )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import time
+import tomllib
 from pathlib import Path
 
 import yaml
@@ -389,6 +390,65 @@ def _dedup(detections: list[DetectedAgent]) -> list[DetectedAgent]:
     return list(by_key.values())
 
 
+_TRAILING_AGENT_RE = re.compile(r"_?agent$", re.IGNORECASE)
+
+
+def _humanize(token: str) -> str:
+    """Return a Title-Cased label from a slug-ish token (``my-bot`` → ``My Bot``)."""
+    parts = re.split(r"[-_\s]+", token.strip())
+    return " ".join(p.capitalize() for p in parts if p)
+
+
+def _read_pyproject_name(root: Path) -> str | None:
+    path = root / "pyproject.toml"
+    if not path.is_file():
+        return None
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    project = data.get("project")
+    if isinstance(project, dict):
+        name = project.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return None
+
+
+def _infer_name(detected: DetectedAgent, root: Path) -> str:
+    """Apply the 6-rule cascade to compute the human-friendly name.
+
+    Rules 1 and 2 — config.name and langgraph.json key — are already
+    populated by the detection paths; this function only fills the
+    blanks for source-detected entries (and overrides empty values
+    that slipped through from config without a name).
+    """
+    if detected.inferred_name:
+        return detected.inferred_name
+
+    pyproject_name = _read_pyproject_name(root)
+    if pyproject_name:
+        return _humanize(pyproject_name)
+
+    file_path = Path(detected.file_path)
+    parent = file_path.parent
+    # Rule 4: parent dir, skipping ``src``
+    if parent.parts and parent.parts != (".",):
+        candidate = parent.parts[-1]
+        if candidate == "src" and len(parent.parts) >= 2:
+            candidate = parent.parts[-2]
+        if candidate and candidate != "src":
+            return _humanize(candidate)
+
+    # Rule 5: filename without extension, strip ``_agent`` / ``agent``
+    stem = file_path.stem
+    stripped = _TRAILING_AGENT_RE.sub("", stem)
+    if stripped:
+        return _humanize(stripped)
+
+    return "My Agent"
+
+
 async def scan_folder(root: Path) -> ScanResult:
     """Walk ``root`` and return a ``ScanResult``."""
     started = time.monotonic()
@@ -403,7 +463,11 @@ async def scan_folder(root: Path) -> ScanResult:
         has_python_files = True
         raw.extend(_detect_in_source(rel, abs_path))
 
-    detected = _dedup(raw)
+    deduped = _dedup(raw)
+    detected = [
+        d.model_copy(update={"inferred_name": _infer_name(d, root)}) for d in deduped
+    ]
+
     duration_ms = int((time.monotonic() - started) * 1000)
     return ScanResult(
         root=str(root),

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -322,6 +322,10 @@ def _detect_in_idun_config(
         if not rel or not variable:
             continue
 
+        # Flips ONLY after the full chain validates (type, config dict,
+        # parseable target, non-empty rel + variable). Moving this above
+        # the empty-rel check would flip the flag on a partially-valid
+        # config and confuse the wizard's state classification.
         has_idun_config = True
         inferred = config.get("name")
         if not isinstance(inferred, str) or not inferred:
@@ -347,12 +351,19 @@ def _iter_idun_config_paths(root: Path, *, max_depth: int):
         if depth > max_depth:
             dirnames[:] = []
             continue
-        if depth == max_depth:
+        if depth >= max_depth:
             dirnames[:] = []
-        dirnames[:] = [d for d in dirnames if not _is_skipped(d)]
+        else:
+            dirnames[:] = [d for d in dirnames if not _is_skipped(d)]
         for filename in filenames:
             if filename in ("config.yaml", "config.yml"):
-                yield Path(dirpath) / filename
+                path = Path(dirpath) / filename
+                try:
+                    if path.stat().st_size > _MAX_FILE_BYTES:
+                        continue
+                except OSError:
+                    continue
+                yield path
 
 
 async def scan_folder(root: Path) -> ScanResult:

--- a/libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
@@ -47,9 +47,7 @@ async def admin_app(async_session, stub_reload_callable, tmp_path):
 
 
 def _seed_langgraph_file(root: Path, *, var: str = "graph") -> None:
-    (root / "agent.py").write_text(
-        textwrap.dedent(
-            f"""
+    (root / "agent.py").write_text(textwrap.dedent(f"""
             from langgraph.graph import StateGraph
             from typing import TypedDict
 
@@ -57,21 +55,15 @@ def _seed_langgraph_file(root: Path, *, var: str = "graph") -> None:
                 m: str
 
             {var} = StateGraph(State).compile()
-            """
-        ).lstrip()
-    )
+            """).lstrip())
 
 
 def _seed_adk_file(root: Path) -> None:
-    (root / "main_adk.py").write_text(
-        textwrap.dedent(
-            """
+    (root / "main_adk.py").write_text(textwrap.dedent("""
             from google.adk.agents import Agent
 
             agent = Agent(name="x", model="gemini-2.5-flash")
-            """
-        ).lstrip()
-    )
+            """).lstrip())
 
 
 async def _seed_existing_agent(async_session) -> StandaloneAgentRow:
@@ -258,3 +250,119 @@ async def test_create_from_detection_stale_pick_409(admin_app, tmp_path) -> None
     assert body["error"]["code"] == "conflict"
     # Message should help the user: it mentions the filename they sent.
     assert "agent.py" in body["error"]["message"]
+
+
+# ---- /create-starter -------------------------------------------------------
+
+
+async def test_create_starter_langgraph_happy_path(
+    admin_app, tmp_path, stub_reload_callable
+) -> None:
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "LANGGRAPH"},
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"]["name"] == "Starter Agent"
+    assert body["reload"]["status"] == "reloaded"
+
+    expected = {
+        "agent.py",
+        "requirements.txt",
+        ".env.example",
+        "README.md",
+        ".gitignore",
+    }
+    assert {p.name for p in tmp_path.iterdir()} >= expected
+
+
+async def test_create_starter_adk_happy_path(admin_app, tmp_path) -> None:
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "ADK", "name": "My Bot"},
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"]["name"] == "My Bot"
+    assert body["data"]["baseEngineConfig"]["agent"]["type"] == "ADK"
+    assert "GOOGLE_API_KEY" in (tmp_path / ".env.example").read_text()
+
+
+async def test_create_starter_scaffold_conflict_409_zero_writes(
+    admin_app, tmp_path
+) -> None:
+    (tmp_path / "agent.py").write_text("# pre-existing\n")
+    pre_state = {p.name: p.read_text() for p in tmp_path.iterdir()}
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "LANGGRAPH"},
+        )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "conflict"
+    assert "Scaffold target exists" in body["error"]["message"]
+    # Pre-existing file untouched, no new files.
+    post_state = {p.name: p.read_text() for p in tmp_path.iterdir()}
+    assert post_state == pre_state
+
+
+async def test_create_starter_already_configured_409_zero_writes(
+    admin_app, async_session, tmp_path
+) -> None:
+    await _seed_existing_agent(async_session)
+    pre_files = list(tmp_path.iterdir())
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "LANGGRAPH"},
+        )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "conflict"
+    assert "Agent already configured" in body["error"]["message"]
+    # Confirm scaffold did not run — directory unchanged.
+    assert list(tmp_path.iterdir()) == pre_files
+
+
+async def test_create_starter_reload_failure_keeps_files(
+    admin_app, tmp_path, stub_reload_callable
+) -> None:
+    """Reload failure surfaces in envelope; scaffolded files persist.
+
+    The reload pipeline rolls back the DB on a ``ReloadInitFailed`` and
+    re-raises as ``AdminAPIError(500, code=reload_failed)`` (see
+    ``services/reload.py``). The scaffolded files live on disk
+    independently of the DB, so they remain — recovery per spec §5.3
+    is to edit ``agent.py`` and re-run the wizard once the row is gone
+    (or PATCH /agent if the row stayed for a different failure mode).
+    """
+    from idun_agent_standalone.services.reload import ReloadInitFailed
+
+    # AsyncMock side_effect: any call to the stub raises this.
+    stub_reload_callable.side_effect = ReloadInitFailed("simulated")
+
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-starter",
+            json={"framework": "LANGGRAPH"},
+        )
+    assert response.status_code == 500
+    assert response.json()["error"]["code"] == "reload_failed"
+
+    expected = {
+        "agent.py",
+        "requirements.txt",
+        ".env.example",
+        "README.md",
+        ".gitignore",
+    }
+    assert {p.name for p in tmp_path.iterdir()} >= expected

--- a/libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
@@ -232,7 +232,13 @@ async def test_create_from_detection_already_configured_409(
             },
         )
     assert response.status_code == 409
-    assert response.json()["error"]["code"] == "conflict"
+    body = response.json()
+    assert body["error"]["code"] == "conflict"
+    # The agent-row pre-check fires BEFORE the scan, so even with a
+    # detectable file on disk we get the "already configured" branch —
+    # not the "detection not found" branch. Recovery hint per Task 6 fix.
+    assert "Agent already configured" in body["error"]["message"]
+    assert "PATCH" in body["error"]["message"]
 
 
 async def test_create_from_detection_stale_pick_409(admin_app, tmp_path) -> None:

--- a/libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
@@ -163,3 +163,92 @@ async def test_scan_state_already_configured_returns_current_agent(
     assert body["currentAgent"]["name"] == "Existing"
     # tmp_path has no Python files so the (now-unconditional) walk reports empty.
     assert body["scanResult"]["detected"] == []
+
+
+# ---- /create-from-detection ------------------------------------------------
+
+
+async def test_create_from_detection_langgraph_happy_path(
+    admin_app, async_session, tmp_path, stub_reload_callable
+) -> None:
+    _seed_langgraph_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-from-detection",
+            json={
+                "framework": "LANGGRAPH",
+                "filePath": "agent.py",
+                "variableName": "graph",
+            },
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"]["baseEngineConfig"]["agent"]["type"] == "LANGGRAPH"
+    assert (
+        body["data"]["baseEngineConfig"]["agent"]["config"]["graph_definition"]
+        == "agent.py:graph"
+    )
+    assert body["reload"]["status"] == "reloaded"
+    assert stub_reload_callable.call_count == 1
+
+
+async def test_create_from_detection_adk_happy_path(
+    admin_app, tmp_path, stub_reload_callable
+) -> None:
+    _seed_adk_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-from-detection",
+            json={
+                "framework": "ADK",
+                "filePath": "main_adk.py",
+                "variableName": "agent",
+            },
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"]["baseEngineConfig"]["agent"]["type"] == "ADK"
+    assert (
+        body["data"]["baseEngineConfig"]["agent"]["config"]["agent"]
+        == "main_adk.py:agent"
+    )
+
+
+async def test_create_from_detection_already_configured_409(
+    admin_app, async_session, tmp_path
+) -> None:
+    await _seed_existing_agent(async_session)
+    _seed_langgraph_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-from-detection",
+            json={
+                "framework": "LANGGRAPH",
+                "filePath": "agent.py",
+                "variableName": "graph",
+            },
+        )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "conflict"
+
+
+async def test_create_from_detection_stale_pick_409(admin_app, tmp_path) -> None:
+    """File deleted between scan and click → re-scan returns no match → 409."""
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/admin/api/v1/onboarding/create-from-detection",
+            json={
+                "framework": "LANGGRAPH",
+                "filePath": "agent.py",
+                "variableName": "graph",
+            },
+        )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "conflict"
+    # Message should help the user: it mentions the filename they sent.
+    assert "agent.py" in body["error"]["message"]

--- a/libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/test_onboarding_flow.py
@@ -1,0 +1,165 @@
+"""Integration tests for ``/admin/api/v1/onboarding/*``."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from idun_agent_standalone.api.v1.deps import (
+    get_reload_callable,
+    get_session,
+)
+from idun_agent_standalone.api.v1.errors import (
+    register_admin_exception_handlers,
+)
+from idun_agent_standalone.api.v1.routers.agent import (
+    router as agent_router,
+)
+from idun_agent_standalone.api.v1.routers.onboarding import (
+    router as onboarding_router,
+)
+from idun_agent_standalone.infrastructure.db.models.agent import (
+    StandaloneAgentRow,
+)
+
+
+@pytest.fixture
+async def admin_app(async_session, stub_reload_callable, tmp_path):
+    app = FastAPI()
+    register_admin_exception_handlers(app)
+    app.include_router(agent_router)
+    app.include_router(onboarding_router)
+    app.state.reload_callable = stub_reload_callable
+    app.state.onboarding_scan_root = tmp_path
+
+    async def override_session():
+        yield async_session
+
+    async def override_reload_callable():
+        return stub_reload_callable
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_reload_callable] = override_reload_callable
+    return app
+
+
+def _seed_langgraph_file(root: Path, *, var: str = "graph") -> None:
+    (root / "agent.py").write_text(
+        textwrap.dedent(
+            f"""
+            from langgraph.graph import StateGraph
+            from typing import TypedDict
+
+            class State(TypedDict):
+                m: str
+
+            {var} = StateGraph(State).compile()
+            """
+        ).lstrip()
+    )
+
+
+def _seed_adk_file(root: Path) -> None:
+    (root / "main_adk.py").write_text(
+        textwrap.dedent(
+            """
+            from google.adk.agents import Agent
+
+            agent = Agent(name="x", model="gemini-2.5-flash")
+            """
+        ).lstrip()
+    )
+
+
+async def _seed_existing_agent(async_session) -> StandaloneAgentRow:
+    row = StandaloneAgentRow(
+        name="Existing",
+        base_engine_config={
+            "server": {"api": {"port": 8000}},
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {"name": "existing", "graph_definition": "agent.py:graph"},
+            },
+        },
+    )
+    async_session.add(row)
+    await async_session.commit()
+    return row
+
+
+# ---- /scan ----------------------------------------------------------------
+
+
+async def test_scan_state_empty(admin_app, tmp_path) -> None:
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "EMPTY"
+    assert body["scanResult"]["hasPythonFiles"] is False
+    assert body["currentAgent"] is None
+
+
+async def test_scan_state_no_supported(admin_app, tmp_path) -> None:
+    (tmp_path / "hello.py").write_text("print('hi')\n")
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "NO_SUPPORTED"
+    assert body["scanResult"]["hasPythonFiles"] is True
+    assert body["scanResult"]["detected"] == []
+
+
+async def test_scan_state_one_detected(admin_app, tmp_path) -> None:
+    _seed_langgraph_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "ONE_DETECTED"
+    assert len(body["scanResult"]["detected"]) == 1
+    detection = body["scanResult"]["detected"][0]
+    assert detection["framework"] == "LANGGRAPH"
+    assert detection["filePath"] == "agent.py"
+    assert detection["variableName"] == "graph"
+
+
+async def test_scan_state_many_detected(admin_app, tmp_path) -> None:
+    _seed_langgraph_file(tmp_path)
+    _seed_adk_file(tmp_path)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "MANY_DETECTED"
+    frameworks = {d["framework"] for d in body["scanResult"]["detected"]}
+    assert frameworks == {"LANGGRAPH", "ADK"}
+
+
+async def test_scan_state_already_configured_returns_current_agent(
+    admin_app, async_session, tmp_path
+) -> None:
+    """When the agent row exists, state is ALREADY_CONFIGURED regardless of
+    what's on disk. The scanner still runs (so direct-curl callers see truthful
+    has_python_files / has_idun_config / detected values), but the wizard UI
+    switches on `state` and short-circuits to chat without re-querying GET /agent.
+    """
+    await _seed_existing_agent(async_session)
+    transport = ASGITransport(app=admin_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/api/v1/onboarding/scan")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "ALREADY_CONFIGURED"
+    assert body["currentAgent"] is not None
+    assert body["currentAgent"]["name"] == "Existing"
+    # tmp_path has no Python files so the (now-unconditional) walk reports empty.
+    assert body["scanResult"]["detected"] == []

--- a/libs/idun_agent_standalone/tests/unit/services/test_onboarding.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_onboarding.py
@@ -118,3 +118,24 @@ def test_engine_config_passes_engine_validation_adk() -> None:
 
     detection = _det(framework="ADK", name="Foo")
     EngineConfig.model_validate(onboarding.engine_config_dict_from_detection(detection))
+
+
+def test_slugify_is_a_fixed_point_of_engine_adk_validator() -> None:
+    """If the engine's app_name derivation rule changes, this fails — forcing a re-sync.
+
+    The engine's ``AdkAgentConfig._default_app_name_from_name`` validator runs the
+    same lower-then-replace transform on ``name`` to derive ``app_name``. We slugify
+    up-front so revalidation is idempotent: ``_slugify(x)`` must round-trip through
+    the engine's rule unchanged.
+    """
+    from idun_agent_schema.engine.adk import AdkAgentConfig
+
+    raw_inputs = ["My Agent", "café", "agent_42", "!!!", "", "HelloWorld", "日本"]
+    for raw in raw_inputs:
+        slug = onboarding._slugify(raw)
+        adk = AdkAgentConfig(name=slug, agent="x.py:y")
+        assert adk.app_name == slug, (
+            f"Engine rule drift: _slugify({raw!r}) -> {slug!r} but engine "
+            f"derived app_name={adk.app_name!r}. Re-sync standalone _slugify "
+            f"with engine adk.py:_default_app_name_from_name."
+        )

--- a/libs/idun_agent_standalone/tests/unit/services/test_onboarding.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_onboarding.py
@@ -1,0 +1,120 @@
+"""Unit tests for the onboarding service helpers."""
+
+from __future__ import annotations
+
+from idun_agent_schema.standalone import DetectedAgent, ScanResult
+from idun_agent_standalone.services import onboarding
+
+
+def _scan_result(
+    *,
+    detected: list[DetectedAgent] | None = None,
+    has_python_files: bool = False,
+    has_idun_config: bool = False,
+) -> ScanResult:
+    return ScanResult(
+        root="/tmp",
+        detected=detected or [],
+        has_python_files=has_python_files,
+        has_idun_config=has_idun_config,
+        scan_duration_ms=0,
+    )
+
+
+def _det(framework: str = "LANGGRAPH", *, name: str = "Agent") -> DetectedAgent:
+    return DetectedAgent(
+        framework=framework,  # type: ignore[arg-type]
+        file_path="agent.py",
+        variable_name="graph" if framework == "LANGGRAPH" else "agent",
+        inferred_name=name,
+        confidence="HIGH",
+        source="source",
+    )
+
+
+def test_classify_state_already_configured_short_circuits() -> None:
+    """Agent row trumps everything else."""
+    state = onboarding.classify_state(
+        _scan_result(detected=[_det()]), agent_row_exists=True
+    )
+    assert state == "ALREADY_CONFIGURED"
+
+
+def test_classify_state_empty() -> None:
+    state = onboarding.classify_state(_scan_result(), agent_row_exists=False)
+    assert state == "EMPTY"
+
+
+def test_classify_state_no_supported() -> None:
+    state = onboarding.classify_state(
+        _scan_result(has_python_files=True), agent_row_exists=False
+    )
+    assert state == "NO_SUPPORTED"
+
+
+def test_classify_state_one_detected() -> None:
+    state = onboarding.classify_state(
+        _scan_result(detected=[_det()], has_python_files=True),
+        agent_row_exists=False,
+    )
+    assert state == "ONE_DETECTED"
+
+
+def test_classify_state_many_detected() -> None:
+    state = onboarding.classify_state(
+        _scan_result(
+            detected=[_det(name="A"), _det(name="B")],
+            has_python_files=True,
+        ),
+        agent_row_exists=False,
+    )
+    assert state == "MANY_DETECTED"
+
+
+def test_engine_config_for_langgraph_detection() -> None:
+    detection = _det(framework="LANGGRAPH", name="My Agent")
+    config_dict = onboarding.engine_config_dict_from_detection(detection)
+    assert config_dict["agent"]["type"] == "LANGGRAPH"
+    assert config_dict["agent"]["config"]["graph_definition"] == "agent.py:graph"
+    # Names that hit the engine config must be slugified — engine ADK validator
+    # derives app_name from name, and arbitrary unicode breaks downstream.
+    assert config_dict["agent"]["config"]["name"]
+
+
+def test_engine_config_for_adk_detection() -> None:
+    detection = _det(framework="ADK", name="My Agent")
+    config_dict = onboarding.engine_config_dict_from_detection(detection)
+    assert config_dict["agent"]["type"] == "ADK"
+    assert config_dict["agent"]["config"]["agent"] == "agent.py:agent"
+    assert config_dict["agent"]["config"]["name"]
+
+
+def test_engine_config_for_starter_langgraph() -> None:
+    config_dict = onboarding.engine_config_dict_for_starter(
+        framework="LANGGRAPH", name="Starter Agent"
+    )
+    assert config_dict["agent"]["type"] == "LANGGRAPH"
+    assert config_dict["agent"]["config"]["graph_definition"] == "agent.py:graph"
+
+
+def test_engine_config_for_starter_adk() -> None:
+    config_dict = onboarding.engine_config_dict_for_starter(
+        framework="ADK", name="Starter Agent"
+    )
+    assert config_dict["agent"]["type"] == "ADK"
+    assert config_dict["agent"]["config"]["agent"] == "agent.py:agent"
+
+
+def test_engine_config_passes_engine_validation_langgraph() -> None:
+    """The dict we hand to StandaloneAgentRow.base_engine_config must validate."""
+    from idun_agent_schema.engine import EngineConfig
+
+    detection = _det(framework="LANGGRAPH", name="Foo")
+    EngineConfig.model_validate(onboarding.engine_config_dict_from_detection(detection))
+
+
+def test_engine_config_passes_engine_validation_adk() -> None:
+    from idun_agent_schema.engine import EngineConfig
+
+    detection = _det(framework="ADK", name="Foo")
+    EngineConfig.model_validate(onboarding.engine_config_dict_from_detection(detection))

--- a/libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
@@ -1,0 +1,52 @@
+"""Unit tests for the starter-project scaffolder."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from idun_agent_standalone.services import scaffold
+
+
+def test_create_starter_langgraph_writes_five_files(tmp_path: Path) -> None:
+    written = scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+
+    expected_names = {
+        "agent.py",
+        "requirements.txt",
+        ".env.example",
+        "README.md",
+        ".gitignore",
+    }
+    assert {p.name for p in written} == expected_names
+    for path in written:
+        assert path.exists()
+        assert path.is_file()
+
+
+def test_langgraph_agent_py_is_syntactically_valid(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    source = (tmp_path / "agent.py").read_text()
+    # ast.parse raises SyntaxError on invalid source
+    ast.parse(source)
+    # Sanity: the variable our scanner expects is present.
+    assert "graph = " in source
+
+
+def test_langgraph_requirements_lists_idun_and_langgraph(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    contents = (tmp_path / "requirements.txt").read_text()
+    assert "idun-agent-standalone" in contents
+    assert "langgraph" in contents
+
+
+def test_langgraph_env_example_carries_openai_key(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    assert "OPENAI_API_KEY" in (tmp_path / ".env.example").read_text()
+
+
+def test_gitignore_covers_env_and_caches(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    contents = (tmp_path / ".gitignore").read_text()
+    for entry in (".env", "__pycache__/", ".venv/"):
+        assert entry in contents

--- a/libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
@@ -109,7 +109,9 @@ def test_mid_write_failure_cleans_up_partial_files(
     real_write_text = Path.write_text
     call_count = {"n": 0}
 
-    def flaky_write_text(self: Path, content: str, *args: object, **kwargs: object) -> int:
+    def flaky_write_text(
+        self: Path, content: str, *args: object, **kwargs: object
+    ) -> int:
         call_count["n"] += 1
         # Fail on the 3rd file written (any in-progress write triggers cleanup).
         if call_count["n"] == 3:
@@ -124,9 +126,9 @@ def test_mid_write_failure_cleans_up_partial_files(
     # Cleanup must remove all final files we successfully renamed AND any
     # in-flight `.idun-tmp` file from the failed write. Directory must be
     # restored to its pre-call state (empty in this fixture).
-    assert list(tmp_path.iterdir()) == [], (
-        f"unexpected leftover files: {[p.name for p in tmp_path.iterdir()]}"
-    )
+    assert (
+        list(tmp_path.iterdir()) == []
+    ), f"unexpected leftover files: {[p.name for p in tmp_path.iterdir()]}"
 
 
 def test_mid_write_failure_cleans_up_orphan_tmp(
@@ -135,7 +137,9 @@ def test_mid_write_failure_cleans_up_orphan_tmp(
     """An OSError during write_text leaves no orphan .idun-tmp file behind."""
     real_write_text = Path.write_text
 
-    def fail_first_write(self: Path, content: str, *args: object, **kwargs: object) -> int:
+    def fail_first_write(
+        self: Path, content: str, *args: object, **kwargs: object
+    ) -> int:
         # Fail on the very first write_text call — no files renamed yet,
         # but the tmp file may have been created and partially written.
         # The contract says: zero leftover files in tmp_path.
@@ -151,9 +155,9 @@ def test_mid_write_failure_cleans_up_orphan_tmp(
         scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
 
     # No final files, no `.idun-tmp` orphans.
-    assert list(tmp_path.iterdir()) == [], (
-        f"unexpected leftover files: {[p.name for p in tmp_path.iterdir()]}"
-    )
+    assert (
+        list(tmp_path.iterdir()) == []
+    ), f"unexpected leftover files: {[p.name for p in tmp_path.iterdir()]}"
 
 
 def test_returned_paths_resolve_inside_root(tmp_path: Path) -> None:

--- a/libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
@@ -50,3 +50,35 @@ def test_gitignore_covers_env_and_caches(tmp_path: Path) -> None:
     contents = (tmp_path / ".gitignore").read_text()
     for entry in (".env", "__pycache__/", ".venv/"):
         assert entry in contents
+
+
+def test_create_starter_adk_writes_five_files(tmp_path: Path) -> None:
+    written = scaffold.create_starter_project(tmp_path, framework="ADK")
+    assert {p.name for p in written} == {
+        "agent.py",
+        "requirements.txt",
+        ".env.example",
+        "README.md",
+        ".gitignore",
+    }
+
+
+def test_adk_agent_py_is_syntactically_valid(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="ADK")
+    source = (tmp_path / "agent.py").read_text()
+    ast.parse(source)
+    # The scanner expects an `agent` variable bound to an ADK Agent.
+    assert "agent = " in source
+    assert "Agent(" in source
+
+
+def test_adk_requirements_lists_idun_and_adk(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="ADK")
+    contents = (tmp_path / "requirements.txt").read_text()
+    assert "idun-agent-standalone" in contents
+    assert "google-adk" in contents
+
+
+def test_adk_env_example_carries_google_key(tmp_path: Path) -> None:
+    scaffold.create_starter_project(tmp_path, framework="ADK")
+    assert "GOOGLE_API_KEY" in (tmp_path / ".env.example").read_text()

--- a/libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scaffold.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
 from idun_agent_standalone.services import scaffold
 
 
@@ -82,3 +83,80 @@ def test_adk_requirements_lists_idun_and_adk(tmp_path: Path) -> None:
 def test_adk_env_example_carries_google_key(tmp_path: Path) -> None:
     scaffold.create_starter_project(tmp_path, framework="ADK")
     assert "GOOGLE_API_KEY" in (tmp_path / ".env.example").read_text()
+
+
+def test_conflict_pre_check_raises_with_paths(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text("# pre-existing\n")
+    (tmp_path / ".gitignore").write_text("# pre-existing\n")
+    with pytest.raises(scaffold.ScaffoldConflictError) as exc_info:
+        scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    conflicts = {p.name for p in exc_info.value.paths}
+    assert conflicts == {"agent.py", ".gitignore"}
+
+
+def test_conflict_writes_zero_files(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text("# pre-existing\n")
+    pre_count = len(list(tmp_path.iterdir()))
+    with pytest.raises(scaffold.ScaffoldConflictError):
+        scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    assert len(list(tmp_path.iterdir())) == pre_count
+
+
+def test_mid_write_failure_cleans_up_partial_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If write_text raises midway through, already-written files get unlinked."""
+    real_write_text = Path.write_text
+    call_count = {"n": 0}
+
+    def flaky_write_text(self: Path, content: str, *args: object, **kwargs: object) -> int:
+        call_count["n"] += 1
+        # Fail on the 3rd file written (any in-progress write triggers cleanup).
+        if call_count["n"] == 3:
+            raise OSError("simulated disk full")
+        return real_write_text(self, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", flaky_write_text)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+
+    # Cleanup must remove all final files we successfully renamed AND any
+    # in-flight `.idun-tmp` file from the failed write. Directory must be
+    # restored to its pre-call state (empty in this fixture).
+    assert list(tmp_path.iterdir()) == [], (
+        f"unexpected leftover files: {[p.name for p in tmp_path.iterdir()]}"
+    )
+
+
+def test_mid_write_failure_cleans_up_orphan_tmp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An OSError during write_text leaves no orphan .idun-tmp file behind."""
+    real_write_text = Path.write_text
+
+    def fail_first_write(self: Path, content: str, *args: object, **kwargs: object) -> int:
+        # Fail on the very first write_text call — no files renamed yet,
+        # but the tmp file may have been created and partially written.
+        # The contract says: zero leftover files in tmp_path.
+        if self.name.endswith(".idun-tmp"):
+            # Simulate a write that creates the file then fails.
+            real_write_text(self, content[:5], *args, **kwargs)
+            raise OSError("simulated mid-write failure")
+        return real_write_text(self, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_first_write)
+
+    with pytest.raises(OSError, match="simulated mid-write failure"):
+        scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+
+    # No final files, no `.idun-tmp` orphans.
+    assert list(tmp_path.iterdir()) == [], (
+        f"unexpected leftover files: {[p.name for p in tmp_path.iterdir()]}"
+    )
+
+
+def test_returned_paths_resolve_inside_root(tmp_path: Path) -> None:
+    written = scaffold.create_starter_project(tmp_path, framework="LANGGRAPH")
+    for path in written:
+        assert path.parent == tmp_path

--- a/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import yaml
 from idun_agent_standalone.services.scanner import scan_folder
 
 
@@ -29,8 +30,7 @@ async def test_skip_list_ignores_dot_venv(tmp_path: Path) -> None:
     venv = tmp_path / ".venv" / "lib"
     venv.mkdir(parents=True)
     (venv / "trap.py").write_text(
-        "from langgraph.graph import StateGraph\n"
-        "graph = StateGraph(int).compile()\n"
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
     )
     result = await scan_folder(tmp_path)
     assert result.detected == []
@@ -61,8 +61,7 @@ async def test_depth_limit_4(tmp_path: Path) -> None:
 
 async def test_detect_minimal_langgraph(tmp_path: Path) -> None:
     (tmp_path / "agent.py").write_text(
-        "from langgraph.graph import StateGraph\n"
-        "graph = StateGraph(int).compile()\n"
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
     )
     result = await scan_folder(tmp_path)
     assert len(result.detected) == 1
@@ -77,8 +76,7 @@ async def test_detect_minimal_langgraph(tmp_path: Path) -> None:
 async def test_detect_uncompiled_langgraph(tmp_path: Path) -> None:
     """A bare StateGraph(...) assignment counts."""
     (tmp_path / "agent.py").write_text(
-        "from langgraph.graph import StateGraph\n"
-        "graph = StateGraph(int)\n"
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int)\n"
     )
     result = await scan_folder(tmp_path)
     assert len(result.detected) == 1
@@ -99,18 +97,14 @@ async def test_detect_compiled_via_intermediate(tmp_path: Path) -> None:
 
 async def test_no_false_positive_on_unrelated_compile(tmp_path: Path) -> None:
     """``something.compile()`` with no traceable StateGraph receiver is ignored."""
-    (tmp_path / "noise.py").write_text(
-        "import re\n"
-        "pat = re.compile(r'x')\n"
-    )
+    (tmp_path / "noise.py").write_text("import re\n" "pat = re.compile(r'x')\n")
     result = await scan_folder(tmp_path)
     assert result.detected == []
 
 
 async def test_detect_minimal_adk(tmp_path: Path) -> None:
     (tmp_path / "agent.py").write_text(
-        "from google.adk.agents import Agent\n"
-        "root_agent = Agent(name='x')\n"
+        "from google.adk.agents import Agent\n" "root_agent = Agent(name='x')\n"
     )
     result = await scan_folder(tmp_path)
     assert len(result.detected) == 1
@@ -143,8 +137,7 @@ async def test_skip_unparseable_source(tmp_path: Path) -> None:
         "graph = StateGraph(int  # missing paren\n"
     )
     (tmp_path / "good.py").write_text(
-        "from langgraph.graph import StateGraph\n"
-        "graph = StateGraph(int).compile()\n"
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
     )
     result = await scan_folder(tmp_path)
     files = {d.file_path for d in result.detected}
@@ -203,4 +196,125 @@ async def test_langgraph_json_only_at_root(tmp_path: Path) -> None:
         json.dumps({"graphs": {"x": "./agent.py:graph"}})
     )
     result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_idun_config_langgraph(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {
+                        "name": "Helpdesk",
+                        "graph_definition": "./agent.py:graph",
+                    },
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is True
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "LANGGRAPH"
+    assert d.file_path == "agent.py"
+    assert d.variable_name == "graph"
+    assert d.confidence == "HIGH"
+    assert d.source == "config"
+
+
+async def test_idun_config_adk(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "ADK",
+                    "config": {
+                        "name": "Helpdesk",
+                        "agent": "./agent.py:root_agent",
+                    },
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is True
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "ADK"
+    assert d.variable_name == "root_agent"
+
+
+async def test_idun_config_yml_extension(tmp_path: Path) -> None:
+    (tmp_path / "config.yml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {"graph_definition": "./agent.py:graph"},
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is True
+    assert len(result.detected) == 1
+
+
+async def test_idun_config_at_depth_2(tmp_path: Path) -> None:
+    nested = tmp_path / "sub" / "deeper"
+    nested.mkdir(parents=True)
+    (nested / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {"graph_definition": "./agent.py:graph"},
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is True
+
+
+async def test_idun_config_at_depth_3_ignored(tmp_path: Path) -> None:
+    """Idun config at depth > 2 is not consulted."""
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    (nested / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {"graph_definition": "./agent.py:graph"},
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is False
+
+
+async def test_idun_config_malformed_skipped(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("not: valid: yaml: at: all:")
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is False
+    assert result.detected == []
+
+
+async def test_idun_config_unsupported_type_skipped(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "HAYSTACK",
+                    "config": {"component_definition": "./pipe.py:pipe"},
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_idun_config is False
     assert result.detected == []

--- a/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
@@ -318,3 +318,59 @@ async def test_idun_config_unsupported_type_skipped(tmp_path: Path) -> None:
     result = await scan_folder(tmp_path)
     assert result.has_idun_config is False
     assert result.detected == []
+
+
+async def test_dedup_config_over_source(tmp_path: Path) -> None:
+    """Config (HIGH) and source (MEDIUM) on same file:var → 1 entry, HIGH wins."""
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {
+                        "name": "From config",
+                        "graph_definition": "./agent.py:graph",
+                    },
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.confidence == "HIGH"
+    assert d.source == "config"
+    assert d.inferred_name == "From config"
+
+
+async def test_dedup_langgraph_json_over_source(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    (tmp_path / "langgraph.json").write_text(
+        json.dumps({"graphs": {"helpdesk": "./agent.py:graph"}})
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.source == "langgraph_json"
+    assert d.inferred_name == "helpdesk"
+
+
+async def test_distinct_files_not_deduped(tmp_path: Path) -> None:
+    """Two genuinely different agents both surface."""
+    (tmp_path / "alpha.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    (tmp_path / "beta.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 2

--- a/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
@@ -1,0 +1,58 @@
+"""Unit tests for ``services.scanner``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from idun_agent_standalone.services.scanner import scan_folder
+
+
+async def test_empty_folder(tmp_path: Path) -> None:
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+    assert result.has_python_files is False
+    assert result.has_idun_config is False
+    assert result.root == str(tmp_path)
+    assert result.scan_duration_ms >= 0
+
+
+async def test_has_python_files_set_when_py_present(tmp_path: Path) -> None:
+    (tmp_path / "noise.py").write_text("print('hi')\n")
+    result = await scan_folder(tmp_path)
+    assert result.has_python_files is True
+    assert result.detected == []
+
+
+async def test_skip_list_ignores_dot_venv(tmp_path: Path) -> None:
+    """A graph file inside .venv must not be detected."""
+    venv = tmp_path / ".venv" / "lib"
+    venv.mkdir(parents=True)
+    (venv / "trap.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+    # The walk did not recurse into .venv at all
+    assert result.has_python_files is False
+
+
+async def test_skip_list_ignores_dotted_dir(tmp_path: Path) -> None:
+    hidden = tmp_path / ".cache"
+    hidden.mkdir()
+    (hidden / "x.py").write_text("x = 1\n")
+    result = await scan_folder(tmp_path)
+    assert result.has_python_files is False
+
+
+async def test_depth_limit_4(tmp_path: Path) -> None:
+    """Files deeper than 4 levels are not visited."""
+    deep = tmp_path / "a" / "b" / "c" / "d" / "e"
+    deep.mkdir(parents=True)
+    (deep / "deep.py").write_text("x = 1\n")
+    shallow = tmp_path / "a" / "b" / "c" / "d"
+    (shallow / "shallow.py").write_text("y = 1\n")
+    result = await scan_folder(tmp_path)
+    # Depth ≤ 4 means up to 4 path components below the root, so
+    # ``a/b/c/d/shallow.py`` is in (4 components) and ``e/deep.py`` is out.
+    assert result.has_python_files is True  # shallow.py was visited

--- a/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from idun_agent_standalone.services.scanner import scan_folder
@@ -148,3 +149,58 @@ async def test_skip_unparseable_source(tmp_path: Path) -> None:
     result = await scan_folder(tmp_path)
     files = {d.file_path for d in result.detected}
     assert files == {"good.py"}
+
+
+async def test_langgraph_json_single_graph(tmp_path: Path) -> None:
+    (tmp_path / "langgraph.json").write_text(
+        json.dumps(
+            {
+                "dependencies": ["./agent.py"],
+                "graphs": {"helpdesk": "./agent.py:graph"},
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "LANGGRAPH"
+    assert d.file_path == "agent.py"
+    assert d.variable_name == "graph"
+    assert d.confidence == "HIGH"
+    assert d.source == "langgraph_json"
+    # has_idun_config is *not* set by langgraph.json
+    assert result.has_idun_config is False
+
+
+async def test_langgraph_json_multiple_graphs(tmp_path: Path) -> None:
+    (tmp_path / "langgraph.json").write_text(
+        json.dumps(
+            {
+                "graphs": {
+                    "alpha": "./a.py:graph",
+                    "beta": "./b.py:graph",
+                },
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 2
+    assert {d.variable_name for d in result.detected} == {"graph"}
+    assert {d.file_path for d in result.detected} == {"a.py", "b.py"}
+
+
+async def test_langgraph_json_malformed_skipped(tmp_path: Path) -> None:
+    (tmp_path / "langgraph.json").write_text("{not valid json")
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_langgraph_json_only_at_root(tmp_path: Path) -> None:
+    """langgraph.json deeper than depth 0 is not consulted."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "langgraph.json").write_text(
+        json.dumps({"graphs": {"x": "./agent.py:graph"}})
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected == []

--- a/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
@@ -374,3 +374,35 @@ async def test_distinct_files_not_deduped(tmp_path: Path) -> None:
     )
     result = await scan_folder(tmp_path)
     assert len(result.detected) == 2
+
+
+async def test_dedup_config_beats_langgraph_json_on_tie(tmp_path: Path) -> None:
+    """HIGH-vs-HIGH tiebreaker: first-seen (config.yaml) wins over langgraph.json.
+
+    Both detection paths emit a HIGH-confidence entry for the same
+    ``(file_path, variable_name)`` pair. ``scan_folder`` runs config
+    detection first, so the config entry is in the dedup map before
+    the langgraph.json entry; with the strict ``>`` comparison in
+    ``_dedup`` the config entry survives.
+    """
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {
+                        "name": "From config",
+                        "graph_definition": "./agent.py:graph",
+                    },
+                }
+            }
+        )
+    )
+    (tmp_path / "langgraph.json").write_text(
+        json.dumps({"graphs": {"helpdesk": "./agent.py:graph"}})
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.source == "config"
+    assert d.inferred_name == "From config"

--- a/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
@@ -56,3 +56,95 @@ async def test_depth_limit_4(tmp_path: Path) -> None:
     # Depth ≤ 4 means up to 4 path components below the root, so
     # ``a/b/c/d/shallow.py`` is in (4 components) and ``e/deep.py`` is out.
     assert result.has_python_files is True  # shallow.py was visited
+
+
+async def test_detect_minimal_langgraph(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "LANGGRAPH"
+    assert d.file_path == "agent.py"
+    assert d.variable_name == "graph"
+    assert d.confidence == "MEDIUM"
+    assert d.source == "source"
+
+
+async def test_detect_uncompiled_langgraph(tmp_path: Path) -> None:
+    """A bare StateGraph(...) assignment counts."""
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int)\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "graph"
+
+
+async def test_detect_compiled_via_intermediate(tmp_path: Path) -> None:
+    """g = StateGraph(...); graph = g.compile() → 1 detection on the compiled binding."""
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "g = StateGraph(int)\n"
+        "graph = g.compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "graph"
+
+
+async def test_no_false_positive_on_unrelated_compile(tmp_path: Path) -> None:
+    """``something.compile()`` with no traceable StateGraph receiver is ignored."""
+    (tmp_path / "noise.py").write_text(
+        "import re\n"
+        "pat = re.compile(r'x')\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_detect_minimal_adk(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text(
+        "from google.adk.agents import Agent\n"
+        "root_agent = Agent(name='x')\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "ADK"
+    assert d.variable_name == "root_agent"
+    assert d.source == "source"
+
+
+async def test_detect_adk_subclasses(tmp_path: Path) -> None:
+    """LlmAgent / SequentialAgent / ParallelAgent / LoopAgent all count."""
+    src = (
+        "from google.adk.agents import LlmAgent, SequentialAgent\n"
+        "from google.adk.agents import ParallelAgent, LoopAgent\n"
+        "a = LlmAgent(name='a')\n"
+        "b = SequentialAgent(name='b')\n"
+        "c = ParallelAgent(name='c')\n"
+        "d = LoopAgent(name='d')\n"
+    )
+    (tmp_path / "agents.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    names = {d.variable_name for d in result.detected}
+    assert names == {"a", "b", "c", "d"}
+
+
+async def test_skip_unparseable_source(tmp_path: Path) -> None:
+    """A SyntaxError in one file does not crash the scan."""
+    (tmp_path / "broken.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int  # missing paren\n"
+    )
+    (tmp_path / "good.py").write_text(
+        "from langgraph.graph import StateGraph\n"
+        "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    files = {d.file_path for d in result.detected}
+    assert files == {"good.py"}

--- a/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
@@ -323,8 +323,7 @@ async def test_idun_config_unsupported_type_skipped(tmp_path: Path) -> None:
 async def test_dedup_config_over_source(tmp_path: Path) -> None:
     """Config (HIGH) and source (MEDIUM) on same file:var → 1 entry, HIGH wins."""
     (tmp_path / "agent.py").write_text(
-        "from langgraph.graph import StateGraph\n"
-        "graph = StateGraph(int).compile()\n"
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
     )
     (tmp_path / "config.yaml").write_text(
         yaml.safe_dump(
@@ -349,8 +348,7 @@ async def test_dedup_config_over_source(tmp_path: Path) -> None:
 
 async def test_dedup_langgraph_json_over_source(tmp_path: Path) -> None:
     (tmp_path / "agent.py").write_text(
-        "from langgraph.graph import StateGraph\n"
-        "graph = StateGraph(int).compile()\n"
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
     )
     (tmp_path / "langgraph.json").write_text(
         json.dumps({"graphs": {"helpdesk": "./agent.py:graph"}})
@@ -365,12 +363,10 @@ async def test_dedup_langgraph_json_over_source(tmp_path: Path) -> None:
 async def test_distinct_files_not_deduped(tmp_path: Path) -> None:
     """Two genuinely different agents both surface."""
     (tmp_path / "alpha.py").write_text(
-        "from langgraph.graph import StateGraph\n"
-        "graph = StateGraph(int).compile()\n"
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
     )
     (tmp_path / "beta.py").write_text(
-        "from langgraph.graph import StateGraph\n"
-        "graph = StateGraph(int).compile()\n"
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
     )
     result = await scan_folder(tmp_path)
     assert len(result.detected) == 2
@@ -406,3 +402,91 @@ async def test_dedup_config_beats_langgraph_json_on_tie(tmp_path: Path) -> None:
     d = result.detected[0]
     assert d.source == "config"
     assert d.inferred_name == "From config"
+
+
+async def test_inferred_name_uses_pyproject(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "my-bot"\nversion = "0.1.0"\n'
+    )
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "My Bot"
+
+
+async def test_inferred_name_falls_back_to_parent_dir(tmp_path: Path) -> None:
+    sub = tmp_path / "chat_assistant"
+    sub.mkdir()
+    (sub / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "Chat Assistant"
+
+
+async def test_inferred_name_skips_src_in_parent(tmp_path: Path) -> None:
+    """A src/ wrapper is skipped during parent-dir inference.
+
+    The cascade falls through to filename-based inference (rule 5) and
+    then to the fallback (rule 6) because the stem ``agent`` strips to
+    empty under the ``_?agent$`` regex. Confirms src/ is correctly NOT
+    used as the inferred name.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    # src/ skipped → rule 5 strips "agent" → empty → rule 6 fallback.
+    assert result.detected[0].inferred_name == "My Agent"
+
+
+async def test_inferred_name_strips_underscore_agent_suffix(tmp_path: Path) -> None:
+    (tmp_path / "chatbot_agent.py").write_text(
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "Chatbot"
+
+
+async def test_inferred_name_fallback(tmp_path: Path) -> None:
+    """Filename ``agent.py`` with no parent context → titlecased filename, not fallback."""
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    # No pyproject, no parent dir, filename ``agent`` after stripping is empty
+    # so we fall through to the literal "My Agent" fallback.
+    assert result.detected[0].inferred_name == "My Agent"
+
+
+async def test_inferred_name_langgraph_json_key_wins(tmp_path: Path) -> None:
+    """langgraph.json key takes priority over pyproject."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "my-bot"\n')
+    (tmp_path / "langgraph.json").write_text(
+        json.dumps({"graphs": {"helpdesk": "./agent.py:graph"}})
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "helpdesk"
+
+
+async def test_inferred_name_config_name_wins(tmp_path: Path) -> None:
+    """Idun config.name takes priority over everything."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "my-bot"\n')
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "agent": {
+                    "type": "LANGGRAPH",
+                    "config": {
+                        "name": "From Config",
+                        "graph_definition": "./agent.py:graph",
+                    },
+                }
+            }
+        )
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected[0].inferred_name == "From Config"

--- a/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
@@ -452,7 +452,7 @@ async def test_inferred_name_strips_underscore_agent_suffix(tmp_path: Path) -> N
 
 
 async def test_inferred_name_fallback(tmp_path: Path) -> None:
-    """Filename ``agent.py`` with no parent context → titlecased filename, not fallback."""
+    """Filename ``agent.py`` strips to empty → ``My Agent`` fallback."""
     (tmp_path / "agent.py").write_text(
         "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
     )
@@ -490,3 +490,61 @@ async def test_inferred_name_config_name_wins(tmp_path: Path) -> None:
     )
     result = await scan_folder(tmp_path)
     assert result.detected[0].inferred_name == "From Config"
+
+
+async def test_ipynb_files_ignored(tmp_path: Path) -> None:
+    """Notebook files are never parsed."""
+    (tmp_path / "agent.ipynb").write_text(
+        '{ "cells": [{ "source": ["from langgraph.graph import StateGraph\\n",'
+        ' "graph = StateGraph(int).compile()\\n"] }] }'
+    )
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+    assert result.has_python_files is False
+
+
+async def test_oversized_py_skipped(tmp_path: Path) -> None:
+    """Files > 1 MB are skipped (binary heuristic)."""
+    (tmp_path / "huge.py").write_text("# pad\n" * 200_000)  # ~1.4 MB
+    result = await scan_folder(tmp_path)
+    assert result.has_python_files is False  # huge.py was skipped
+    assert result.detected == []
+
+
+async def test_scan_duration_populated(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.scan_duration_ms >= 0
+
+
+async def test_full_state_2_shape(tmp_path: Path) -> None:
+    """End-to-end: state-2 (one supported agent) feeds the wizard correctly."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "support-bot"\n')
+    (tmp_path / "agent.py").write_text(
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert result.has_python_files is True
+    assert result.has_idun_config is False
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "LANGGRAPH"
+    assert d.inferred_name == "Support Bot"
+    assert d.confidence == "MEDIUM"
+    assert d.source == "source"
+
+
+async def test_full_state_3_shape(tmp_path: Path) -> None:
+    """End-to-end: state-3 (multiple agents) returns a list the wizard can show."""
+    (tmp_path / "alpha.py").write_text(
+        "from langgraph.graph import StateGraph\n" "graph = StateGraph(int).compile()\n"
+    )
+    (tmp_path / "beta.py").write_text(
+        "from google.adk.agents import Agent\n" "root_agent = Agent(name='b')\n"
+    )
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 2
+    frameworks = {d.framework for d in result.detected}
+    assert frameworks == {"LANGGRAPH", "ADK"}

--- a/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
@@ -67,4 +67,36 @@ describe("apiFetch 401 redirect", () => {
       "/login/?next=%2Fadmin%2Fagent%3Ffoo%3Dbar",
     );
   });
+
+  it("redirects only once even on repeated 401s", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 401 }));
+    await expect(apiFetch("/admin/api/v1/agent")).rejects.toThrow();
+    const firstHref = window.location.href;
+    expect(firstHref).toBe("/login/?next=%2Fonboarding");
+
+    // Mutate the href to detect whether a second 401 writes it again.
+    (window.location as { href: string }).href = "SENTINEL";
+    await expect(apiFetch("/admin/api/v1/agent")).rejects.toThrow();
+    expect(window.location.href).toBe("SENTINEL");
+  });
+
+  it("when already on /login, redirects to plain /login/ (no ?next= self-loop)", async () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: {
+        ...originalLocation,
+        pathname: "/login",
+        search: "",
+        href: "",
+      },
+    });
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 401 }),
+    );
+    await expect(apiFetch("/admin/api/v1/agent")).rejects.toThrow();
+    expect(window.location.href).toBe("/login/");
+  });
 });

--- a/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
@@ -82,7 +82,7 @@ describe("apiFetch 401 redirect", () => {
     expect(window.location.href).toBe("SENTINEL");
   });
 
-  it("when already on /login, redirects to plain /login/ (no ?next= self-loop)", async () => {
+  it("when already on /login, does NOT redirect (login page owns its UX)", async () => {
     Object.defineProperty(window, "location", {
       configurable: true,
       writable: true,
@@ -90,13 +90,14 @@ describe("apiFetch 401 redirect", () => {
         ...originalLocation,
         pathname: "/login",
         search: "",
-        href: "",
+        href: "SENTINEL_NO_REDIRECT",
       },
     });
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({}), { status: 401 }),
     );
     await expect(apiFetch("/admin/api/v1/agent")).rejects.toThrow();
-    expect(window.location.href).toBe("/login/");
+    // href is unchanged — apiFetch did not redirect.
+    expect(window.location.href).toBe("SENTINEL_NO_REDIRECT");
   });
 });

--- a/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ApiFetch = typeof import("@/lib/api/client").apiFetch;
+
+describe("apiFetch 401 redirect", () => {
+  const fetchMock = vi.fn();
+  const originalLocation = window.location;
+  let apiFetch: ApiFetch;
+
+  beforeEach(async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    // The 401 redirect uses a module-level `redirected` flag to avoid loops.
+    // Reset modules so each test gets a fresh evaluation and the flag is
+    // back to `false`.
+    vi.resetModules();
+    const mod = await import("@/lib/api/client");
+    apiFetch = mod.apiFetch;
+    // jsdom doesn't allow assigning to window.location.href directly without
+    // this trick. Replace location with a writable mock so the redirect is
+    // observable.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: {
+        ...originalLocation,
+        pathname: "/onboarding",
+        search: "",
+        href: "",
+      },
+    });
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("redirects to /login/?next=<pathname> on 401", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 401 }),
+    );
+    await expect(apiFetch("/admin/api/v1/agent")).rejects.toThrow();
+    expect(window.location.href).toBe("/login/?next=%2Fonboarding");
+  });
+
+  it("encodes the pathname so query strings stay intact", async () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: {
+        ...originalLocation,
+        pathname: "/admin/agent",
+        search: "?foo=bar",
+        href: "",
+      },
+    });
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 401 }),
+    );
+    await expect(apiFetch("/admin/api/v1/agent")).rejects.toThrow();
+    expect(window.location.href).toBe(
+      "/login/?next=%2Fadmin%2Fagent%3Ffoo%3Dbar",
+    );
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/api/onboarding.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/onboarding.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, api } from "@/lib/api";
+
+describe("onboarding api", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("scan() POSTs /admin/api/v1/onboarding/scan with no body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          state: "EMPTY",
+          scanResult: {
+            root: "/tmp",
+            detected: [],
+            hasPythonFiles: false,
+            hasIdunConfig: false,
+            scanDurationMs: 12,
+          },
+          currentAgent: null,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await api.scan();
+    expect(result.state).toBe("EMPTY");
+    expect(result.scanResult.hasPythonFiles).toBe(false);
+
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/admin/api/v1/onboarding/scan");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBeUndefined();
+  });
+
+  it("createFromDetection() POSTs the typed body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: { id: "x", name: "Foo" },
+          reload: { status: "reloaded" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const result = await api.createFromDetection({
+      framework: "LANGGRAPH",
+      filePath: "agent.py",
+      variableName: "graph",
+    });
+    expect(result.data.name).toBe("Foo");
+    expect(result.reload.status).toBe("reloaded");
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/admin/api/v1/onboarding/create-from-detection");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      framework: "LANGGRAPH",
+      filePath: "agent.py",
+      variableName: "graph",
+    });
+  });
+
+  it("createStarter() POSTs the typed body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: { id: "x", name: "Starter Agent" },
+          reload: { status: "reloaded" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const result = await api.createStarter({ framework: "ADK", name: "My Bot" });
+    expect(result.data.name).toBe("Starter Agent");
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/admin/api/v1/onboarding/create-starter");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      framework: "ADK",
+      name: "My Bot",
+    });
+  });
+
+  it("createStarter() omits name when not provided", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: { id: "x", name: "Starter Agent" },
+          reload: { status: "reloaded" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    await api.createStarter({ framework: "LANGGRAPH" });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      framework: "LANGGRAPH",
+    });
+  });
+
+  it("409 conflict surfaces as ApiError with the conflict envelope", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "conflict", message: "Agent already configured." },
+        }),
+        { status: 409, headers: { "content-type": "application/json" } },
+      ),
+    );
+    try {
+      await api.createStarter({ framework: "LANGGRAPH" });
+      throw new Error("expected ApiError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(409);
+      expect((err as ApiError).detail).toMatchObject({
+        error: { code: "conflict" },
+      });
+    }
+  });
+
+  it("500 reload_failed surfaces as ApiError with the reload envelope", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "reload_failed", message: "Engine init failed." },
+        }),
+        { status: 500, headers: { "content-type": "application/json" } },
+      ),
+    );
+    try {
+      await api.createStarter({ framework: "LANGGRAPH" });
+      throw new Error("expected ApiError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(500);
+      expect((err as ApiError).detail).toMatchObject({
+        error: { code: "reload_failed" },
+      });
+    }
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/login.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/login.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import LoginPage from "@/app/login/page";
+
+const replace = vi.fn();
+const useSearchParamsMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => useSearchParamsMock(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      login: vi.fn(),
+    },
+  };
+});
+
+import { api, ApiError } from "@/lib/api";
+import { toast } from "sonner";
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    replace.mockReset();
+    useSearchParamsMock.mockReturnValue(new URLSearchParams(""));
+    (api.login as ReturnType<typeof vi.fn>).mockReset();
+    (toast.error as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("on success without ?next, redirects to /", async () => {
+    (api.login as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/admin password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+  });
+
+  it("on success with ?next=/onboarding, redirects there", async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams("next=/onboarding"));
+    (api.login as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/admin password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
+  });
+
+  it("on 401, fires toast.error and does not redirect", async () => {
+    (api.login as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiError(401, null),
+    );
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/admin password/i), {
+      target: { value: "wrong" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/login.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/login.test.tsx
@@ -73,4 +73,30 @@ describe("LoginPage", () => {
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
     expect(replace).not.toHaveBeenCalled();
   });
+
+  it("rejects unsafe ?next= values and falls back to /", async () => {
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams("next=https://evil.com"),
+    );
+    (api.login as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/admin password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+  });
+
+  it("rejects protocol-relative ?next= values", async () => {
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams("next=//evil.com/path"),
+    );
+    (api.login as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/admin password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+  });
 });

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardDone.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardDone.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardDone } from "@/components/onboarding/WizardDone";
+import type { AgentRead } from "@/lib/api";
+
+const AGENT: AgentRead = {
+  id: "x",
+  slug: null,
+  name: "Foo",
+  description: null,
+  version: null,
+  status: "draft",
+  baseUrl: null,
+  baseEngineConfig: {},
+  createdAt: "2026-04-29T00:00:00Z",
+  updatedAt: "2026-04-29T00:00:00Z",
+};
+
+describe("WizardDone", () => {
+  it("renders the agent name", () => {
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="LANGGRAPH"
+        mode="starter"
+        onGoToChat={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Foo is ready/i)).toBeInTheDocument();
+  });
+
+  it("starter + LANGGRAPH shows OPENAI_API_KEY reminder", () => {
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="LANGGRAPH"
+        mode="starter"
+        onGoToChat={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/OPENAI_API_KEY/)).toBeInTheDocument();
+  });
+
+  it("starter + ADK shows GOOGLE_API_KEY reminder", () => {
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="ADK"
+        mode="starter"
+        onGoToChat={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/GOOGLE_API_KEY/)).toBeInTheDocument();
+  });
+
+  it("detection mode shows the generic env reminder", () => {
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="LANGGRAPH"
+        mode="detection"
+        onGoToChat={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/make sure your agent's environment variables are set/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/OPENAI_API_KEY/)).not.toBeInTheDocument();
+  });
+
+  it("calls onGoToChat when CTA clicked", () => {
+    const onGoToChat = vi.fn();
+    render(
+      <WizardDone
+        agent={AGENT}
+        framework="LANGGRAPH"
+        mode="starter"
+        onGoToChat={onGoToChat}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /go to chat/i }));
+    expect(onGoToChat).toHaveBeenCalled();
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardEmpty.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardEmpty.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardEmpty } from "@/components/onboarding/WizardEmpty";
+
+describe("WizardEmpty", () => {
+  it("renders the title and both framework options", () => {
+    render(<WizardEmpty onContinue={vi.fn()} onRescan={vi.fn()} />);
+    expect(screen.getByText(/let's create your first idun agent/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/langgraph/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/adk/i)).toBeInTheDocument();
+    expect(screen.getByText(/recommended/i)).toBeInTheDocument();
+  });
+
+  it("Continue is disabled until a framework is selected", () => {
+    render(<WizardEmpty onContinue={vi.fn()} onRescan={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+  });
+
+  it("calls onContinue with the selected framework", () => {
+    const onContinue = vi.fn();
+    render(<WizardEmpty onContinue={onContinue} onRescan={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText(/langgraph/i));
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onContinue).toHaveBeenCalledWith("LANGGRAPH");
+  });
+
+  it("calls onRescan when re-scan link is clicked", () => {
+    const onRescan = vi.fn();
+    render(<WizardEmpty onContinue={vi.fn()} onRescan={onRescan} />);
+    fireEvent.click(screen.getByText(/re-scan/i));
+    expect(onRescan).toHaveBeenCalled();
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardError.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardError.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardError } from "@/components/onboarding/WizardError";
+
+describe("WizardError", () => {
+  it("renders the error message verbatim", () => {
+    render(
+      <WizardError
+        message="Engine init failed: bad import"
+        code="reload_failed"
+        onRetry={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/engine init failed: bad import/i),
+    ).toBeInTheDocument();
+  });
+
+  it("appends recovery hint when code is reload_failed", () => {
+    render(
+      <WizardError
+        message="boom"
+        code="reload_failed"
+        onRetry={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/edit your `?agent\.py`? to fix the issue/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the recovery hint for other codes", () => {
+    render(
+      <WizardError
+        message="boom"
+        code="other"
+        onRetry={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByText(/edit your `?agent\.py`?/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onRetry when retry clicked", () => {
+    const onRetry = vi.fn();
+    render(
+      <WizardError
+        message="boom"
+        code="reload_failed"
+        onRetry={onRetry}
+        onBack={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("calls onBack when back link clicked", () => {
+    const onBack = vi.fn();
+    render(
+      <WizardError
+        message="boom"
+        code="reload_failed"
+        onRetry={vi.fn()}
+        onBack={onBack}
+      />,
+    );
+    fireEvent.click(screen.getByText(/back to wizard/i));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardError.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardError.test.tsx
@@ -26,9 +26,14 @@ describe("WizardError", () => {
         onBack={vi.fn()}
       />,
     );
-    expect(
-      screen.getByText(/edit your `?agent\.py`? to fix the issue/i),
-    ).toBeInTheDocument();
+    // The hint may render with `agent.py` wrapped in a `<code>` element, so
+    // assert against the surrounding paragraph's text content.
+    const hintParagraph = screen.getByText(
+      (_, node) =>
+        node?.tagName.toLowerCase() === "p" &&
+        Boolean(node.textContent?.match(/edit your.*agent\.py/i)),
+    );
+    expect(hintParagraph).toBeInTheDocument();
   });
 
   it("does not show the recovery hint for other codes", () => {
@@ -41,7 +46,11 @@ describe("WizardError", () => {
       />,
     );
     expect(
-      screen.queryByText(/edit your `?agent\.py`?/i),
+      screen.queryByText(
+        (_, node) =>
+          node?.tagName.toLowerCase() === "p" &&
+          Boolean(node.textContent?.match(/edit your.*agent\.py/i)),
+      ),
     ).not.toBeInTheDocument();
   });
 

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardManyDetected.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardManyDetected.test.tsx
@@ -45,7 +45,9 @@ describe("WizardManyDetected", () => {
     );
     const rows = screen.getAllByRole("radio");
     // First row should be the LANGGRAPH HIGH detection ("A Agent").
-    expect(rows[0]).toHaveAttribute("value", "0");
+    // First row's radio value is the unique "filePath:variableName" key of
+    // the LANGGRAPH HIGH detection (sorted to the top).
+    expect(rows[0]).toHaveAttribute("value", "agent.py:graph");
     const aAgentText = screen.getByText("A Agent");
     const bAgentText = screen.getByText("B Agent");
     // A Agent should appear before B Agent in the document order.

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardManyDetected.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardManyDetected.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardManyDetected } from "@/components/onboarding/WizardManyDetected";
+import type { DetectedAgent } from "@/lib/api";
+
+const detections: DetectedAgent[] = [
+  {
+    framework: "ADK",
+    filePath: "main_adk.py",
+    variableName: "agent",
+    inferredName: "B Agent",
+    confidence: "MEDIUM",
+    source: "source",
+  },
+  {
+    framework: "LANGGRAPH",
+    filePath: "agent.py",
+    variableName: "graph",
+    inferredName: "A Agent",
+    confidence: "HIGH",
+    source: "source",
+  },
+];
+
+describe("WizardManyDetected", () => {
+  it("renders the title with the count", () => {
+    render(
+      <WizardManyDetected
+        detections={detections}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/pick your agent/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 agents/i)).toBeInTheDocument();
+  });
+
+  it("sorts: HIGH confidence first, then LANGGRAPH first, then by name", () => {
+    render(
+      <WizardManyDetected
+        detections={detections}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    const rows = screen.getAllByRole("radio");
+    // First row should be the LANGGRAPH HIGH detection ("A Agent").
+    expect(rows[0]).toHaveAttribute("value", "0");
+    const aAgentText = screen.getByText("A Agent");
+    const bAgentText = screen.getByText("B Agent");
+    // A Agent should appear before B Agent in the document order.
+    expect(
+      aAgentText.compareDocumentPosition(bAgentText) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("Use selected agent is disabled until a row is picked", () => {
+    render(
+      <WizardManyDetected
+        detections={detections}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /use selected/i }),
+    ).toBeDisabled();
+  });
+
+  it("calls onConfirm with the picked detection", () => {
+    const onConfirm = vi.fn();
+    render(
+      <WizardManyDetected
+        detections={detections}
+        onConfirm={onConfirm}
+        onRescan={vi.fn()}
+      />,
+    );
+    // Click the radio for "B Agent" (the second in sorted order).
+    fireEvent.click(screen.getByLabelText(/B Agent/));
+    fireEvent.click(screen.getByRole("button", { name: /use selected/i }));
+    // B Agent is the ADK MEDIUM detection.
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ inferredName: "B Agent" }),
+    );
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardMaterializing.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardMaterializing.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WizardMaterializing } from "@/components/onboarding/WizardMaterializing";
+
+describe("WizardMaterializing", () => {
+  it("renders the loading caption", () => {
+    render(<WizardMaterializing />);
+    expect(screen.getByText(/creating your agent/i)).toBeInTheDocument();
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardNoSupported.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardNoSupported.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardNoSupported } from "@/components/onboarding/WizardNoSupported";
+
+describe("WizardNoSupported", () => {
+  it("renders the no-supported framing copy", () => {
+    render(<WizardNoSupported onContinue={vi.fn()} onRescan={vi.fn()} />);
+    expect(
+      screen.getByText(/we found python code, but no supported agent/i),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onContinue with the selected framework", () => {
+    const onContinue = vi.fn();
+    render(<WizardNoSupported onContinue={onContinue} onRescan={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText(/adk/i));
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    expect(onContinue).toHaveBeenCalledWith("ADK");
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardOneDetected.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardOneDetected.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardOneDetected } from "@/components/onboarding/WizardOneDetected";
+import type { DetectedAgent } from "@/lib/api";
+
+const HIGH: DetectedAgent = {
+  framework: "LANGGRAPH",
+  filePath: "agent.py",
+  variableName: "graph",
+  inferredName: "My Agent",
+  confidence: "HIGH",
+  source: "source",
+};
+
+const MEDIUM: DetectedAgent = { ...HIGH, confidence: "MEDIUM" };
+
+describe("WizardOneDetected", () => {
+  it("renders the framework, name, and path", () => {
+    render(
+      <WizardOneDetected
+        detection={HIGH}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/found your agent/i)).toBeInTheDocument();
+    expect(screen.getByText("My Agent")).toBeInTheDocument();
+    expect(screen.getByText("agent.py:graph")).toBeInTheDocument();
+    expect(screen.getByText(/langgraph/i)).toBeInTheDocument();
+  });
+
+  it("hides the confidence pill for HIGH detections", () => {
+    render(
+      <WizardOneDetected
+        detection={HIGH}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/medium/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the confidence pill for MEDIUM detections", () => {
+    render(
+      <WizardOneDetected
+        detection={MEDIUM}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/medium confidence/i)).toBeInTheDocument();
+  });
+
+  it("calls onConfirm with the detection when CTA clicked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <WizardOneDetected
+        detection={HIGH}
+        onConfirm={onConfirm}
+        onRescan={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /use this agent/i }));
+    expect(onConfirm).toHaveBeenCalledWith(HIGH);
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardScanning.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardScanning.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WizardScanning } from "@/components/onboarding/WizardScanning";
+
+describe("WizardScanning", () => {
+  it("renders the loading caption", () => {
+    render(<WizardScanning />);
+    expect(screen.getByText(/scanning your project/i)).toBeInTheDocument();
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardStarterConfirm.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardStarterConfirm.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { WizardStarterConfirm } from "@/components/onboarding/WizardStarterConfirm";
+
+describe("WizardStarterConfirm", () => {
+  it("renders the 5 file preview rows", () => {
+    render(
+      <WizardStarterConfirm
+        framework="LANGGRAPH"
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    for (const filename of [
+      "agent.py",
+      "requirements.txt",
+      ".env.example",
+      "README.md",
+      ".gitignore",
+    ]) {
+      expect(screen.getByText(filename)).toBeInTheDocument();
+    }
+  });
+
+  it("name input has the Starter Agent placeholder", () => {
+    render(
+      <WizardStarterConfirm
+        framework="LANGGRAPH"
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(screen.getByPlaceholderText(/starter agent/i)).toBeInTheDocument();
+  });
+
+  it("calls onConfirm with the typed name when set", () => {
+    const onConfirm = vi.fn();
+    render(
+      <WizardStarterConfirm
+        framework="ADK"
+        onConfirm={onConfirm}
+        onBack={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText(/starter agent/i), {
+      target: { value: "My Bot" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create starter/i }));
+    expect(onConfirm).toHaveBeenCalledWith({ framework: "ADK", name: "My Bot" });
+  });
+
+  it("calls onConfirm with name omitted when input is blank", () => {
+    const onConfirm = vi.fn();
+    render(
+      <WizardStarterConfirm
+        framework="LANGGRAPH"
+        onConfirm={onConfirm}
+        onBack={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /create starter/i }));
+    expect(onConfirm).toHaveBeenCalledWith({ framework: "LANGGRAPH" });
+  });
+
+  it("calls onBack when Back is clicked", () => {
+    const onBack = vi.fn();
+    render(
+      <WizardStarterConfirm
+        framework="LANGGRAPH"
+        onConfirm={vi.fn()}
+        onBack={onBack}
+        onRescan={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/page-already-configured.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/page-already-configured.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import OnboardingPage from "@/app/onboarding/page";
+
+const { replace } = vi.hoisted(() => ({ replace: vi.fn() }));
+
+vi.mock("next/navigation", () => {
+  const router = { replace };
+  return {
+    useRouter: () => router,
+  };
+});
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      scan: vi.fn(),
+    },
+  };
+});
+
+import { api } from "@/lib/api";
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe("OnboardingPage redirect branch", () => {
+  beforeEach(() => {
+    replace.mockReset();
+    (api.scan as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it("redirects to / when scan returns ALREADY_CONFIGURED", async () => {
+    (api.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      state: "ALREADY_CONFIGURED",
+      scanResult: {
+        root: "/tmp",
+        detected: [],
+        hasPythonFiles: false,
+        hasIdunConfig: false,
+        scanDurationMs: 0,
+      },
+      currentAgent: { id: "x", name: "Existing" },
+    });
+    renderWithQueryClient(<OnboardingPage />);
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+  });
+
+  it("does not redirect when scan returns EMPTY", async () => {
+    (api.scan as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      state: "EMPTY",
+      scanResult: {
+        root: "/tmp",
+        detected: [],
+        hasPythonFiles: false,
+        hasIdunConfig: false,
+        scanDurationMs: 0,
+      },
+      currentAgent: null,
+    });
+    renderWithQueryClient(<OnboardingPage />);
+    // Wait for the query to resolve and the effect to run.
+    await waitFor(() => expect(api.scan).toHaveBeenCalled());
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import Home from "@/app/page";
+
+const replace = vi.fn();
+// Stable router object so useEffect deps don't refire across renders.
+const routerInstance = { replace };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerInstance,
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getAgent: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/components/chat/BrandedLayout", () => ({
+  BrandedLayout: () => <div data-testid="branded-layout" />,
+}));
+
+vi.mock("@/components/chat/MinimalLayout", () => ({
+  MinimalLayout: () => <div data-testid="minimal-layout" />,
+}));
+
+vi.mock("@/components/chat/InspectorLayout", () => ({
+  InspectorLayout: () => <div data-testid="inspector-layout" />,
+}));
+
+import { api, ApiError } from "@/lib/api";
+
+describe("Home (chat root)", () => {
+  beforeEach(() => {
+    replace.mockReset();
+    (api.getAgent as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it("renders chat when getAgent returns 200", async () => {
+    (api.getAgent as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: "x",
+      name: "Foo",
+    });
+    const { findByTestId } = render(<Home />);
+    await findByTestId("branded-layout");
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /onboarding when getAgent returns 404", async () => {
+    (api.getAgent as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiError(404, null),
+    );
+    render(<Home />);
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
+  });
+
+  it("does not redirect on non-404 errors (e.g. transient 500)", async () => {
+    (api.getAgent as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiError(500, null),
+    );
+    render(<Home />);
+    // Wait one tick to make sure no redirect happens.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx
@@ -65,8 +65,26 @@ describe("Home (chat root)", () => {
       new ApiError(500, null),
     );
     render(<Home />);
-    // Wait one tick to make sure no redirect happens.
-    await new Promise((r) => setTimeout(r, 10));
+    // Wait until the probe was invoked, then assert no redirect happened.
+    await waitFor(() =>
+      expect(api.getAgent as ReturnType<typeof vi.fn>).toHaveBeenCalled(),
+    );
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect if unmounted before getAgent resolves", async () => {
+    let resolveIt!: () => void;
+    (api.getAgent as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise<never>((_resolve, reject) => {
+        // Reject (matches the 404 path) only after we've unmounted.
+        resolveIt = () => reject(new ApiError(404, null));
+      }),
+    );
+    const { unmount } = render(<Home />);
+    unmount();
+    resolveIt();
+    // Yield one microtask so any leaked then/catch would have a chance to fire.
+    await new Promise((r) => setTimeout(r, 0));
     expect(replace).not.toHaveBeenCalled();
   });
 });

--- a/services/idun_agent_standalone_ui/app/login/page.tsx
+++ b/services/idun_agent_standalone_ui/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -9,7 +9,13 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-export default function LoginPage() {
+function isSafeNext(next: string): boolean {
+  // Only same-origin paths. Reject `https://evil.com`, `//evil.com`,
+  // `http://`, etc. — open redirect guard.
+  return next.startsWith("/") && !next.startsWith("//");
+}
+
+function LoginForm() {
   const router = useRouter();
   const params = useSearchParams();
   const [password, setPassword] = useState("");
@@ -31,7 +37,8 @@ export default function LoginPage() {
             setBusy(true);
             try {
               await api.login(password);
-              const next = params?.get("next") ?? "/";
+              const raw = params?.get("next") ?? "/";
+              const next = isSafeNext(raw) ? raw : "/";
               router.replace(next);
             } catch (err) {
               const status = err instanceof ApiError ? err.status : 0;
@@ -62,5 +69,13 @@ export default function LoginPage() {
         </form>
       </Card>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/services/idun_agent_standalone_ui/app/login/page.tsx
+++ b/services/idun_agent_standalone_ui/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 
 export default function LoginPage() {
   const router = useRouter();
+  const params = useSearchParams();
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
 
@@ -30,12 +31,14 @@ export default function LoginPage() {
             setBusy(true);
             try {
               await api.login(password);
-              router.replace("/admin/");
+              const next = params?.get("next") ?? "/";
+              router.replace(next);
             } catch (err) {
               const status = err instanceof ApiError ? err.status : 0;
               toast.error(
                 status === 401 ? "Invalid credentials" : "Sign-in failed",
               );
+              setPassword("");
             } finally {
               setBusy(false);
             }

--- a/services/idun_agent_standalone_ui/app/onboarding/layout.tsx
+++ b/services/idun_agent_standalone_ui/app/onboarding/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+export default function OnboardingLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <header className="px-6 py-4">
+        <span className="text-sm font-semibold text-foreground">Idun</span>
+      </header>
+      <main className="flex-1 grid place-items-center px-6 pb-12">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/services/idun_agent_standalone_ui/app/onboarding/page.tsx
+++ b/services/idun_agent_standalone_ui/app/onboarding/page.tsx
@@ -2,21 +2,31 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api";
-import type { DetectedAgent, Framework, ScanResponse } from "@/lib/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError, api } from "@/lib/api";
+import type {
+  CreateFromDetectionBody,
+  CreateStarterBody,
+  DetectedAgent,
+  Framework,
+  ScanResponse,
+} from "@/lib/api";
 import { WizardScanning } from "@/components/onboarding/WizardScanning";
 import { WizardEmpty } from "@/components/onboarding/WizardEmpty";
 import { WizardNoSupported } from "@/components/onboarding/WizardNoSupported";
 import { WizardOneDetected } from "@/components/onboarding/WizardOneDetected";
 import { WizardManyDetected } from "@/components/onboarding/WizardManyDetected";
+import { WizardStarterConfirm } from "@/components/onboarding/WizardStarterConfirm";
+import { WizardMaterializing } from "@/components/onboarding/WizardMaterializing";
 
 const SCAN_QUERY_KEY = ["onboarding-scan"] as const;
 
 type WizardStep =
   | { kind: "scanning" }
   | { kind: "scan-result"; data: ScanResponse }
-  | { kind: "starter-confirm"; framework: Framework; name: string };
+  | { kind: "starter-confirm"; framework: Framework }
+  | { kind: "materializing" };
 
 export default function OnboardingPage() {
   const router = useRouter();
@@ -27,7 +37,6 @@ export default function OnboardingPage() {
   });
 
   const [step, setStep] = useState<WizardStep>({ kind: "scanning" });
-
   const redirecting = data?.state === "ALREADY_CONFIGURED";
 
   useEffect(() => {
@@ -36,7 +45,15 @@ export default function OnboardingPage() {
       return;
     }
     if (data && !redirecting) {
-      setStep({ kind: "scan-result", data });
+      // Only sync to scan-result when we're returning from a 409 conflict
+      // (which routes through "scanning") or on first load. Don't clobber
+      // starter-confirm or materializing with a stale scan refetch.
+      setStep((prev) => {
+        if (prev.kind === "scanning" || prev.kind === "scan-result") {
+          return { kind: "scan-result", data };
+        }
+        return prev;
+      });
     }
   }, [data, isLoading, redirecting]);
 
@@ -48,7 +65,47 @@ export default function OnboardingPage() {
 
   const onRescan = () => {
     queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+    setStep({ kind: "scanning" });
   };
+
+  function extractMessage(err: unknown): string {
+    if (err instanceof ApiError) {
+      const detail = err.detail as { error?: { message?: string } } | null;
+      return detail?.error?.message ?? `Request failed (${err.status})`;
+    }
+    return "Something went wrong";
+  }
+
+  const detectionMutation = useMutation({
+    mutationFn: (body: CreateFromDetectionBody) => api.createFromDetection(body),
+    onSuccess: () => {
+      // Done screen lands in CT9. For now navigate home so the user
+      // doesn't get stuck on the materializing loader.
+      router.replace("/");
+    },
+    onError: (err) => handleMutationError(err),
+  });
+
+  const starterMutation = useMutation({
+    mutationFn: (body: CreateStarterBody) => api.createStarter(body),
+    onSuccess: () => {
+      router.replace("/");
+    },
+    onError: (err) => handleMutationError(err),
+  });
+
+  function handleMutationError(err: unknown) {
+    if (err instanceof ApiError && err.status === 409) {
+      toast.error(extractMessage(err));
+      queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+      setStep({ kind: "scanning" });
+      return;
+    }
+    // Error screen lands in CT9. For now toast and bounce back to scan.
+    toast.error(extractMessage(err));
+    queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+    setStep({ kind: "scanning" });
+  }
 
   if (error) {
     return (
@@ -62,13 +119,37 @@ export default function OnboardingPage() {
     return <WizardScanning />;
   }
 
+  if (step.kind === "materializing") {
+    return <WizardMaterializing />;
+  }
+
+  if (step.kind === "starter-confirm") {
+    return (
+      <WizardStarterConfirm
+        framework={step.framework}
+        onConfirm={(body) => {
+          setStep({ kind: "materializing" });
+          starterMutation.mutate(body);
+        }}
+        onBack={() => {
+          if (data) setStep({ kind: "scan-result", data });
+        }}
+        onRescan={onRescan}
+      />
+    );
+  }
+
   if (step.kind === "scan-result") {
     const onPickFramework = (framework: Framework) => {
-      setStep({ kind: "starter-confirm", framework, name: "" });
+      setStep({ kind: "starter-confirm", framework });
     };
-    const onPickDetection = (_detection: DetectedAgent) => {
-      // Materialize lands in CT8 (advances to "materializing" step).
-      // For now, this is a no-op placeholder.
+    const onPickDetection = (detection: DetectedAgent) => {
+      setStep({ kind: "materializing" });
+      detectionMutation.mutate({
+        framework: detection.framework,
+        filePath: detection.filePath,
+        variableName: detection.variableName,
+      });
     };
     if (step.data.state === "EMPTY") {
       return <WizardEmpty onContinue={onPickFramework} onRescan={onRescan} />;
@@ -98,10 +179,5 @@ export default function OnboardingPage() {
     }
   }
 
-  // starter-confirm screen lands in CT8.
-  return (
-    <div className="text-sm text-muted-foreground">
-      Starter confirm (screen lands in CT8)
-    </div>
-  );
+  return null;
 }

--- a/services/idun_agent_standalone_ui/app/onboarding/page.tsx
+++ b/services/idun_agent_standalone_ui/app/onboarding/page.tsx
@@ -4,10 +4,12 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import type { Framework, ScanResponse } from "@/lib/api";
+import type { DetectedAgent, Framework, ScanResponse } from "@/lib/api";
 import { WizardScanning } from "@/components/onboarding/WizardScanning";
 import { WizardEmpty } from "@/components/onboarding/WizardEmpty";
 import { WizardNoSupported } from "@/components/onboarding/WizardNoSupported";
+import { WizardOneDetected } from "@/components/onboarding/WizardOneDetected";
+import { WizardManyDetected } from "@/components/onboarding/WizardManyDetected";
 
 const SCAN_QUERY_KEY = ["onboarding-scan"] as const;
 
@@ -64,6 +66,10 @@ export default function OnboardingPage() {
     const onPickFramework = (framework: Framework) => {
       setStep({ kind: "starter-confirm", framework, name: "" });
     };
+    const onPickDetection = (_detection: DetectedAgent) => {
+      // Materialize lands in CT8 (advances to "materializing" step).
+      // For now, this is a no-op placeholder.
+    };
     if (step.data.state === "EMPTY") {
       return <WizardEmpty onContinue={onPickFramework} onRescan={onRescan} />;
     }
@@ -72,12 +78,24 @@ export default function OnboardingPage() {
         <WizardNoSupported onContinue={onPickFramework} onRescan={onRescan} />
       );
     }
-    // ONE_DETECTED / MANY_DETECTED land in CT7.
-    return (
-      <div className="text-sm text-muted-foreground">
-        State: {step.data.state} (screen lands in CT7)
-      </div>
-    );
+    if (step.data.state === "ONE_DETECTED") {
+      return (
+        <WizardOneDetected
+          detection={step.data.scanResult.detected[0]}
+          onConfirm={onPickDetection}
+          onRescan={onRescan}
+        />
+      );
+    }
+    if (step.data.state === "MANY_DETECTED") {
+      return (
+        <WizardManyDetected
+          detections={step.data.scanResult.detected}
+          onConfirm={onPickDetection}
+          onRescan={onRescan}
+        />
+      );
+    }
   }
 
   // starter-confirm screen lands in CT8.

--- a/services/idun_agent_standalone_ui/app/onboarding/page.tsx
+++ b/services/idun_agent_standalone_ui/app/onboarding/page.tsx
@@ -13,16 +13,17 @@ export default function OnboardingPage() {
   const { data, isLoading, error } = useQuery({
     queryKey: SCAN_QUERY_KEY,
     queryFn: () => api.scan(),
-    retry: false,
   });
 
+  const redirecting = data?.state === "ALREADY_CONFIGURED";
+
   useEffect(() => {
-    if (data?.state === "ALREADY_CONFIGURED") {
+    if (redirecting) {
       router.replace("/");
     }
-  }, [data, router]);
+  }, [redirecting, router]);
 
-  if (isLoading || data?.state === "ALREADY_CONFIGURED") {
+  if (isLoading || redirecting) {
     return <WizardScanning />;
   }
 

--- a/services/idun_agent_standalone_ui/app/onboarding/page.tsx
+++ b/services/idun_agent_standalone_ui/app/onboarding/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { WizardScanning } from "@/components/onboarding/WizardScanning";
+
+const SCAN_QUERY_KEY = ["onboarding-scan"] as const;
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { data, isLoading, error } = useQuery({
+    queryKey: SCAN_QUERY_KEY,
+    queryFn: () => api.scan(),
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (data?.state === "ALREADY_CONFIGURED") {
+      router.replace("/");
+    }
+  }, [data, router]);
+
+  if (isLoading || data?.state === "ALREADY_CONFIGURED") {
+    return <WizardScanning />;
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Could not scan project. Please refresh.
+      </div>
+    );
+  }
+
+  // Subsequent tasks (6–9) replace this with screen dispatch.
+  return (
+    <div className="text-sm text-muted-foreground">
+      State: {data?.state} (screens not yet implemented)
+    </div>
+  );
+}

--- a/services/idun_agent_standalone_ui/app/onboarding/page.tsx
+++ b/services/idun_agent_standalone_ui/app/onboarding/page.tsx
@@ -1,21 +1,42 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import type { Framework, ScanResponse } from "@/lib/api";
 import { WizardScanning } from "@/components/onboarding/WizardScanning";
+import { WizardEmpty } from "@/components/onboarding/WizardEmpty";
+import { WizardNoSupported } from "@/components/onboarding/WizardNoSupported";
 
 const SCAN_QUERY_KEY = ["onboarding-scan"] as const;
 
+type WizardStep =
+  | { kind: "scanning" }
+  | { kind: "scan-result"; data: ScanResponse }
+  | { kind: "starter-confirm"; framework: Framework; name: string };
+
 export default function OnboardingPage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery({
     queryKey: SCAN_QUERY_KEY,
     queryFn: () => api.scan(),
   });
 
+  const [step, setStep] = useState<WizardStep>({ kind: "scanning" });
+
   const redirecting = data?.state === "ALREADY_CONFIGURED";
+
+  useEffect(() => {
+    if (isLoading) {
+      setStep({ kind: "scanning" });
+      return;
+    }
+    if (data && !redirecting) {
+      setStep({ kind: "scan-result", data });
+    }
+  }, [data, isLoading, redirecting]);
 
   useEffect(() => {
     if (redirecting) {
@@ -23,9 +44,9 @@ export default function OnboardingPage() {
     }
   }, [redirecting, router]);
 
-  if (isLoading || redirecting) {
-    return <WizardScanning />;
-  }
+  const onRescan = () => {
+    queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+  };
 
   if (error) {
     return (
@@ -35,10 +56,34 @@ export default function OnboardingPage() {
     );
   }
 
-  // Subsequent tasks (6–9) replace this with screen dispatch.
+  if (step.kind === "scanning" || redirecting) {
+    return <WizardScanning />;
+  }
+
+  if (step.kind === "scan-result") {
+    const onPickFramework = (framework: Framework) => {
+      setStep({ kind: "starter-confirm", framework, name: "" });
+    };
+    if (step.data.state === "EMPTY") {
+      return <WizardEmpty onContinue={onPickFramework} onRescan={onRescan} />;
+    }
+    if (step.data.state === "NO_SUPPORTED") {
+      return (
+        <WizardNoSupported onContinue={onPickFramework} onRescan={onRescan} />
+      );
+    }
+    // ONE_DETECTED / MANY_DETECTED land in CT7.
+    return (
+      <div className="text-sm text-muted-foreground">
+        State: {step.data.state} (screen lands in CT7)
+      </div>
+    );
+  }
+
+  // starter-confirm screen lands in CT8.
   return (
     <div className="text-sm text-muted-foreground">
-      State: {data?.state} (screens not yet implemented)
+      Starter confirm (screen lands in CT8)
     </div>
   );
 }

--- a/services/idun_agent_standalone_ui/app/onboarding/page.tsx
+++ b/services/idun_agent_standalone_ui/app/onboarding/page.tsx
@@ -76,6 +76,21 @@ export default function OnboardingPage() {
     return "Something went wrong";
   }
 
+  function handleMutationError(err: unknown) {
+    // TODO(CT9): split 409 (re-scan) vs other errors (Error screen with retry).
+    // For now both paths converge: toast the message, invalidate the scan,
+    // and bounce back to the scanning loader.
+    if (err instanceof ApiError && err.status === 409) {
+      toast.error(extractMessage(err));
+      queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+      setStep({ kind: "scanning" });
+      return;
+    }
+    toast.error(extractMessage(err));
+    queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
+    setStep({ kind: "scanning" });
+  }
+
   const detectionMutation = useMutation({
     mutationFn: (body: CreateFromDetectionBody) => api.createFromDetection(body),
     onSuccess: () => {
@@ -93,19 +108,6 @@ export default function OnboardingPage() {
     },
     onError: (err) => handleMutationError(err),
   });
-
-  function handleMutationError(err: unknown) {
-    if (err instanceof ApiError && err.status === 409) {
-      toast.error(extractMessage(err));
-      queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
-      setStep({ kind: "scanning" });
-      return;
-    }
-    // Error screen lands in CT9. For now toast and bounce back to scan.
-    toast.error(extractMessage(err));
-    queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
-    setStep({ kind: "scanning" });
-  }
 
   if (error) {
     return (

--- a/services/idun_agent_standalone_ui/app/onboarding/page.tsx
+++ b/services/idun_agent_standalone_ui/app/onboarding/page.tsx
@@ -46,11 +46,10 @@ export default function OnboardingPage() {
   const [step, setStep] = useState<WizardStep>({ kind: "scanning" });
   const redirecting = data?.state === "ALREADY_CONFIGURED";
 
-  // Tracks the framework / mode of the most recent materialize call so the
-  // Done screen can render the right env-var reminder. Refs avoid extra
-  // renders during the materialize → done transition.
+  // Tracks the framework of the most recent materialize call so the Done
+  // screen can render the right env-var reminder. A ref avoids extra renders
+  // during the materialize → done transition.
   const lastFrameworkRef = useRef<Framework>("LANGGRAPH");
-  const lastModeRef = useRef<Mode>("starter");
 
   useEffect(() => {
     if (isLoading) {
@@ -204,7 +203,6 @@ export default function OnboardingPage() {
         framework={step.framework}
         onConfirm={(body) => {
           lastFrameworkRef.current = body.framework;
-          lastModeRef.current = "starter";
           setStep({ kind: "materializing" });
           starterMutation.mutate(body);
         }}
@@ -222,7 +220,6 @@ export default function OnboardingPage() {
     };
     const onPickDetection = (detection: DetectedAgent) => {
       lastFrameworkRef.current = detection.framework;
-      lastModeRef.current = "detection";
       setStep({ kind: "materializing" });
       detectionMutation.mutate({
         framework: detection.framework,

--- a/services/idun_agent_standalone_ui/app/onboarding/page.tsx
+++ b/services/idun_agent_standalone_ui/app/onboarding/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
 import type {
+  AgentRead,
   CreateFromDetectionBody,
   CreateStarterBody,
   DetectedAgent,
@@ -19,14 +20,20 @@ import { WizardOneDetected } from "@/components/onboarding/WizardOneDetected";
 import { WizardManyDetected } from "@/components/onboarding/WizardManyDetected";
 import { WizardStarterConfirm } from "@/components/onboarding/WizardStarterConfirm";
 import { WizardMaterializing } from "@/components/onboarding/WizardMaterializing";
+import { WizardDone } from "@/components/onboarding/WizardDone";
+import { WizardError } from "@/components/onboarding/WizardError";
 
 const SCAN_QUERY_KEY = ["onboarding-scan"] as const;
+
+type Mode = "starter" | "detection";
 
 type WizardStep =
   | { kind: "scanning" }
   | { kind: "scan-result"; data: ScanResponse }
   | { kind: "starter-confirm"; framework: Framework }
-  | { kind: "materializing" };
+  | { kind: "materializing" }
+  | { kind: "done"; agent: AgentRead; framework: Framework; mode: Mode }
+  | { kind: "error"; message: string; code: string; retry: () => void };
 
 export default function OnboardingPage() {
   const router = useRouter();
@@ -39,16 +46,21 @@ export default function OnboardingPage() {
   const [step, setStep] = useState<WizardStep>({ kind: "scanning" });
   const redirecting = data?.state === "ALREADY_CONFIGURED";
 
+  // Tracks the framework / mode of the most recent materialize call so the
+  // Done screen can render the right env-var reminder. Refs avoid extra
+  // renders during the materialize → done transition.
+  const lastFrameworkRef = useRef<Framework>("LANGGRAPH");
+  const lastModeRef = useRef<Mode>("starter");
+
   useEffect(() => {
     if (isLoading) {
       setStep({ kind: "scanning" });
       return;
     }
     if (data && !redirecting) {
-      // Only sync to scan-result when we're returning from a 409 conflict
-      // (which routes through "scanning") or on first load. Don't clobber
-      // starter-confirm or materializing with a stale scan refetch.
       setStep((prev) => {
+        // Only sync to scan-result when we're returning from scan/scan-result;
+        // don't clobber starter-confirm, materializing, done, or error states.
         if (prev.kind === "scanning" || prev.kind === "scan-result") {
           return { kind: "scan-result", data };
         }
@@ -76,37 +88,73 @@ export default function OnboardingPage() {
     return "Something went wrong";
   }
 
-  function handleMutationError(err: unknown) {
-    // TODO(CT9): split 409 (re-scan) vs other errors (Error screen with retry).
-    // For now both paths converge: toast the message, invalidate the scan,
-    // and bounce back to the scanning loader.
+  function extractCode(err: unknown): string {
+    if (err instanceof ApiError) {
+      const detail = err.detail as { error?: { code?: string } } | null;
+      return detail?.error?.code ?? "unknown";
+    }
+    return "unknown";
+  }
+
+  function handleMutationError(err: unknown, retry: () => void) {
     if (err instanceof ApiError && err.status === 409) {
+      // 409: stale state (another tab raced, or a TOCTOU on detection-not-found).
+      // Toast the reason and bounce to a fresh scan so the user sees current state.
       toast.error(extractMessage(err));
       queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
       setStep({ kind: "scanning" });
       return;
     }
-    toast.error(extractMessage(err));
-    queryClient.invalidateQueries({ queryKey: SCAN_QUERY_KEY });
-    setStep({ kind: "scanning" });
+    // Anything else — most likely 500 reload_failed — gets the Error screen
+    // with retry.
+    setStep({
+      kind: "error",
+      message: extractMessage(err),
+      code: extractCode(err),
+      retry,
+    });
   }
 
   const detectionMutation = useMutation({
     mutationFn: (body: CreateFromDetectionBody) => api.createFromDetection(body),
-    onSuccess: () => {
-      // Done screen lands in CT9. For now navigate home so the user
-      // doesn't get stuck on the materializing loader.
-      router.replace("/");
+    onSuccess: (response) => {
+      setStep({
+        kind: "done",
+        agent: response.data,
+        framework: lastFrameworkRef.current,
+        mode: "detection",
+      });
     },
-    onError: (err) => handleMutationError(err),
+    onError: (err) => {
+      handleMutationError(err, () => {
+        const body = detectionMutation.variables;
+        if (body) {
+          setStep({ kind: "materializing" });
+          detectionMutation.mutate(body);
+        }
+      });
+    },
   });
 
   const starterMutation = useMutation({
     mutationFn: (body: CreateStarterBody) => api.createStarter(body),
-    onSuccess: () => {
-      router.replace("/");
+    onSuccess: (response) => {
+      setStep({
+        kind: "done",
+        agent: response.data,
+        framework: lastFrameworkRef.current,
+        mode: "starter",
+      });
     },
-    onError: (err) => handleMutationError(err),
+    onError: (err) => {
+      handleMutationError(err, () => {
+        const body = starterMutation.variables;
+        if (body) {
+          setStep({ kind: "materializing" });
+          starterMutation.mutate(body);
+        }
+      });
+    },
   });
 
   if (error) {
@@ -125,11 +173,38 @@ export default function OnboardingPage() {
     return <WizardMaterializing />;
   }
 
+  if (step.kind === "done") {
+    return (
+      <WizardDone
+        agent={step.agent}
+        framework={step.framework}
+        mode={step.mode}
+        onGoToChat={() => router.push("/")}
+      />
+    );
+  }
+
+  if (step.kind === "error") {
+    return (
+      <WizardError
+        message={step.message}
+        code={step.code}
+        onRetry={step.retry}
+        onBack={() => {
+          if (data) setStep({ kind: "scan-result", data });
+          else setStep({ kind: "scanning" });
+        }}
+      />
+    );
+  }
+
   if (step.kind === "starter-confirm") {
     return (
       <WizardStarterConfirm
         framework={step.framework}
         onConfirm={(body) => {
+          lastFrameworkRef.current = body.framework;
+          lastModeRef.current = "starter";
           setStep({ kind: "materializing" });
           starterMutation.mutate(body);
         }}
@@ -146,6 +221,8 @@ export default function OnboardingPage() {
       setStep({ kind: "starter-confirm", framework });
     };
     const onPickDetection = (detection: DetectedAgent) => {
+      lastFrameworkRef.current = detection.framework;
+      lastModeRef.current = "detection";
       setStep({ kind: "materializing" });
       detectionMutation.mutate({
         framework: detection.framework,

--- a/services/idun_agent_standalone_ui/app/page.tsx
+++ b/services/idun_agent_standalone_ui/app/page.tsx
@@ -36,9 +36,11 @@ function ChatHome() {
         if (err instanceof ApiError && err.status === 404) {
           router.replace("/onboarding");
         } else {
-          // Non-404 errors don't block chat from rendering — let the chat
-          // layouts surface their own loading/error state on the next API
-          // call. Treat as "ready" so the user sees something.
+          // Non-404 errors don't block chat from rendering. 401 is already
+          // handled by apiFetch (hard-redirects to /login/?next=…); other
+          // errors (network, 5xx) fall through and the chat layouts surface
+          // them on the next API call. Doubles as a flash-of-default-layout
+          // guard until the runtime-config layout effect resolves.
           setAgentReady(true);
         }
       });

--- a/services/idun_agent_standalone_ui/app/page.tsx
+++ b/services/idun_agent_standalone_ui/app/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { Suspense, useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { getRuntimeConfig } from "@/lib/runtime-config";
+import { ApiError, api } from "@/lib/api";
 import { BrandedLayout } from "@/components/chat/BrandedLayout";
 import { MinimalLayout } from "@/components/chat/MinimalLayout";
 import { InspectorLayout } from "@/components/chat/InspectorLayout";
 
 function ChatHome() {
+  const router = useRouter();
   const params = useSearchParams();
   const threadId = useMemo(
     () => params.get("session") ?? crypto.randomUUID(),
@@ -16,10 +18,38 @@ function ChatHome() {
   const [layout, setLayout] = useState<"branded" | "minimal" | "inspector">(
     "branded",
   );
+  const [agentReady, setAgentReady] = useState<boolean | null>(null);
 
   useEffect(() => {
     setLayout(getRuntimeConfig().layout);
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getAgent()
+      .then(() => {
+        if (!cancelled) setAgentReady(true);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof ApiError && err.status === 404) {
+          router.replace("/onboarding");
+        } else {
+          // Non-404 errors don't block chat from rendering — let the chat
+          // layouts surface their own loading/error state on the next API
+          // call. Treat as "ready" so the user sees something.
+          setAgentReady(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  if (agentReady !== true) {
+    return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
+  }
 
   if (layout === "minimal") return <MinimalLayout threadId={threadId} />;
   if (layout === "inspector") return <InspectorLayout threadId={threadId} />;

--- a/services/idun_agent_standalone_ui/components/onboarding/DetectionRow.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/DetectionRow.tsx
@@ -1,0 +1,28 @@
+import { Badge } from "@/components/ui/badge";
+import type { DetectedAgent } from "@/lib/api";
+
+interface DetectionRowProps {
+  detection: DetectedAgent;
+  large?: boolean;
+}
+
+export function DetectionRow({ detection, large = false }: DetectionRowProps) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <Badge variant="secondary">{detection.framework}</Badge>
+        <span className={large ? "text-base font-medium" : "text-sm font-medium"}>
+          {detection.inferredName}
+        </span>
+        {detection.confidence === "MEDIUM" && (
+          <Badge variant="outline" className="text-xs">
+            Medium confidence
+          </Badge>
+        )}
+      </div>
+      <code className="text-xs text-muted-foreground font-mono">
+        {detection.filePath}:{detection.variableName}
+      </code>
+    </div>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/FrameworkPicker.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/FrameworkPicker.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import type { Framework } from "@/lib/api";
+
+interface FrameworkPickerProps {
+  onContinue: (framework: Framework) => void;
+  onRescan: () => void;
+}
+
+export function FrameworkPicker({ onContinue, onRescan }: FrameworkPickerProps) {
+  const [selected, setSelected] = useState<Framework | "">("");
+
+  return (
+    <div className="space-y-6">
+      <RadioGroup
+        value={selected}
+        onValueChange={(value) => setSelected(value as Framework)}
+        className="space-y-3"
+      >
+        <div className="flex items-start space-x-3 rounded-md border border-border p-4">
+          <RadioGroupItem value="LANGGRAPH" id="fw-langgraph" />
+          <div className="flex-1">
+            <Label htmlFor="fw-langgraph" className="flex items-center gap-2">
+              LangGraph
+              <Badge variant="secondary">Recommended</Badge>
+            </Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              StateGraph-based agents from the LangGraph Python SDK.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-start space-x-3 rounded-md border border-border p-4">
+          <RadioGroupItem value="ADK" id="fw-adk" />
+          <div className="flex-1">
+            <Label htmlFor="fw-adk">Google ADK</Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              Google Agent Development Kit (Gemini-based).
+            </p>
+          </div>
+        </div>
+      </RadioGroup>
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onRescan}
+          className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+        >
+          Re-scan
+        </button>
+        <Button
+          onClick={() => selected && onContinue(selected)}
+          disabled={!selected}
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { AgentRead, Framework } from "@/lib/api";
+
+type Mode = "starter" | "detection";
+
+interface WizardDoneProps {
+  agent: AgentRead;
+  framework: Framework;
+  mode: Mode;
+  onGoToChat: () => void;
+}
+
+function envReminder(framework: Framework, mode: Mode): string {
+  if (mode === "detection") {
+    return "Make sure your agent's environment variables are set before chatting.";
+  }
+  if (framework === "LANGGRAPH") {
+    return "Set `OPENAI_API_KEY` in your environment before chatting. Copy `.env.example` to `.env` and fill it in, then restart `idun-standalone`.";
+  }
+  return "Set `GOOGLE_API_KEY` in your environment before chatting. Copy `.env.example` to `.env` and fill it in, then restart `idun-standalone`.";
+}
+
+export function WizardDone({
+  agent,
+  framework,
+  mode,
+  onGoToChat,
+}: WizardDoneProps) {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>{agent.name} is ready</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2 text-sm">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Framework</span>
+            <Badge variant="secondary">{framework}</Badge>
+          </div>
+        </div>
+        <Alert>
+          <AlertTitle>Set up your model credentials</AlertTitle>
+          <AlertDescription>{envReminder(framework, mode)}</AlertDescription>
+        </Alert>
+        <div className="flex justify-end">
+          <Button onClick={onGoToChat}>Go to chat</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -20,14 +21,18 @@ interface WizardDoneProps {
   onGoToChat: () => void;
 }
 
-function envReminder(framework: Framework, mode: Mode): string {
+function envReminder(framework: Framework, mode: Mode): ReactNode {
   if (mode === "detection") {
     return "Make sure your agent's environment variables are set before chatting.";
   }
-  if (framework === "LANGGRAPH") {
-    return "Set `OPENAI_API_KEY` in your environment before chatting. Copy `.env.example` to `.env` and fill it in, then restart `idun-standalone`.";
-  }
-  return "Set `GOOGLE_API_KEY` in your environment before chatting. Copy `.env.example` to `.env` and fill it in, then restart `idun-standalone`.";
+  const envVar = framework === "LANGGRAPH" ? "OPENAI_API_KEY" : "GOOGLE_API_KEY";
+  return (
+    <>
+      Set <code>{envVar}</code> in your environment before chatting. Copy{" "}
+      <code>.env.example</code> to <code>.env</code> and fill it in, then
+      restart <code>idun-standalone</code>.
+    </>
+  );
 }
 
 export function WizardDone({

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardEmpty.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardEmpty.tsx
@@ -1,0 +1,25 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Framework } from "@/lib/api";
+import { FrameworkPicker } from "./FrameworkPicker";
+
+interface WizardEmptyProps {
+  onContinue: (framework: Framework) => void;
+  onRescan: () => void;
+}
+
+export function WizardEmpty({ onContinue, onRescan }: WizardEmptyProps) {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Let's create your first Idun agent</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          We didn't find any Python files in this folder. Pick a framework and
+          we'll scaffold a starter for you.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <FrameworkPicker onContinue={onContinue} onRescan={onRescan} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardError.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardError.tsx
@@ -34,7 +34,10 @@ export function WizardError({
           <AlertDescription className="space-y-2">
             <p>{message}</p>
             {isReloadFailed && (
-              <p>Edit your `agent.py` to fix the issue, then click Retry.</p>
+              <p>
+                Edit your <code>agent.py</code> to fix the issue, then click
+                Retry.
+              </p>
             )}
           </AlertDescription>
         </Alert>

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardError.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardError.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface WizardErrorProps {
+  message: string;
+  code: string;
+  onRetry: () => void;
+  onBack: () => void;
+}
+
+export function WizardError({
+  message,
+  code,
+  onRetry,
+  onBack,
+}: WizardErrorProps) {
+  const isReloadFailed = code === "reload_failed";
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Something went wrong</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Alert variant="destructive">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription className="space-y-2">
+            <p>{message}</p>
+            {isReloadFailed && (
+              <p>Edit your `agent.py` to fix the issue, then click Retry.</p>
+            )}
+          </AlertDescription>
+        </Alert>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onBack}
+            className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          >
+            Back to wizard
+          </button>
+          <Button onClick={onRetry}>Retry</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx
@@ -33,18 +33,20 @@ export function WizardManyDetected({
   onConfirm,
   onRescan,
 }: WizardManyDetectedProps) {
-  const sorted = useMemo(
-    () =>
-      [...detections].sort((a, b) => {
-        const c = CONFIDENCE_RANK[a.confidence] - CONFIDENCE_RANK[b.confidence];
-        if (c !== 0) return c;
-        const f = FRAMEWORK_RANK[a.framework] - FRAMEWORK_RANK[b.framework];
-        if (f !== 0) return f;
-        return a.inferredName.localeCompare(b.inferredName);
-      }),
-    [detections],
-  );
-  const [selectedIndex, setSelectedIndex] = useState<string>("");
+  const { sorted, byKey } = useMemo(() => {
+    const sorted = [...detections].sort((a, b) => {
+      const c = CONFIDENCE_RANK[a.confidence] - CONFIDENCE_RANK[b.confidence];
+      if (c !== 0) return c;
+      const f = FRAMEWORK_RANK[a.framework] - FRAMEWORK_RANK[b.framework];
+      if (f !== 0) return f;
+      return a.inferredName.localeCompare(b.inferredName);
+    });
+    const byKey = new Map<string, DetectedAgent>(
+      sorted.map((d) => [`${d.filePath}:${d.variableName}`, d]),
+    );
+    return { sorted, byKey };
+  }, [detections]);
+  const [selectedKey, setSelectedKey] = useState<string>("");
 
   return (
     <Card className="w-full max-w-lg">
@@ -57,21 +59,24 @@ export function WizardManyDetected({
       </CardHeader>
       <CardContent className="space-y-6">
         <RadioGroup
-          value={selectedIndex}
-          onValueChange={setSelectedIndex}
+          value={selectedKey}
+          onValueChange={setSelectedKey}
           className="space-y-3"
         >
-          {sorted.map((d, i) => (
-            <div
-              key={`${d.filePath}:${d.variableName}`}
-              className="flex items-start space-x-3 rounded-md border border-border p-4"
-            >
-              <RadioGroupItem value={String(i)} id={`det-${i}`} />
-              <Label htmlFor={`det-${i}`} className="flex-1 cursor-pointer">
-                <DetectionRow detection={d} />
-              </Label>
-            </div>
-          ))}
+          {sorted.map((d) => {
+            const key = `${d.filePath}:${d.variableName}`;
+            return (
+              <div
+                key={key}
+                className="flex items-start space-x-3 rounded-md border border-border p-4"
+              >
+                <RadioGroupItem value={key} id={`det-${key}`} />
+                <Label htmlFor={`det-${key}`} className="flex-1 cursor-pointer">
+                  <DetectionRow detection={d} />
+                </Label>
+              </div>
+            );
+          })}
         </RadioGroup>
         <div className="flex items-center justify-between">
           <button
@@ -83,12 +88,12 @@ export function WizardManyDetected({
           </button>
           <Button
             onClick={() => {
-              const idx = parseInt(selectedIndex, 10);
-              if (!Number.isNaN(idx) && sorted[idx]) {
-                onConfirm(sorted[idx]);
+              const detection = byKey.get(selectedKey);
+              if (detection) {
+                onConfirm(detection);
               }
             }}
-            disabled={selectedIndex === ""}
+            disabled={selectedKey === ""}
           >
             Use selected agent
           </Button>

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import type { DetectedAgent } from "@/lib/api";
+import { DetectionRow } from "./DetectionRow";
+
+interface WizardManyDetectedProps {
+  detections: DetectedAgent[];
+  onConfirm: (detection: DetectedAgent) => void;
+  onRescan: () => void;
+}
+
+const CONFIDENCE_RANK: Record<DetectedAgent["confidence"], number> = {
+  HIGH: 0,
+  MEDIUM: 1,
+};
+const FRAMEWORK_RANK: Record<DetectedAgent["framework"], number> = {
+  LANGGRAPH: 0,
+  ADK: 1,
+};
+
+export function WizardManyDetected({
+  detections,
+  onConfirm,
+  onRescan,
+}: WizardManyDetectedProps) {
+  const sorted = useMemo(
+    () =>
+      [...detections].sort((a, b) => {
+        const c = CONFIDENCE_RANK[a.confidence] - CONFIDENCE_RANK[b.confidence];
+        if (c !== 0) return c;
+        const f = FRAMEWORK_RANK[a.framework] - FRAMEWORK_RANK[b.framework];
+        if (f !== 0) return f;
+        return a.inferredName.localeCompare(b.inferredName);
+      }),
+    [detections],
+  );
+  const [selectedIndex, setSelectedIndex] = useState<string>("");
+
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Pick your agent</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          We found {sorted.length} agents in this folder. Choose one — Idun runs
+          one agent per install.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <RadioGroup
+          value={selectedIndex}
+          onValueChange={setSelectedIndex}
+          className="space-y-3"
+        >
+          {sorted.map((d, i) => (
+            <div
+              key={`${d.filePath}:${d.variableName}`}
+              className="flex items-start space-x-3 rounded-md border border-border p-4"
+            >
+              <RadioGroupItem value={String(i)} id={`det-${i}`} />
+              <Label htmlFor={`det-${i}`} className="flex-1 cursor-pointer">
+                <DetectionRow detection={d} />
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onRescan}
+            className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          >
+            Re-scan
+          </button>
+          <Button
+            onClick={() => {
+              const idx = parseInt(selectedIndex, 10);
+              if (!Number.isNaN(idx) && sorted[idx]) {
+                onConfirm(sorted[idx]);
+              }
+            }}
+            disabled={selectedIndex === ""}
+          >
+            Use selected agent
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardMaterializing.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardMaterializing.tsx
@@ -1,0 +1,16 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function WizardMaterializing() {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardContent className="p-6 space-y-4">
+        <p className="text-sm text-muted-foreground">Creating your agent…</p>
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardNoSupported.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardNoSupported.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Framework } from "@/lib/api";
+import { FrameworkPicker } from "./FrameworkPicker";
+
+interface WizardNoSupportedProps {
+  onContinue: (framework: Framework) => void;
+  onRescan: () => void;
+}
+
+export function WizardNoSupported({
+  onContinue,
+  onRescan,
+}: WizardNoSupportedProps) {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>We found Python code, but no supported agent</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Idun supports LangGraph and Google ADK. Pick one to scaffold a
+          starter alongside your existing code, or re-scan if you just added
+          an agent.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <FrameworkPicker onContinue={onContinue} onRescan={onRescan} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardOneDetected.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardOneDetected.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { DetectedAgent } from "@/lib/api";
+import { DetectionRow } from "./DetectionRow";
+
+interface WizardOneDetectedProps {
+  detection: DetectedAgent;
+  onConfirm: (detection: DetectedAgent) => void;
+  onRescan: () => void;
+}
+
+export function WizardOneDetected({
+  detection,
+  onConfirm,
+  onRescan,
+}: WizardOneDetectedProps) {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Found your agent</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          We detected one agent in this folder.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="rounded-md border border-border p-4">
+          <DetectionRow detection={detection} large />
+        </div>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onRescan}
+            className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          >
+            Re-scan
+          </button>
+          <Button onClick={() => onConfirm(detection)}>Use this agent</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardScanning.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardScanning.tsx
@@ -1,0 +1,17 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function WizardScanning() {
+  return (
+    <Card className="w-full max-w-lg">
+      <CardContent className="p-6 space-y-4">
+        <p className="text-sm text-muted-foreground">Scanning your project…</p>
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardStarterConfirm.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardStarterConfirm.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import { File } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { Framework } from "@/lib/api";
+
+const STARTER_FILES = [
+  "agent.py",
+  "requirements.txt",
+  ".env.example",
+  "README.md",
+  ".gitignore",
+];
+
+interface WizardStarterConfirmProps {
+  framework: Framework;
+  onConfirm: (input: { framework: Framework; name?: string }) => void;
+  onBack: () => void;
+  onRescan: () => void;
+}
+
+export function WizardStarterConfirm({
+  framework,
+  onConfirm,
+  onBack,
+  onRescan,
+}: WizardStarterConfirmProps) {
+  const [name, setName] = useState("");
+
+  return (
+    <Card className="w-full max-w-lg">
+      <CardHeader>
+        <CardTitle>Confirm your starter</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          We'll create the following files in your project:
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <ul className="space-y-2">
+          {STARTER_FILES.map((filename) => (
+            <li key={filename} className="flex items-center gap-2 text-sm">
+              <File className="h-4 w-4 text-muted-foreground" />
+              <code className="font-mono text-xs">{filename}</code>
+            </li>
+          ))}
+        </ul>
+        <div className="space-y-1">
+          <Label htmlFor="agent-name" className="text-xs text-muted-foreground">
+            Agent name (optional)
+          </Label>
+          <Input
+            id="agent-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Starter Agent"
+            maxLength={80}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={onBack}
+              className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={onRescan}
+              className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+            >
+              Re-scan
+            </button>
+          </div>
+          <Button
+            onClick={() => {
+              const trimmed = name.trim();
+              onConfirm(
+                trimmed ? { framework, name: trimmed } : { framework },
+              );
+            }}
+          >
+            Create starter
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/e2e/boot-standalone.sh
+++ b/services/idun_agent_standalone_ui/e2e/boot-standalone.sh
@@ -2,13 +2,17 @@
 # Boot a standalone server for E2E without dirtying the source tree.
 #
 # Builds the Next.js UI into a temp dir, points IDUN_UI_DIR at it,
-# generates a minimal echo-agent config inline, and execs the server in
-# the foreground so signal-forwarding (Ctrl-C, Playwright shutdown) works
-# normally. The temp dir is cleaned up on exit.
+# generates a minimal echo-agent module + config inline, runs migrations
+# + seed via `idun-standalone setup`, then execs `idun-standalone serve`
+# in the foreground so signal-forwarding (Ctrl-C, Playwright shutdown)
+# works normally. The temp dir is cleaned up on exit.
 #
 # Override the port with $E2E_PORT (default 8001). The repo's existing
 # dev workflow uses 8000, so we deliberately default to a different
 # port to avoid clashing with a hand-launched local server.
+#
+# Configuration is fully env-var driven — the standalone CLI's `serve`
+# command no longer accepts flags (simplified in the post-rework branch).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
@@ -16,6 +20,7 @@ PORT="${E2E_PORT:-8001}"
 TMPDIR_E2E="$(mktemp -d -t idun-e2e-XXXXXX)"
 DBFILE="$TMPDIR_E2E/standalone.db"
 UIDIR="$TMPDIR_E2E/ui"
+AGENT_FILE="$TMPDIR_E2E/echo_agent.py"
 CONFIG="$TMPDIR_E2E/config.yaml"
 
 cleanup() {
@@ -35,34 +40,83 @@ echo "[boot] building UI -> $UIDIR" >&2
 mkdir -p "$UIDIR"
 cp -R "$ROOT/services/idun_agent_standalone_ui/out/." "$UIDIR/"
 
-# Inline echo-agent config — points at the bundled echo_graph symbol so
-# the new P1.3 MESSAGES_SNAPSHOT hydration assertion can run end-to-end
-# without depending on a real LLM key.
-cat > "$CONFIG" <<'YAML'
+# Inline echo-agent module. A trivial LangGraph that echoes the last
+# user message back. Lives in the temp dir so the engine resolves the
+# absolute path via importlib.util.spec_from_file_location — no PYTHONPATH
+# games, no permanent test fixture in the package.
+cat > "$AGENT_FILE" <<'PY'
+"""Minimal LangGraph echo agent for E2E tests.
+
+Uses LangChain message types + `add_messages` reducer so the engine's
+AG-UI adapter can stream the response (the chat UI hydrates its
+assistant bubble from MESSAGES_SNAPSHOT events).
+"""
+from typing import Annotated, TypedDict
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph import END, StateGraph
+from langgraph.graph.message import add_messages
+
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+def _echo(state: State) -> State:
+    last_user = ""
+    for msg in reversed(state.get("messages", [])):
+        if isinstance(msg, HumanMessage):
+            last_user = msg.content if isinstance(msg.content, str) else ""
+            break
+    return {"messages": [AIMessage(content=f"echo: {last_user}")]}
+
+
+_builder = StateGraph(State)
+_builder.add_node("echo", _echo)
+_builder.set_entry_point("echo")
+_builder.add_edge("echo", END)
+graph = _builder.compile()
+PY
+
+# Inline config — points at the temp-dir agent file. The engine's
+# LangGraph adapter resolves "/abs/path/to/file.py:varname" via
+# importlib.util.spec_from_file_location, so absolute paths Just Work.
+cat > "$CONFIG" <<YAML
 agent:
   type: LANGGRAPH
   config:
     name: e2e-echo
-    graph_definition: idun_agent_standalone.testing:echo_graph
+    graph_definition: $AGENT_FILE:graph
     checkpointer:
       type: memory
 YAML
 
-echo "[boot] starting idun-standalone on 127.0.0.1:$PORT" >&2
+echo "[boot] running idun-standalone setup (migrations + seed)" >&2
 
-# Boot the server. Use the workspace project so the editable install of
-# idun-standalone picks up local source changes. CLI flags are duplicated
-# alongside env vars so either resolution path works.
+# `setup` creates the SQLite schema and seeds the agent row from the
+# config YAML. Without this, `serve` would boot but every admin call
+# would hit "no such table" against an empty DB.
 IDUN_PORT="$PORT" \
   IDUN_HOST=127.0.0.1 \
   IDUN_ADMIN_AUTH_MODE=none \
   IDUN_UI_DIR="$UIDIR" \
   IDUN_CONFIG_PATH="$CONFIG" \
   DATABASE_URL="sqlite+aiosqlite:///$DBFILE" \
-  uv run --project "$ROOT" idun-standalone serve \
-    --port "$PORT" --host 127.0.0.1 --auth-mode none \
-    --config "$CONFIG" \
-    --database-url "sqlite+aiosqlite:///$DBFILE" &
+  uv run --project "$ROOT" idun-standalone setup --config "$CONFIG"
+
+echo "[boot] starting idun-standalone on 127.0.0.1:$PORT" >&2
+
+# `serve` reads everything from env vars (IDUN_PORT, IDUN_HOST,
+# IDUN_ADMIN_AUTH_MODE, IDUN_UI_DIR, IDUN_CONFIG_PATH, DATABASE_URL).
+# The CLI accepts no flags — the simplified surface lives in
+# libs/idun_agent_standalone/src/idun_agent_standalone/cli.py.
+IDUN_PORT="$PORT" \
+  IDUN_HOST=127.0.0.1 \
+  IDUN_ADMIN_AUTH_MODE=none \
+  IDUN_UI_DIR="$UIDIR" \
+  IDUN_CONFIG_PATH="$CONFIG" \
+  DATABASE_URL="sqlite+aiosqlite:///$DBFILE" \
+  uv run --project "$ROOT" idun-standalone serve &
 SERVER_PID=$!
 
 # Block until /health returns 200. Playwright's webServer integration

--- a/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
@@ -1,0 +1,323 @@
+import { test, expect, type Route, type Page } from "@playwright/test";
+
+/**
+ * E2E tests for the onboarding wizard.
+ *
+ * The repo's existing `e2e/boot-standalone.sh` always seeds an agent, so
+ * `GET /admin/api/v1/agent` would normally short-circuit the chat root
+ * away from `/onboarding`. We use `page.route()` to override the agent +
+ * onboarding endpoints per-test so the wizard can be exercised in
+ * scenarios the live backend can't easily reproduce (reload-failure,
+ * MANY_DETECTED, ALREADY_CONFIGURED with a pre-seeded current agent, …).
+ *
+ * Each test routes the relevant URLs and then navigates the wizard
+ * through the browser. The mocks live entirely on the client side — the
+ * real backend is never reached for these calls.
+ */
+
+interface MockState {
+  scan: () => unknown;
+  agent?: () => unknown;
+  createStarter?: () => { status: number; body: unknown };
+  createFromDetection?: () => { status: number; body: unknown };
+  login?: () => { status: number; body: unknown };
+}
+
+async function setupMocks(page: Page, state: MockState) {
+  // GET /admin/api/v1/agent — controls whether the chat root redirects.
+  await page.route("**/admin/api/v1/agent", async (route: Route) => {
+    if (state.agent) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(state.agent()),
+      });
+    } else {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "not_found" } }),
+      });
+    }
+  });
+
+  await page.route(
+    "**/admin/api/v1/onboarding/scan",
+    async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(state.scan()),
+      });
+    },
+  );
+
+  if (state.createStarter) {
+    await page.route(
+      "**/admin/api/v1/onboarding/create-starter",
+      async (route: Route) => {
+        const r = state.createStarter!();
+        await route.fulfill({
+          status: r.status,
+          contentType: "application/json",
+          body: JSON.stringify(r.body),
+        });
+      },
+    );
+  }
+
+  if (state.createFromDetection) {
+    await page.route(
+      "**/admin/api/v1/onboarding/create-from-detection",
+      async (route: Route) => {
+        const r = state.createFromDetection!();
+        await route.fulfill({
+          status: r.status,
+          contentType: "application/json",
+          body: JSON.stringify(r.body),
+        });
+      },
+    );
+  }
+
+  if (state.login) {
+    await page.route("**/admin/api/v1/auth/login", async (route: Route) => {
+      const r = state.login!();
+      await route.fulfill({
+        status: r.status,
+        contentType: "application/json",
+        body: JSON.stringify(r.body),
+      });
+    });
+  }
+}
+
+const EMPTY_SCAN = {
+  state: "EMPTY",
+  scanResult: {
+    root: "/tmp",
+    detected: [],
+    hasPythonFiles: false,
+    hasIdunConfig: false,
+    scanDurationMs: 1,
+  },
+  currentAgent: null,
+};
+
+const ONE_LANGGRAPH_DETECTION = {
+  framework: "LANGGRAPH" as const,
+  filePath: "agent.py",
+  variableName: "graph",
+  inferredName: "My Agent",
+  confidence: "HIGH" as const,
+  source: "source" as const,
+};
+
+const ONE_DETECTED_SCAN = {
+  state: "ONE_DETECTED",
+  scanResult: {
+    root: "/tmp",
+    detected: [ONE_LANGGRAPH_DETECTION],
+    hasPythonFiles: true,
+    hasIdunConfig: false,
+    scanDurationMs: 1,
+  },
+  currentAgent: null,
+};
+
+const STARTER_AGENT_RESPONSE = {
+  data: {
+    id: "x",
+    slug: null,
+    name: "Starter Agent",
+    description: null,
+    version: null,
+    status: "draft",
+    baseUrl: null,
+    baseEngineConfig: { agent: { type: "LANGGRAPH" } },
+    createdAt: "2026-04-29T00:00:00Z",
+    updatedAt: "2026-04-29T00:00:00Z",
+  },
+  reload: { status: "reloaded", message: "Reloaded." },
+};
+
+test("EMPTY → user picks LangGraph → confirms → done shows OPENAI_API_KEY", async ({
+  page,
+}) => {
+  await setupMocks(page, {
+    scan: () => EMPTY_SCAN,
+    createStarter: () => ({ status: 200, body: STARTER_AGENT_RESPONSE }),
+  });
+  await page.goto("/onboarding");
+  await expect(page.getByText(/let's create your first idun agent/i)).toBeVisible();
+  await page.getByLabel(/langgraph/i).click();
+  await page.getByRole("button", { name: /continue/i }).click();
+  await expect(page.getByText(/confirm your starter/i)).toBeVisible();
+  await page.getByRole("button", { name: /create starter/i }).click();
+  await expect(page.getByText(/Starter Agent is ready/i)).toBeVisible();
+  await expect(page.getByText("OPENAI_API_KEY")).toBeVisible();
+});
+
+test("ONE_DETECTED → user clicks Use → done shows generic env reminder", async ({
+  page,
+}) => {
+  await setupMocks(page, {
+    scan: () => ONE_DETECTED_SCAN,
+    createFromDetection: () => ({
+      status: 200,
+      body: {
+        ...STARTER_AGENT_RESPONSE,
+        data: { ...STARTER_AGENT_RESPONSE.data, name: "My Agent" },
+      },
+    }),
+  });
+  await page.goto("/onboarding");
+  await expect(page.getByText(/found your agent/i)).toBeVisible();
+  await page.getByRole("button", { name: /use this agent/i }).click();
+  await expect(page.getByText(/My Agent is ready/i)).toBeVisible();
+  await expect(
+    page.getByText(/make sure your agent's environment variables are set/i),
+  ).toBeVisible();
+});
+
+test("MANY_DETECTED → user picks the second → confirms → done", async ({
+  page,
+}) => {
+  const SECOND = {
+    framework: "ADK" as const,
+    filePath: "main_adk.py",
+    variableName: "agent",
+    inferredName: "B Agent",
+    confidence: "HIGH" as const,
+    source: "source" as const,
+  };
+  await setupMocks(page, {
+    scan: () => ({
+      ...ONE_DETECTED_SCAN,
+      state: "MANY_DETECTED",
+      scanResult: {
+        ...ONE_DETECTED_SCAN.scanResult,
+        detected: [ONE_LANGGRAPH_DETECTION, SECOND],
+      },
+    }),
+    createFromDetection: () => ({
+      status: 200,
+      body: {
+        ...STARTER_AGENT_RESPONSE,
+        data: { ...STARTER_AGENT_RESPONSE.data, name: "B Agent" },
+      },
+    }),
+  });
+  await page.goto("/onboarding");
+  await expect(page.getByText(/pick your agent/i)).toBeVisible();
+  await page.getByLabel(/B Agent/).click();
+  await page.getByRole("button", { name: /use selected/i }).click();
+  await expect(page.getByText(/B Agent is ready/i)).toBeVisible();
+});
+
+test("ALREADY_CONFIGURED → wizard auto-redirects to /", async ({ page }) => {
+  await setupMocks(page, {
+    scan: () => ({
+      ...EMPTY_SCAN,
+      state: "ALREADY_CONFIGURED",
+      currentAgent: STARTER_AGENT_RESPONSE.data,
+    }),
+    agent: () => STARTER_AGENT_RESPONSE.data,
+  });
+  await page.goto("/onboarding");
+  // After wizard sees ALREADY_CONFIGURED, it replaces the route with /.
+  await page.waitForURL(/\/(?:\?.*)?$/, { timeout: 15_000 });
+});
+
+test("Reload failure → error screen shows diagnostic + Retry → second attempt 200 → done", async ({
+  page,
+}) => {
+  let attempts = 0;
+  await setupMocks(page, {
+    scan: () => EMPTY_SCAN,
+    createStarter: () => {
+      attempts++;
+      if (attempts === 1) {
+        return {
+          status: 500,
+          body: {
+            error: {
+              code: "reload_failed",
+              message: "Engine init failed: bad import in agent.py.",
+            },
+          },
+        };
+      }
+      return { status: 200, body: STARTER_AGENT_RESPONSE };
+    },
+  });
+  await page.goto("/onboarding");
+  await page.getByLabel(/langgraph/i).click();
+  await page.getByRole("button", { name: /continue/i }).click();
+  await page.getByRole("button", { name: /create starter/i }).click();
+  await expect(page.getByText(/something went wrong/i)).toBeVisible();
+  await expect(page.getByText(/bad import in agent\.py/i)).toBeVisible();
+  // The recovery hint mentions agent.py.
+  await expect(page.locator("p", { hasText: /edit your.*agent\.py/i })).toBeVisible();
+  await page.getByRole("button", { name: /retry/i }).click();
+  await expect(page.getByText(/Starter Agent is ready/i)).toBeVisible();
+});
+
+test("Re-scan: EMPTY → user clicks Re-scan → backend returns ONE_DETECTED → screen flips", async ({
+  page,
+}) => {
+  let calls = 0;
+  await setupMocks(page, {
+    scan: () => {
+      calls++;
+      return calls === 1 ? EMPTY_SCAN : ONE_DETECTED_SCAN;
+    },
+  });
+  await page.goto("/onboarding");
+  await expect(page.getByText(/let's create your first idun agent/i)).toBeVisible();
+  // Click the re-scan link in the EMPTY screen's framework picker footer.
+  await page.getByRole("button", { name: /re-scan/i }).click();
+  await expect(page.getByText(/found your agent/i)).toBeVisible();
+});
+
+test("Login redirect (password mode): /onboarding 401 → /login → submit → back to /onboarding", async ({
+  page,
+}) => {
+  let scanAttempts = 0;
+  await page.route("**/admin/api/v1/agent", async (route: Route) => {
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ error: { code: "not_found" } }),
+    });
+  });
+  await page.route(
+    "**/admin/api/v1/onboarding/scan",
+    async (route: Route) => {
+      scanAttempts++;
+      if (scanAttempts === 1) {
+        await route.fulfill({ status: 401, body: JSON.stringify({}) });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(EMPTY_SCAN),
+        });
+      }
+    },
+  );
+  await page.route("**/admin/api/v1/auth/login", async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+
+  await page.goto("/onboarding");
+  await page.waitForURL(/\/login\/?\?next=/, { timeout: 15_000 });
+  await page.getByLabel(/admin password/i).fill("hunter2");
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.waitForURL(/\/onboarding/, { timeout: 15_000 });
+  await expect(page.getByText(/let's create your first idun agent/i)).toBeVisible();
+});

--- a/services/idun_agent_standalone_ui/lib/api/client.ts
+++ b/services/idun_agent_standalone_ui/lib/api/client.ts
@@ -26,15 +26,16 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     ...init,
   });
   if (res.status === 401 && typeof window !== "undefined" && !redirected) {
-    redirected = true;
-    const onLogin = window.location.pathname.startsWith("/login");
-    if (onLogin) {
-      window.location.href = "/login/";
-    } else {
-      const nextPath = window.location.pathname + window.location.search;
-      const next = encodeURIComponent(nextPath);
-      window.location.href = `/login/?next=${next}`;
+    // When the request was made FROM /login, skip the redirect entirely so
+    // the login page's own catch block can render the error (toast + clear
+    // field). A hard navigation back to /login would clobber that UX.
+    if (window.location.pathname.startsWith("/login")) {
+      throw new ApiError(401, null);
     }
+    redirected = true;
+    const nextPath = window.location.pathname + window.location.search;
+    const next = encodeURIComponent(nextPath);
+    window.location.href = `/login/?next=${next}`;
     throw new ApiError(401, null);
   }
   if (!res.ok) {

--- a/services/idun_agent_standalone_ui/lib/api/client.ts
+++ b/services/idun_agent_standalone_ui/lib/api/client.ts
@@ -25,7 +25,9 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   });
   if (res.status === 401 && typeof window !== "undefined" && !redirected) {
     redirected = true;
-    window.location.href = "/login/";
+    const nextPath = window.location.pathname + window.location.search;
+    const next = encodeURIComponent(nextPath);
+    window.location.href = `/login/?next=${next}`;
     throw new ApiError(401, null);
   }
   if (!res.ok) {

--- a/services/idun_agent_standalone_ui/lib/api/client.ts
+++ b/services/idun_agent_standalone_ui/lib/api/client.ts
@@ -2,7 +2,9 @@
  * Low level fetch wrapper.
  *
  * - Sends the session cookie on every request.
- * - Redirects to /login/ once on 401.
+ * - Redirects to /login/?next=<encoded path> once on 401 so the user
+ *   lands back on their original page after authenticating. Skips the
+ *   `?next=` round-trip when the request already came from /login.
  * - Throws ApiError on non-2xx so TanStack Query surfaces the failure.
  */
 
@@ -25,9 +27,14 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   });
   if (res.status === 401 && typeof window !== "undefined" && !redirected) {
     redirected = true;
-    const nextPath = window.location.pathname + window.location.search;
-    const next = encodeURIComponent(nextPath);
-    window.location.href = `/login/?next=${next}`;
+    const onLogin = window.location.pathname.startsWith("/login");
+    if (onLogin) {
+      window.location.href = "/login/";
+    } else {
+      const nextPath = window.location.pathname + window.location.search;
+      const next = encodeURIComponent(nextPath);
+      window.location.href = `/login/?next=${next}`;
+    }
     throw new ApiError(401, null);
   }
   if (!res.ok) {

--- a/services/idun_agent_standalone_ui/lib/api/index.ts
+++ b/services/idun_agent_standalone_ui/lib/api/index.ts
@@ -13,6 +13,8 @@ import type {
   AgentRead,
   AgentSessionDetail,
   AgentSessionSummary,
+  CreateFromDetectionBody,
+  CreateStarterBody,
   DeleteResult,
   GuardrailCreate,
   GuardrailPatch,
@@ -31,6 +33,7 @@ import type {
   PromptCreate,
   PromptPatch,
   PromptRead,
+  ScanResponse,
   SingletonDeleteResult,
 } from "./types";
 
@@ -171,4 +174,20 @@ export const api = {
     apiFetch<AgentSessionDetail>(`/agent/sessions/${encodeURIComponent(id)}`),
   getAgentCapabilities: () =>
     apiFetch<AgentCapabilities>("/agent/capabilities"),
+
+  // onboarding wizard
+  scan: () =>
+    apiFetch<ScanResponse>(`${ADMIN}/onboarding/scan`, {
+      method: "POST",
+    }),
+  createFromDetection: (body: CreateFromDetectionBody) =>
+    apiFetch<MutationResponse<AgentRead>>(
+      `${ADMIN}/onboarding/create-from-detection`,
+      { method: "POST", body: j(body) },
+    ),
+  createStarter: (body: CreateStarterBody) =>
+    apiFetch<MutationResponse<AgentRead>>(`${ADMIN}/onboarding/create-starter`, {
+      method: "POST",
+      body: j(body),
+    }),
 };

--- a/services/idun_agent_standalone_ui/lib/api/types/index.ts
+++ b/services/idun_agent_standalone_ui/lib/api/types/index.ts
@@ -7,3 +7,4 @@ export * from "./guardrails";
 export * from "./prompts";
 export * from "./integrations";
 export * from "./sessions";
+export * from "./onboarding";

--- a/services/idun_agent_standalone_ui/lib/api/types/onboarding.ts
+++ b/services/idun_agent_standalone_ui/lib/api/types/onboarding.ts
@@ -11,36 +11,36 @@ export type Framework = "LANGGRAPH" | "ADK";
 export type DetectionConfidence = "HIGH" | "MEDIUM";
 export type DetectionSource = "config" | "source" | "langgraph_json";
 
-export interface DetectedAgent {
+export type DetectedAgent = {
   framework: Framework;
   filePath: string;
   variableName: string;
   inferredName: string;
   confidence: DetectionConfidence;
   source: DetectionSource;
-}
+};
 
-export interface ScanResult {
+export type ScanResult = {
   root: string;
   detected: DetectedAgent[];
   hasPythonFiles: boolean;
   hasIdunConfig: boolean;
   scanDurationMs: number;
-}
+};
 
-export interface ScanResponse {
+export type ScanResponse = {
   state: OnboardingState;
   scanResult: ScanResult;
   currentAgent: AgentRead | null;
-}
+};
 
-export interface CreateFromDetectionBody {
+export type CreateFromDetectionBody = {
   framework: Framework;
   filePath: string;
   variableName: string;
-}
+};
 
-export interface CreateStarterBody {
+export type CreateStarterBody = {
   framework: Framework;
   name?: string;
-}
+};

--- a/services/idun_agent_standalone_ui/lib/api/types/onboarding.ts
+++ b/services/idun_agent_standalone_ui/lib/api/types/onboarding.ts
@@ -1,0 +1,46 @@
+import type { AgentRead } from "./agent";
+
+export type OnboardingState =
+  | "EMPTY"
+  | "NO_SUPPORTED"
+  | "ONE_DETECTED"
+  | "MANY_DETECTED"
+  | "ALREADY_CONFIGURED";
+
+export type Framework = "LANGGRAPH" | "ADK";
+export type DetectionConfidence = "HIGH" | "MEDIUM";
+export type DetectionSource = "config" | "source" | "langgraph_json";
+
+export interface DetectedAgent {
+  framework: Framework;
+  filePath: string;
+  variableName: string;
+  inferredName: string;
+  confidence: DetectionConfidence;
+  source: DetectionSource;
+}
+
+export interface ScanResult {
+  root: string;
+  detected: DetectedAgent[];
+  hasPythonFiles: boolean;
+  hasIdunConfig: boolean;
+  scanDurationMs: number;
+}
+
+export interface ScanResponse {
+  state: OnboardingState;
+  scanResult: ScanResult;
+  currentAgent: AgentRead | null;
+}
+
+export interface CreateFromDetectionBody {
+  framework: Framework;
+  filePath: string;
+  variableName: string;
+}
+
+export interface CreateStarterBody {
+  framework: Framework;
+  name?: string;
+}


### PR DESCRIPTION
## Summary

Combined landing for the first three sub-projects of the Idun onboarding UX initiative. The branch evolved past the original sub-project A scope as B and C were stacked on top — keeping them in one PR rather than splitting into three because the work is functionally interdependent (B consumes A's `ScanResult`; C consumes B's HTTP endpoints) and shares one review cycle.

**Parent UX spec:** `docs/superpowers/specs/2026-04-27-idun-onboarding-ux-design.md`

| Sub-project | Spec | Plan | Layer |
|---|---|---|---|
| A — Scanner | `2026-04-28-onboarding-scanner-design.md` | `2026-04-28-onboarding-scanner.md` | `services/scanner.py` |
| B — HTTP API | `2026-04-29-onboarding-http-api-design.md` | `2026-04-29-onboarding-http-api.md` | `services/onboarding.py` + `services/scaffold.py` + `routers/onboarding.py` |
| C — Wizard UI | `2026-04-29-onboarding-wizard-ui-design.md` | `2026-04-29-onboarding-wizard-ui.md` | `app/onboarding/*` + `components/onboarding/*` + login `?next=` |

Sub-projects D (`idun init` CLI) and E (Driver.js guided tour) build on this foundation but ship in subsequent PRs.

---

## Sub-project A — Filesystem scanner

Single async function `scan_folder(root: Path) -> ScanResult` in `services/scanner.py`. Detects LangGraph and Google ADK agents from three sources:

| Path | Source | Confidence | What it does |
|---|---|---|---|
| 1 | Idun `config.yaml` / `config.yml` (depth 0–2) | HIGH | Reads `agent.{type, config.{graph_definition\|agent}}`. Sets `has_idun_config=True`. |
| 2 | `langgraph.json` (root only) | HIGH | Reads `graphs` dict; each entry → one detection with the dict key as `inferred_name`. |
| 3 | `.py` source (regex pre-filter + AST) | MEDIUM | Two-pass walk: collect StateGraph bindings, then emit detections including `<binding>.compile()`. ADK `Agent`/`LlmAgent`/`SequentialAgent`/`ParallelAgent`/`LoopAgent`. |

Detections deduped by `(file_path, variable_name)`, HIGH wins over MEDIUM (strict `>`, first-seen wins on tie — config.yaml beats langgraph.json). 6-rule inference cascade fills `inferred_name`.

Walk: `os.walk` with fixed skip-list, depth ≤ 4, files > 1 MB skipped, `.ipynb` ignored. Zero new deps. Malformed YAML/JSON/Python all fail gracefully.

**39 unit tests** in `libs/idun_agent_standalone/tests/unit/services/test_scanner.py`.

## Sub-project B — Onboarding HTTP API

Three endpoints under `/admin/api/v1/onboarding/`:

- `POST /scan` — runs the scanner + classifies into `EMPTY` / `NO_SUPPORTED` / `ONE_DETECTED` / `MANY_DETECTED` / `ALREADY_CONFIGURED`. Returns `ScanResponse { state, scanResult, currentAgent? }`. Always runs the walk (so direct-curl callers see truthful values even in `ALREADY_CONFIGURED`).
- `POST /create-from-detection` — re-scans inside the handler (TOCTOU protection), looks up the detection by `(framework, file_path, variable_name)`, materializes a `StandaloneAgentRow` + triggers reload via the existing `commit_with_reload` pipeline. 409 on stale pick.
- `POST /create-starter` — atomically scaffolds 5 files (`agent.py`, `requirements.txt`, `.env.example`, `README.md`, `.gitignore`) for LangGraph or ADK + materializes the row + reload. 409 on existing files.

**Key design points:**

- Singleton agent invariant enforced at app level (UUID PK + mutex re-check inside `_reload_mutex`), not via DB constraint. See spec §10.
- Scaffolder lives in `services/scaffold.py` as a pure-IO module — sub-project D's CLI imports it directly without dragging in FastAPI/SQLAlchemy.
- Atomic scaffold writes via `tmp + rename`, with explicit `.idun-tmp` orphan cleanup on partial-write failure.
- Reload-failure rollback is asymmetric per spec §5.3: DB row rolled back, scaffolded files persist on disk (the user's recovery path is to edit `agent.py` and re-trigger).

**73 schema tests + 14 scaffold unit tests + 12 onboarding service unit tests + 14 integration tests**. The integration suite uses ASGITransport + an in-memory SQLite + the real `commit_with_reload` pipeline.

## Sub-project C — Wizard UI

Next.js 15 + Tailwind v4 + React 19 wizard at `/onboarding`. Single-page state-driven (tagged-union `WizardStep`), 9 screen components, 1 layout, 1 page.

**Routing flow:**

```
/  → app/page.tsx mounts → api.getAgent()
   ├─ 200 → render existing chat layouts
   ├─ 404 → router.replace('/onboarding')
   └─ 401 → apiFetch redirects to /login/?next=%2F (loops back)

/onboarding → onboarding/page.tsx mounts → api.scan()
   ├─ 200, ALREADY_CONFIGURED → router.replace('/')
   ├─ 200, other state → render screen
   └─ 401 → apiFetch redirects to /login/?next=%2Fonboarding
```

**Screens (9):** WizardScanning · WizardEmpty · WizardNoSupported · WizardOneDetected · WizardManyDetected · WizardStarterConfirm · WizardMaterializing · WizardDone · WizardError — all built on shadcn primitives already in the package.

**Login fixes:** the existing stub `/login` page now reads `?next=` from search params and redirects there on success (default `/`). `apiFetch` 401 handler builds `?next=<encoded path>` (with self-loop guard for requests originating from `/login` itself, plus single-redirect-per-session and open-redirect protection — `next=https://evil.com` and `next=//evil.com` both fall back to `/`).

**Tests:** 88 unit tests via Vitest + React Testing Library, 7 Playwright E2E flows (`e2e/onboarding.spec.ts`). The E2E suite uses `page.route()` mocks to drive the wizard through scenarios the live backend can't easily reproduce (reload-failure, ALREADY_CONFIGURED with pre-seeded agent, MANY_DETECTED).

---

## Tests

Backend:

```
$ uv run pytest libs/idun_agent_standalone/tests libs/idun_agent_schema/tests
... (passing — see per-task review notes)
```

Frontend:

```
$ pnpm test
Test Files  21 passed (21)
     Tests  88 passed (88)
```

E2E: 7 onboarding flows committed in `e2e/onboarding.spec.ts`. Validated by static inspection against the shipped CT5–CT9 components — runtime gate is currently blocked by a pre-existing `e2e/boot-standalone.sh` issue (stale CLI flags + missing `idun_agent_standalone.testing` module + missing `setup` step) that affects all e2e specs on this branch, not just onboarding. Tracked as a follow-up; no functional regression introduced by this PR.

---

## What this does NOT include

- `idun init` CLI scaffolder — sub-project D, ships separately. Will reuse `services/scaffold.py` directly (no FastAPI/SQLAlchemy import surface).
- Driver.js post-wizard guided tour — sub-project E.
- Logout button + change-password UI — separate settings work.
- Active LLM-readiness probe — current Done screen uses an honor-system `.env` reminder; an active probe would need a new backend endpoint.
- `DELETE /agent` — called out in spec §13 as deferred. Today the wizard is "first-agent-only".

---

## Dev notes

Built across three subagent-driven-development cycles, two-stage review per task (spec compliance → code quality), Opus 4.7 throughout. Per-cycle polish iterations folded inline. Each sub-project's review-loop findings are captured in the corresponding fix/refactor commits (~30 commits total across all three sub-projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)