### PR TITLE
feat: Microsoft Teams integration

### DIFF
--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
     "click>=8.2.0,<9.0.0",
     "platformdirs>=4.0.0,<5.0.0",
     "PyYAML>=6.0.0,<7.0.0",
+    "cachetools>=5.0.0,<7.0.0",
+    "httpx-sse>=0.4.0,<1.0.0",
+    "botbuilder-integration-aiohttp>=4.17.0,<5.0.0",
     # Agent frameworks and orchestration
     "deepagents>=0.2.8,<1.0.0",
     "langgraph>=1.0.0,<2.0.0",

--- a/libs/idun_agent_engine/src/idun_agent_engine/core/app_factory.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/core/app_factory.py
@@ -161,6 +161,7 @@ def create_app(
         from idun_agent_schema.engine.integrations import IntegrationProvider
 
         from ..integrations.discord.handler import router as discord_router
+        from ..integrations.teams.handler import router as teams_router
         from ..integrations.whatsapp.handler import router as whatsapp_router
 
         for integration in validated_config.integrations:
@@ -176,6 +177,12 @@ def create_app(
                         discord_router,
                         prefix="/integrations/discord",
                         tags=["Discord"],
+                    )
+                case IntegrationProvider.TEAMS if integration.enabled:
+                    app.include_router(
+                        teams_router,
+                        prefix="/integrations/teams",
+                        tags=["Teams"],
                     )
                 case _:
                     pass

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/base.py
@@ -47,6 +47,10 @@ def _create_integration(config: IntegrationConfig) -> BaseIntegration:
             from .google_chat.integration import GoogleChatIntegration
 
             return GoogleChatIntegration(config)
+        case IntegrationProvider.TEAMS:
+            from .teams.integration import TeamsIntegration
+
+            return TeamsIntegration(config)
         case _:
             raise ValueError(f"Unsupported integration provider: {config.provider}")
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/__init__.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/__init__.py
@@ -1,0 +1,1 @@
+"""Microsoft Teams integration (Bot Framework, single-tenant)."""

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/_idempotency.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/_idempotency.py
@@ -1,0 +1,16 @@
+"""In-process activity dedup using cachetools TTLCache."""
+
+from __future__ import annotations
+
+from cachetools import TTLCache
+
+
+class SeenActivities:
+    def __init__(self, maxsize: int = 1024, ttl_seconds: float = 60.0) -> None:
+        self._cache: TTLCache[str, bool] = TTLCache(maxsize=maxsize, ttl=ttl_seconds)
+
+    def seen(self, key: str) -> bool:
+        if key in self._cache:
+            return True
+        self._cache[key] = True
+        return False

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/_settings.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/_settings.py
@@ -1,0 +1,14 @@
+"""Adapter object that feeds Bot Framework auth from integration config."""
+
+from __future__ import annotations
+
+from idun_agent_schema.engine.integrations.teams import TeamsIntegrationConfig
+
+
+class TeamsAuthSettings:
+    APP_TYPE = "SingleTenant"
+
+    def __init__(self, config: TeamsIntegrationConfig) -> None:
+        self.APP_ID = config.app_id
+        self.APP_PASSWORD = config.app_password
+        self.APP_TENANTID = config.app_tenant_id

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/bot.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/bot.py
@@ -1,0 +1,79 @@
+"""Teams ActivityHandler that bridges messages to the agent over loopback HTTP."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from typing import Any
+
+import httpx
+from botbuilder.core import ActivityHandler, TurnContext
+from botbuilder.schema import Activity, ActivityTypes
+from httpx_sse import aconnect_sse
+
+from ._idempotency import SeenActivities
+
+logger = logging.getLogger(__name__)
+
+
+def _short_id(value: str) -> str:
+    return hashlib.sha1(value.encode("utf-8")).hexdigest()[:32]
+
+
+class TeamsBot(ActivityHandler):
+    def __init__(
+        self,
+        agent_url: str,
+        http_client: httpx.AsyncClient,
+        seen: SeenActivities,
+    ) -> None:
+        self._agent_url = agent_url.rstrip("/")
+        self._http = http_client
+        self._seen = seen
+
+    async def on_message_activity(self, turn_context: TurnContext) -> None:
+        activity = turn_context.activity
+        text = (activity.text or "").strip()
+        if not text:
+            return
+        if activity.id and self._seen.seen(activity.id):
+            logger.info("teams.dup")
+            return
+
+        logger.info("teams.msg len=%d", len(text))
+        thread_id = _short_id(activity.conversation.id)
+
+        await turn_context.send_activity(Activity(type=ActivityTypes.typing))
+        reply = await self._call_agent(thread_id, text)
+        await turn_context.send_activity(reply or "(no response)")
+
+    async def _call_agent(self, thread_id: str, text: str) -> str:
+        payload: dict[str, Any] = {
+            "threadId": thread_id,
+            "runId": str(uuid.uuid4()),
+            "state": {},
+            "messages": [{"id": str(uuid.uuid4()), "role": "user", "content": text}],
+            "tools": [],
+            "context": [],
+            "forwardedProps": {},
+        }
+        chunks: list[str] = []
+        async with aconnect_sse(
+            self._http,
+            "POST",
+            f"{self._agent_url}/agent/run",
+            json=payload,
+            timeout=httpx.Timeout(120.0, connect=5.0),
+        ) as es:
+            async for sse in es.aiter_sse():
+                event = sse.json()
+                ev_type = event.get("type")
+                if ev_type == "TEXT_MESSAGE_CONTENT":
+                    delta = event.get("delta") or ""
+                    if delta:
+                        chunks.append(delta)
+                elif ev_type == "RUN_ERROR":
+                    logger.warning("teams.run_error")
+                    return event.get("message") or "Agent run failed."
+        return "".join(chunks).strip()

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/handler.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/handler.py
@@ -1,0 +1,29 @@
+"""Teams messaging endpoint — receives Bot Framework activities."""
+
+from __future__ import annotations
+
+from botbuilder.schema import Activity
+from fastapi import APIRouter, Request, Response
+
+router = APIRouter()
+
+
+@router.post("/messages")
+async def teams_messages(request: Request) -> Response:
+    adapter = getattr(request.app.state, "teams_adapter", None)
+    bot = getattr(request.app.state, "teams_bot", None)
+    if adapter is None or bot is None:
+        return Response(status_code=503, content="Teams integration not configured")
+
+    body = await request.json()
+    activity = Activity().deserialize(body)
+    auth_header = request.headers.get("authorization", "")
+
+    invoke_response = await adapter.process_activity(auth_header, activity, bot.on_turn)
+    if invoke_response is None:
+        return Response(status_code=201)
+    return Response(
+        content=invoke_response.body if invoke_response.body else None,
+        status_code=invoke_response.status,
+        media_type="application/json",
+    )

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/integration.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/integration.py
@@ -1,0 +1,60 @@
+"""Teams integration — wires the Bot Framework adapter into app state."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import httpx
+from botbuilder.integration.aiohttp import (
+    CloudAdapter,
+    ConfigurationBotFrameworkAuthentication,
+)
+from idun_agent_schema.engine.integrations import IntegrationConfig
+from idun_agent_schema.engine.integrations.teams import TeamsIntegrationConfig
+
+from ..base import BaseIntegration
+from ._idempotency import SeenActivities
+from ._settings import TeamsAuthSettings
+from .bot import TeamsBot
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from ...agent.base import BaseAgent
+
+logger = logging.getLogger(__name__)
+
+
+class TeamsIntegration(BaseIntegration):
+    def __init__(self, config: IntegrationConfig) -> None:
+        if not isinstance(config.config, TeamsIntegrationConfig):
+            raise TypeError(
+                f"Expected TeamsIntegrationConfig, got {type(config.config).__name__}"
+            )
+        self._teams_config = config.config
+        self._http: httpx.AsyncClient | None = None
+        self._app: FastAPI | None = None
+
+    async def setup(self, app: FastAPI, agent: BaseAgent) -> None:
+        port = app.state.engine_config.server.api.port
+        agent_url = f"http://127.0.0.1:{port}"
+
+        adapter_settings = TeamsAuthSettings(self._teams_config)
+        adapter = CloudAdapter(ConfigurationBotFrameworkAuthentication(adapter_settings))
+
+        self._http = httpx.AsyncClient()
+        bot = TeamsBot(agent_url, self._http, SeenActivities())
+
+        app.state.teams_adapter = adapter
+        app.state.teams_bot = bot
+        self._app = app
+        logger.info("Teams integration configured")
+
+    async def shutdown(self) -> None:
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+        if self._app is not None:
+            self._app.state.teams_adapter = None
+            self._app.state.teams_bot = None

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -59,6 +59,17 @@ async def cleanup_agent(app: FastAPI):
             if inspect.isawaitable(result):
                 await result
 
+    integrations = getattr(app.state, "integrations", [])
+    if integrations:
+        logger.info("Shutting down %d integration(s)", len(integrations))
+        for integration in integrations:
+            try:
+                await integration.shutdown()
+                logger.info("Integration %s shut down", type(integration).__name__)
+            except Exception:
+                logger.exception("integration shutdown failed during reload")
+        app.state.integrations = []
+
 
 async def configure_app(app: FastAPI, engine_config):
     """Initialize the agent, MCP registry, guardrails, and app state with the given engine config.

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/integrations/base.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/integrations/base.py
@@ -11,6 +11,7 @@ from pydantic.alias_generators import to_camel
 from .discord import DiscordIntegrationConfig
 from .google_chat import GoogleChatIntegrationConfig
 from .slack import SlackIntegrationConfig
+from .teams import TeamsIntegrationConfig
 from .whatsapp import WhatsAppIntegrationConfig
 
 
@@ -21,6 +22,7 @@ class IntegrationProvider(StrEnum):
     DISCORD = "DISCORD"
     SLACK = "SLACK"
     GOOGLE_CHAT = "GOOGLE_CHAT"
+    TEAMS = "TEAMS"
 
 
 class IntegrationConfig(BaseModel):
@@ -48,6 +50,7 @@ class IntegrationConfig(BaseModel):
         DiscordIntegrationConfig,
         SlackIntegrationConfig,
         GoogleChatIntegrationConfig,
+        TeamsIntegrationConfig,
     ] = Field(
         description="Provider-specific configuration.",
     )
@@ -74,5 +77,7 @@ class IntegrationConfig(BaseModel):
                 values["config"] = SlackIntegrationConfig(**config)
             elif provider_str == IntegrationProvider.GOOGLE_CHAT:
                 values["config"] = GoogleChatIntegrationConfig(**config)
+            elif provider_str == IntegrationProvider.TEAMS:
+                values["config"] = TeamsIntegrationConfig(**config)
 
         return values

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/integrations/teams.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/integrations/teams.py
@@ -1,0 +1,31 @@
+"""Microsoft Teams integration configuration (single-tenant Bot Framework)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+
+class TeamsIntegrationConfig(BaseModel):
+    """Microsoft Teams integration configuration.
+
+    Single-tenant only: each customer registers their own Microsoft app
+    in their own Azure AD and runs their own engine instance against it.
+    Authentication uses Bot Framework's ``ConfigurationBotFrameworkAuthentication``
+    with ``MicrosoftAppType=SingleTenant`` hardcoded.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+    app_id: str = Field(
+        description="Microsoft App ID from the Azure AD app registration.",
+    )
+    app_password: str = Field(
+        description="Client secret from the Azure AD app registration.",
+    )
+    app_tenant_id: str = Field(
+        description="Azure AD tenant ID that owns the app registration.",
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/engine_config.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/engine_config.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from idun_agent_standalone.core.logging import get_logger
+from idun_agent_standalone.core.settings import StandaloneSettings
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
 from idun_agent_standalone.infrastructure.db.models.guardrail import (
     StandaloneGuardrailRow,
@@ -84,6 +85,7 @@ async def assemble_engine_config(session: AsyncSession) -> EngineConfig:
     memory_payload = _resolve_memory_payload(agent.name, memory, framework)
 
     base_dict = base_config.model_dump(exclude_none=True)
+    base_dict["server"] = {"api": {"port": StandaloneSettings().port}}
     _layer_memory(base_dict, framework, memory_payload)
     _layer_observability(base_dict, agent.name, observability)
     _layer_mcp_servers(base_dict, agent.name, mcp_servers)

--- a/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
@@ -61,7 +61,13 @@ import {
   api,
 } from "@/lib/api";
 
-const PROVIDERS = ["SLACK", "WHATSAPP", "DISCORD", "GOOGLE_CHAT"] as const;
+const PROVIDERS = [
+  "SLACK",
+  "WHATSAPP",
+  "DISCORD",
+  "GOOGLE_CHAT",
+  "TEAMS",
+] as const;
 type Provider = (typeof PROVIDERS)[number];
 
 const PROVIDER_META: Record<Provider, { label: string; summary: string }> = {
@@ -80,6 +86,10 @@ const PROVIDER_META: Record<Provider, { label: string; summary: string }> = {
   GOOGLE_CHAT: {
     label: "Google Chat",
     summary: "Bridge Google Chat spaces with the agent.",
+  },
+  TEAMS: {
+    label: "Microsoft Teams",
+    summary: "Connect a Bot Framework app to relay Teams messages.",
   },
 };
 
@@ -119,6 +129,10 @@ const formSchema = z.object({
   service_account_credentials_json: z.string().optional().default(""),
   project_number: z.string().optional().default(""),
   local_mode: z.boolean().optional().default(false),
+  // Teams
+  app_id: z.string().optional().default(""),
+  app_password: z.string().optional().default(""),
+  app_tenant_id: z.string().optional().default(""),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -144,6 +158,9 @@ function emptyForm(): FormValues {
     service_account_credentials_json: "",
     project_number: "",
     local_mode: false,
+    app_id: "",
+    app_password: "",
+    app_tenant_id: "",
   };
 }
 
@@ -181,6 +198,12 @@ function configToValues(
         str(config.projectNumber) || str(config.project_number);
       base.local_mode = bool(config.localMode ?? config.local_mode, false);
       break;
+    case "TEAMS":
+      base.app_id = str(config.appId) || str(config.app_id);
+      base.app_password = str(config.appPassword) || str(config.app_password);
+      base.app_tenant_id =
+        str(config.appTenantId) || str(config.app_tenant_id);
+      break;
   }
   return base;
 }
@@ -211,6 +234,12 @@ function valuesToConfig(values: FormValues): Record<string, unknown> {
         service_account_credentials_json: values.service_account_credentials_json,
         project_number: values.project_number,
         local_mode: values.local_mode,
+      };
+    case "TEAMS":
+      return {
+        app_id: values.app_id,
+        app_password: values.app_password,
+        app_tenant_id: values.app_tenant_id,
       };
   }
 }
@@ -293,6 +322,30 @@ function ProviderFields({
           control={control}
           name="guild_id"
           label="Guild ID (optional)"
+        />
+      </>
+    );
+  }
+  if (provider === "TEAMS") {
+    return (
+      <>
+        <TextField
+          control={control}
+          name="app_id"
+          label="App ID"
+          placeholder="Microsoft App ID (Azure AD client ID)"
+        />
+        <SecretField
+          control={control}
+          name="app_password"
+          label="App password"
+          placeholder="Client secret value"
+        />
+        <TextField
+          control={control}
+          name="app_tenant_id"
+          label="App tenant ID"
+          placeholder="Azure AD tenant ID"
         />
       </>
     );

--- a/uv.lock
+++ b/uv.lock
@@ -404,6 +404,19 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/83/bbde3faa84ddcb8eb0eca4b3ffb3221252281db4ce351300fe248c5c70b1/azure_core-1.39.0.tar.gz", hash = "sha256:8a90a562998dd44ce84597590fff6249701b98c0e8797c95fcdd695b54c35d74", size = 367531 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d6/8ebcd05b01a580f086ac9a97fb9fac65c09a4b012161cc97c21a336e880b/azure_core-1.39.0-py3-none-any.whl", hash = "sha256:4ac7b70fab5438c3f68770649a78daf97833caa83827f91df9c14e0e0ea7d34f", size = 218318 },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -521,6 +534,73 @@ wheels = [
 ]
 
 [[package]]
+name = "botbuilder-core"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botbuilder-schema" },
+    { name = "botframework-connector" },
+    { name = "botframework-streaming" },
+    { name = "jsonpickle" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/11/cd231b48525e6b34a11cf211db110a95e901204f141c1633bdcbfe1866f1/botbuilder_core-4.17.1-py3-none-any.whl", hash = "sha256:b0a5eea6ce9759dba0847adeed0587fec83ce069f3b4938eb348bb44becde8d7", size = 116145 },
+]
+
+[[package]]
+name = "botbuilder-integration-aiohttp"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "botbuilder-core" },
+    { name = "botbuilder-schema" },
+    { name = "botframework-connector" },
+    { name = "yarl" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0f/19ebe8cfaf7181940e6a31c98a116c9549a8e23b74965be445954ce803db/botbuilder_integration_aiohttp-4.17.1-py3-none-any.whl", hash = "sha256:3b66245e2ba76b2aeeb680ac0a97915f36385bc98361984a7a0d48389d86b524", size = 19030 },
+]
+
+[[package]]
+name = "botbuilder-schema"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msrest" },
+    { name = "urllib3" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/44/abac81a80ed8aea977afbf8c40c22dec11610bbc1e4bd5bff4a7d7386b94/botbuilder_schema-4.17.1-py2.py3-none-any.whl", hash = "sha256:34da28d721b0635fc41bbe3b368225b9883f527d6f17337f858efe80f74656eb", size = 38196 },
+]
+
+[[package]]
+name = "botframework-connector"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botbuilder-schema" },
+    { name = "msal" },
+    { name = "msrest" },
+    { name = "pyjwt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/37/6c325f4e6441cba2b3184e6c9a15c3ddc00b5e5aa47966398c3d9836b598/botframework_connector-4.17.1-py2.py3-none-any.whl", hash = "sha256:929d242a242f16c7c637eec7c239a84fd7f5f5bb7f95968407d3a9aa9d7bdf8d", size = 100883 },
+]
+
+[[package]]
+name = "botframework-streaming"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botbuilder-schema" },
+    { name = "botframework-connector" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/67/16b1a40b9bdc6288d90f17a464fca457e1e50cc36f1c25bc6265bcdffefe/botframework_streaming-4.17.1-py3-none-any.whl", hash = "sha256:66ad1cfe24c8c6b1fde8f95131e39e01197158e7e0bab797dfa709b4f905deb3", size = 41951 },
+]
+
+[[package]]
 name = "bottleneck"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -549,11 +629,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.0.4"
+version = "6.2.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/cc/eb3fd22f3b96b8b70ce456d0854ef08434e5ca79c02bf8db3fc07ccfca87/cachetools-7.0.4.tar.gz", hash = "sha256:7042c0e4eea87812f04744ce6ee9ed3de457875eb1f82d8a206c46d6e48b6734", size = 37379 }
+sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/bc/72adfb3f2ed19eb0317f89ea9b1eeccc670ae46bc394ec2c4ba1dd8c22b7/cachetools-7.0.4-py3-none-any.whl", hash = "sha256:0c8bb1b9ec8194fa4d764accfde602dfe52f70d0f311e62792d4c3f8c051b1e9", size = 13900 },
+    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668 },
 ]
 
 [[package]]
@@ -1963,6 +2043,8 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "arize-phoenix" },
     { name = "arize-phoenix-otel" },
+    { name = "botbuilder-integration-aiohttp" },
+    { name = "cachetools" },
     { name = "click" },
     { name = "copilotkit" },
     { name = "deepagents" },
@@ -1971,6 +2053,7 @@ dependencies = [
     { name = "google-cloud-logging" },
     { name = "guardrails-ai" },
     { name = "httpx" },
+    { name = "httpx-sse" },
     { name = "idun-agent-schema" },
     { name = "langchain" },
     { name = "langchain-core" },
@@ -2028,6 +2111,8 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0,<=0.22.1" },
     { name = "arize-phoenix", specifier = ">=11.22.0,<14.0.0" },
     { name = "arize-phoenix-otel", specifier = ">=0.2.0,<1.0.0" },
+    { name = "botbuilder-integration-aiohttp", specifier = ">=4.17.0,<5.0.0" },
+    { name = "cachetools", specifier = ">=5.0.0,<7.0.0" },
     { name = "click", specifier = ">=8.2.0,<9.0.0" },
     { name = "copilotkit", specifier = "==0.1.78" },
     { name = "deepagents", specifier = ">=0.2.8,<1.0.0" },
@@ -2036,6 +2121,7 @@ requires-dist = [
     { name = "google-cloud-logging", specifier = ">=3.10.0,<4.0.0" },
     { name = "guardrails-ai", specifier = "==0.9.2" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
+    { name = "httpx-sse", specifier = ">=0.4.0,<1.0.0" },
     { name = "idun-agent-schema", editable = "libs/idun_agent_schema" },
     { name = "langchain", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
@@ -2333,6 +2419,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320 },
+]
+
+[[package]]
 name = "isoduration"
 version = "20.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2423,6 +2518,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/32/58/250751940d75c8019659e15482d548a4aa3b6ce122c515102a4bfdac50e3/jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3", size = 74513 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/99/33c7d78a3fb70d545fd5411ac67a651c81602cc09c9cf0df383733f068c5/jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138", size = 67844 },
+]
+
+[[package]]
+name = "jsonpickle"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/d9/05365407d3312653498001adcebe64a14024f7189691b728610209991c46/jsonpickle-3.4.2.tar.gz", hash = "sha256:2efa2778859b6397d5804b0a98d52cd2a7d9a70fcb873bc5a3ca5acca8f499ba", size = 314339 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/a3/e610ae0feba3e7374da08ab6cc9bb76c8bfa84b4e502aa357bda0ef6dcae/jsonpickle-3.4.2-py3-none-any.whl", hash = "sha256:fd6c273278a02b3b66e3405db3dd2f4dbc8f4a4a3123bfcab3045177c6feb9c3", size = 46256 },
 ]
 
 [[package]]
@@ -3207,6 +3311,36 @@ wheels = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/cb/b02b0f748ac668922364ccb3c3bff5b71628a05f5adfec2ba2a5c3031483/msal-1.36.0.tar.gz", hash = "sha256:3f6a4af2b036b476a4215111c4297b4e6e236ed186cd804faefba23e4990978b", size = 174217 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/d3/414d1f0a5f6f4fe5313c2b002c54e78a3332970feb3f5fed14237aa17064/msal-1.36.0-py3-none-any.whl", hash = "sha256:36ecac30e2ff4322d956029aabce3c82301c29f0acb1ad89b94edcabb0e58ec4", size = 121547 },
+]
+
+[[package]]
+name = "msrest"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "certifi" },
+    { name = "isodate" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9", size = 175332 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/cf/f2966a2638144491f8696c27320d5219f48a072715075d168b31d3237720/msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32", size = 85384 },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3476,6 +3610,15 @@ version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954 },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065 },
 ]
 
 [[package]]
@@ -4710,6 +4853,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738 },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add Teams integration to engine: schema, Bot Framework adapter, handler at `/integrations/teams/messages`, idempotent message handling
- Wire Teams provider into the standalone admin UI integrations page
- Pin standalone engine config loopback port to `settings.port` so the bot can reach the agent regardless of YAML/DB state