### PR TITLE
fix(engine): stop mcp helpers from hanging when no MCP source is configured

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/mcp/helpers.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/mcp/helpers.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -7,6 +8,8 @@ import yaml
 from idun_agent_schema.engine.mcp_server import MCPServer
 
 from idun_agent_engine.mcp.registry import MCPClientRegistry
+
+logger = logging.getLogger(__name__)
 
 
 def _extract_mcp_configs(config_data: dict[str, Any]) -> list[MCPServer]:
@@ -65,6 +68,9 @@ def _load_config_from_file(config_path: str | Path) -> dict[str, Any]:
     return _unwrap_engine_config(config_data)
 
 
+_API_FETCH_TIMEOUT_SECONDS = 5.0
+
+
 def _fetch_config_from_api() -> dict[str, Any]:
     """Fetch configuration from the Idun Manager API."""
     api_key = os.environ.get("IDUN_AGENT_API_KEY")
@@ -80,7 +86,9 @@ def _fetch_config_from_api() -> dict[str, Any]:
     url = f"{manager_host.rstrip('/')}/api/v1/agents/config"
 
     try:
-        response = requests.get(url=url, headers=headers)
+        response = requests.get(
+            url=url, headers=headers, timeout=_API_FETCH_TIMEOUT_SECONDS
+        )
         response.raise_for_status()
         config_data = yaml.safe_load(response.text)
         return _unwrap_engine_config(config_data)
@@ -118,7 +126,9 @@ def get_adk_tools(config_path: str | Path | None = None) -> list[Any]:
 
     The function resolves configuration in the following order:
     1. Uses the provided config_path if specified
-    2. Uses the active in-memory registry if set (engine is running)
+    2. Uses the active in-memory registry if set (engine is running). When the
+       engine has set a registry with no usable servers, returns an empty list
+       rather than falling through.
     3. Uses IDUN_CONFIG_PATH environment variable if set
     4. Falls back to fetching from Idun Manager API
 
@@ -138,8 +148,13 @@ def get_adk_tools(config_path: str | Path | None = None) -> list[Any]:
     from .registry import get_active_registry
 
     registry = get_active_registry()
-    if registry and registry.enabled:
-        return registry.get_adk_toolsets()
+    if registry is not None:
+        if registry.enabled:
+            return registry.get_adk_toolsets()
+        logger.info(
+            "Active MCP registry has no usable servers, returning no ADK toolsets."
+        )
+        return []
 
     env_config_path = os.environ.get("IDUN_CONFIG_PATH")
     if env_config_path:
@@ -165,7 +180,9 @@ async def get_langchain_tools(config_path: str | Path | None = None) -> list[Any
 
     The function resolves configuration in the following order:
     1. Uses the provided config_path if specified
-    2. Uses the active in-memory registry if set (engine is running)
+    2. Uses the active in-memory registry if set (engine is running). When the
+       engine has set a registry with no usable servers, returns an empty list
+       rather than falling through.
     3. Uses IDUN_CONFIG_PATH environment variable if set
     4. Falls back to fetching from Idun Manager API
 
@@ -185,8 +202,13 @@ async def get_langchain_tools(config_path: str | Path | None = None) -> list[Any
     from .registry import get_active_registry
 
     registry = get_active_registry()
-    if registry and registry.enabled:
-        return await registry.get_tools()
+    if registry is not None:
+        if registry.enabled:
+            return await registry.get_tools()
+        logger.info(
+            "Active MCP registry has no usable servers, returning no LangChain tools."
+        )
+        return []
 
     env_config_path = os.environ.get("IDUN_CONFIG_PATH")
     if env_config_path:

--- a/libs/idun_agent_engine/tests/unit/mcp/test_mcp_helpers.py
+++ b/libs/idun_agent_engine/tests/unit/mcp/test_mcp_helpers.py
@@ -85,21 +85,32 @@ class TestGetLangchainToolsResolution:
         registry._client.get_tools.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_skips_disabled_active_registry(self, monkeypatch):
-        """When active registry has no servers (disabled), fall through."""
+    async def test_disabled_active_registry_returns_empty(self, monkeypatch, caplog):
+        """When active registry has no servers (disabled), it is the definitive
+        answer — return [] and skip env/API fallbacks."""
         registry = MCPClientRegistry()  # no configs → disabled
         set_active_registry(registry)
 
         monkeypatch.setenv("IDUN_CONFIG_PATH", "/fake/path.yaml")
+        monkeypatch.setenv("IDUN_AGENT_API_KEY", "should-not-be-used")
+        monkeypatch.setenv("IDUN_MANAGER_HOST", "http://should-not-be-used")
 
         with patch(
             "idun_agent_engine.mcp.helpers.get_langchain_tools_from_file",
             new_callable=AsyncMock,
-            return_value=["from-env"],
-        ) as mock_file:
-            result = await get_langchain_tools()
-            mock_file.assert_called_once_with("/fake/path.yaml")
-            assert result == ["from-env"]
+        ) as mock_file, patch(
+            "idun_agent_engine.mcp.helpers.get_langchain_tools_from_api",
+            new_callable=AsyncMock,
+        ) as mock_api:
+            with caplog.at_level("INFO", logger="idun_agent_engine.mcp.helpers"):
+                result = await get_langchain_tools()
+
+            assert result == []
+            mock_file.assert_not_called()
+            mock_api.assert_not_called()
+            assert any(
+                "no usable servers" in rec.message for rec in caplog.records
+            ), "expected info log when disabled registry returns empty"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_env_var(self, monkeypatch):
@@ -203,20 +214,30 @@ class TestGetAdkToolsResolution:
             result = get_adk_tools()
             assert result == expected_toolsets
 
-    def test_skips_disabled_active_registry(self, monkeypatch):
-        """When active registry has no servers (disabled), fall through."""
+    def test_disabled_active_registry_returns_empty(self, monkeypatch, caplog):
+        """When active registry has no servers (disabled), it is the definitive
+        answer — return [] and skip env/API fallbacks."""
         registry = MCPClientRegistry()  # disabled
         set_active_registry(registry)
 
         monkeypatch.setenv("IDUN_CONFIG_PATH", "/fake/path.yaml")
+        monkeypatch.setenv("IDUN_AGENT_API_KEY", "should-not-be-used")
+        monkeypatch.setenv("IDUN_MANAGER_HOST", "http://should-not-be-used")
 
         with patch(
             "idun_agent_engine.mcp.helpers.get_adk_tools_from_file",
-            return_value=["from-env"],
-        ) as mock_file:
-            result = get_adk_tools()
-            mock_file.assert_called_once_with("/fake/path.yaml")
-            assert result == ["from-env"]
+        ) as mock_file, patch(
+            "idun_agent_engine.mcp.helpers.get_adk_tools_from_api",
+        ) as mock_api:
+            with caplog.at_level("INFO", logger="idun_agent_engine.mcp.helpers"):
+                result = get_adk_tools()
+
+            assert result == []
+            mock_file.assert_not_called()
+            mock_api.assert_not_called()
+            assert any(
+                "no usable servers" in rec.message for rec in caplog.records
+            ), "expected info log when disabled registry returns empty"
 
     def test_falls_back_to_env_var(self, monkeypatch):
         """No active registry, no config_path → uses IDUN_CONFIG_PATH."""
@@ -275,3 +296,32 @@ class TestGetAdkToolsResolution:
         with patch.object(registry, "get_adk_toolsets", return_value=[]):
             result = get_adk_tools()
             assert result == []
+
+
+# ---------------------------------------------------------------------------
+# API fetch timeout (defense against indefinite hangs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFetchConfigFromApiTimeout:
+    def test_passes_timeout_to_requests_get(self, monkeypatch):
+        """_fetch_config_from_api must bound the request so it never hangs forever."""
+        from idun_agent_engine.mcp import helpers
+        from idun_agent_engine.mcp.helpers import _fetch_config_from_api
+
+        monkeypatch.setenv("IDUN_AGENT_API_KEY", "k")
+        monkeypatch.setenv("IDUN_MANAGER_HOST", "http://example.invalid")
+
+        fake_response = MagicMock()
+        fake_response.text = "engine_config: {}"
+        fake_response.raise_for_status = MagicMock()
+
+        with patch.object(helpers.requests, "get", return_value=fake_response) as get:
+            _fetch_config_from_api()
+
+        get.assert_called_once()
+        assert "timeout" in get.call_args.kwargs, (
+            "requests.get must be called with a timeout to prevent indefinite hangs"
+        )
+        assert get.call_args.kwargs["timeout"] == helpers._API_FETCH_TIMEOUT_SECONDS


### PR DESCRIPTION
Closes #525.

## Summary

`get_langchain_tools()` (and `get_adk_tools()`) walk a fallback chain to resolve MCP tools: explicit `config_path` → active in-memory registry → `IDUN_CONFIG_PATH` env → Manager API. Two bugs let the helper block indefinitely from inside an agent node body:

1. **Disabled active registry was treated as "no registry".** `lifespan.configure_app` always installs an active registry (even when `mcp_servers=[]` → `enabled=False`). The helper checked `registry and registry.enabled`, so a disabled registry fell through to env/API. In the standalone repro (no MCP, no `IDUN_CONFIG_PATH`, no API creds) the chain reached the API path. Now an active registry is definitive: disabled → return `[]` plus an INFO log.
2. **API request had no timeout.** `_fetch_config_from_api` called `requests.get(...)` with no `timeout=`, so an unreachable host hung forever. Added `timeout=5.0` (module constant `_API_FETCH_TIMEOUT_SECONDS`).

The pre-existing `ValueError("Environment variable 'IDUN_AGENT_API_KEY' is not set")` for genuinely-no-credentials configs is preserved — silencing it would mask misconfigurations.

## Behavior changes

| Scenario | Before | After |
| --- | --- | --- |
| Engine running, `mcp_servers=[]` | Falls through, hits env/API | Returns `[]` + INFO log |
| API host unreachable | Blocks indefinitely | Raises `ValueError` after 5s |
| Genuinely no MCP source + no API creds | Raises `ValueError` | Same — unchanged |
| Engine running with MCP servers | Returns tools | Same — unchanged |

## Tests

- Inverted `test_skips_disabled_active_registry` (×2) → `test_disabled_active_registry_returns_empty`. They asserted the buggy fall-through behavior; now they assert `[]` is returned, env/API are not called, and the INFO log fires.
- Added `TestFetchConfigFromApiTimeout::test_passes_timeout_to_requests_get` — asserts `requests.get` is called with `timeout=_API_FETCH_TIMEOUT_SECONDS`.
- All other helper tests unchanged.

`uv run pytest libs/idun_agent_engine/tests/unit/mcp/` → 67/67 pass.

## Smoke test

Disabled-registry case returns `[]` in 0.1 ms with the INFO log. Unroutable-host case raises in exactly 5.00 s. Genuinely-no-creds case still raises the precise pre-existing `ValueError`.

## Out of scope

- `idun_agent_engine/prompts/helpers.py` has the same unbounded `requests.get` pattern. Worth a follow-up.

## Base

Targets `feat/standalone-admin-db-rework` (umbrella branch for #534) since the registry's `failed` property added there is forward-compatible with this fix.

