### PR TITLE
feat(standalone-ui): brand-icon picker, per-provider observability, verify buttons

### DIFF
--- a/libs/idun_agent_schema/src/idun_agent_schema/manager/guardrail_configs.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/manager/guardrail_configs.py
@@ -112,6 +112,10 @@ def convert_guardrail(guardrails_data: dict) -> dict:
 
     converted = {"input": [], "output": []}
 
+    def _reject_message(guardrail: dict, default: str) -> str:
+        msg = guardrail.get("reject_message")
+        return msg if isinstance(msg, str) and msg else default
+
     for position in ["input", "output"]:
         if position not in guardrails_data:
             continue
@@ -134,7 +138,7 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                 converted[position].append({
                     "config_id": "ban_list",
                     "api_key": api_key,
-                    "reject_message": "ban!!",
+                    "reject_message": _reject_message(guardrail, "ban!!"),
                     "guard_url": "hub://guardrails/ban_list",
                     "guard_params": {"banned_words": banned_words},
                 })
@@ -158,7 +162,7 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                 converted[position].append({
                     "config_id": "detect_pii",
                     "api_key": api_key,
-                    "reject_message": "PII detected",
+                    "reject_message": _reject_message(guardrail, "PII detected"),
                     "guard_url": "hub://guardrails/detect_pii",
                     "guard_params": {
                         "pii_entities": mapped_entities,
@@ -170,7 +174,7 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                 converted[position].append({
                     "config_id": "nsfw_text",
                     "api_key": api_key,
-                    "reject_message": "NSFW content detected",
+                    "reject_message": _reject_message(guardrail, "NSFW content detected"),
                     "guard_url": "hub://guardrails/nsfw_text",
                     "threshold": guardrail["threshold"],
                 })
@@ -179,7 +183,7 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                 converted[position].append({
                     "config_id": "toxic_language",
                     "api_key": api_key,
-                    "reject_message": "Toxic language detected",
+                    "reject_message": _reject_message(guardrail, "Toxic language detected"),
                     "guard_url": "hub://guardrails/toxic_language",
                     "threshold": guardrail["threshold"],
                 })
@@ -188,7 +192,7 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                 converted[position].append({
                     "config_id": "gibberish_text",
                     "api_key": api_key,
-                    "reject_message": "Gibberish text detected",
+                    "reject_message": _reject_message(guardrail, "Gibberish text detected"),
                     "guard_url": "hub://guardrails/gibberish_text",
                     "threshold": guardrail["threshold"],
                 })
@@ -197,7 +201,7 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                 converted[position].append({
                     "config_id": "bias_check",
                     "api_key": api_key,
-                    "reject_message": "Bias detected",
+                    "reject_message": _reject_message(guardrail, "Bias detected"),
                     "guard_url": "hub://guardrails/bias_check",
                     "threshold": guardrail["threshold"],
                 })
@@ -206,7 +210,7 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                 converted[position].append({
                     "config_id": "competition_check",
                     "api_key": api_key,
-                    "reject_message": "Competitor mentioned",
+                    "reject_message": _reject_message(guardrail, "Competitor mentioned"),
                     "guard_url": "hub://guardrails/competitor_check",
                     "competitors": guardrail["competitors"],
                 })
@@ -215,7 +219,7 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                 converted[position].append({
                     "config_id": "correct_language",
                     "api_key": api_key,
-                    "reject_message": "Incorrect language detected",
+                    "reject_message": _reject_message(guardrail, "Incorrect language detected"),
                     "guard_url": "hub://scb-10x/correct_language",
                     "expected_languages": guardrail["expected_languages"],
                 })
@@ -224,7 +228,7 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                 converted[position].append({
                     "config_id": "restrict_to_topic",
                     "api_key": api_key,
-                    "reject_message": "Off-topic content detected",
+                    "reject_message": _reject_message(guardrail, "Off-topic content detected"),
                     "guard_url": "hub://tryolabs/restricttotopic",
                     "valid_topics": guardrail.get("valid_topics", []),
                     "invalid_topics": guardrail.get("invalid_topics", []),

--- a/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
@@ -10,6 +10,11 @@ import { stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 
 import { EditYamlSheet } from "@/components/admin/EditYamlSheet";
+import { ProviderPicker } from "@/components/admin/ProviderPicker";
+import {
+  AdkIcon,
+  LangGraphIcon,
+} from "@/components/admin/provider-icons";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -30,11 +35,24 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ApiError, type AgentRead, api } from "@/lib/api";
 
 type Framework = "langgraph" | "adk";
-const FRAMEWORKS: Framework[] = ["langgraph", "adk"];
+
+const FRAMEWORK_OPTIONS = [
+  {
+    id: "langgraph" as const,
+    label: "LangGraph",
+    description: "Graph-based orchestration. The default for most agents.",
+    icon: <LangGraphIcon size={44} />,
+  },
+  {
+    id: "adk" as const,
+    label: "ADK",
+    description: "Google Agent Development Kit. Vertex-friendly.",
+    icon: <AdkIcon size={44} />,
+  },
+];
 
 const formSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -249,81 +267,73 @@ export default function AgentPage() {
             is a structural change and requires a restart.
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <Tabs
+        <CardContent className="space-y-6">
+          <ProviderPicker
             value={activeTab}
-            onValueChange={(t) => setActiveTab(t as Framework)}
-          >
-            <TabsList>
-              {FRAMEWORKS.map((f) => (
-                <TabsTrigger key={f} value={f}>
-                  {f === "langgraph" ? "LangGraph" : "ADK"}
-                </TabsTrigger>
-              ))}
-            </TabsList>
+            onChange={(t) => setActiveTab(t)}
+            options={FRAMEWORK_OPTIONS}
+            columns={2}
+          />
 
-            <TabsContent value={activeTab} className="mt-4">
-              <Form {...form}>
-                <form
-                  id="agent-form"
-                  onSubmit={form.handleSubmit(handleSubmit)}
-                  className="space-y-4"
-                >
-                  <FormField
-                    control={form.control}
-                    name="name"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Name</FormLabel>
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="description"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Description</FormLabel>
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="definition"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>
-                          {activeTab === "adk" ? "Agent definition" : "Graph definition"}
-                        </FormLabel>
-                        <FormControl>
-                          <Input
-                            {...field}
-                            placeholder={
-                              activeTab === "adk"
-                                ? "./agent/agent.py:root_agent"
-                                : "./agent.py:graph"
-                            }
-                          />
-                        </FormControl>
-                        <FormDescription>
-                          Module path and attribute, separated by a colon.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </form>
-              </Form>
-            </TabsContent>
-          </Tabs>
+          <Form {...form}>
+            <form
+              id="agent-form"
+              onSubmit={form.handleSubmit(handleSubmit)}
+              className="space-y-4"
+            >
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="definition"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {activeTab === "adk" ? "Agent definition" : "Graph definition"}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder={
+                          activeTab === "adk"
+                            ? "./agent/agent.py:root_agent"
+                            : "./agent.py:graph"
+                        }
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Module path and attribute, separated by a colon.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </form>
+          </Form>
         </CardContent>
         <CardFooter className="justify-between">
           <Button

--- a/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
@@ -2,12 +2,21 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { MessageSquare, Plus, Settings, Trash2 } from "lucide-react";
+import { Plus, Settings, Trash2 } from "lucide-react";
+import * as React from "react";
 import { useEffect, useState } from "react";
 import { useForm, type Control } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { ProviderPicker } from "@/components/admin/ProviderPicker";
+import {
+  DiscordIcon,
+  GoogleChatIcon,
+  MicrosoftTeamsIcon,
+  SlackIcon,
+  WhatsAppIcon,
+} from "@/components/admin/provider-icons";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -38,13 +47,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import {
   Sheet,
   SheetContent,
@@ -92,6 +94,28 @@ const PROVIDER_META: Record<Provider, { label: string; summary: string }> = {
     summary: "Connect a Bot Framework app to relay Teams messages.",
   },
 };
+
+function providerIcon(p: Provider, size = 40): React.ReactNode {
+  switch (p) {
+    case "SLACK":
+      return <SlackIcon size={size} />;
+    case "WHATSAPP":
+      return <WhatsAppIcon size={size} />;
+    case "DISCORD":
+      return <DiscordIcon size={size} />;
+    case "GOOGLE_CHAT":
+      return <GoogleChatIcon size={size} />;
+    case "TEAMS":
+      return <MicrosoftTeamsIcon size={size} />;
+  }
+}
+
+const PROVIDER_PICKER_OPTIONS = PROVIDERS.map((p) => ({
+  id: p,
+  label: PROVIDER_META[p].label,
+  description: PROVIDER_META[p].summary,
+  icon: providerIcon(p, 44),
+}));
 
 function isProvider(v: unknown): v is Provider {
   return typeof v === "string" && (PROVIDERS as readonly string[]).includes(v);
@@ -672,24 +696,16 @@ export default function IntegrationsPage() {
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>Provider</FormLabel>
-                      <Select
-                        value={field.value}
-                        onValueChange={(v) => field.onChange(v as Provider)}
-                        disabled={editingId !== "new"}
-                      >
-                        <FormControl>
-                          <SelectTrigger className="w-full">
-                            <SelectValue placeholder="Pick a channel" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {PROVIDERS.map((p) => (
-                            <SelectItem key={p} value={p}>
-                              {PROVIDER_META[p].label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormControl>
+                        <fieldset disabled={editingId !== "new"} className="contents">
+                          <ProviderPicker
+                            value={field.value}
+                            onChange={(v) => field.onChange(v as Provider)}
+                            options={PROVIDER_PICKER_OPTIONS}
+                            columns={2}
+                          />
+                        </fieldset>
+                      </FormControl>
                       <FormDescription>
                         Provider cannot change after creation.
                       </FormDescription>
@@ -794,9 +810,7 @@ function IntegrationCard({
     <Card className="flex flex-col">
       <CardHeader className="flex-row items-start justify-between space-y-0 gap-3">
         <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted shrink-0">
-            <MessageSquare className="h-5 w-5 text-muted-foreground" />
-          </div>
+          {providerIcon(provider, 40)}
           <div className="min-w-0">
             <CardTitle className="text-base truncate">
               {integration.name}

--- a/services/idun_agent_standalone_ui/app/admin/memory/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/memory/page.tsx
@@ -10,6 +10,13 @@ import { stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 
 import { EditYamlSheet } from "@/components/admin/EditYamlSheet";
+import { ProviderPicker } from "@/components/admin/ProviderPicker";
+import {
+  MemoryChipIcon,
+  PostgresIcon,
+  SqliteIcon,
+  VertexAiIcon,
+} from "@/components/admin/provider-icons";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -30,7 +37,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ApiError, type AgentFramework, api } from "@/lib/api";
 
 const LG_TYPES = ["memory", "sqlite", "postgres"] as const;
@@ -45,6 +51,30 @@ const TAB_LABELS: Record<MemoryType, string> = {
   vertex_ai: "Vertex AI",
   database: "Database",
 };
+
+const MEMORY_DESCRIPTIONS: Record<MemoryType, string> = {
+  memory: "Volatile. Lost on restart. Good for dev.",
+  sqlite: "File-backed local store. Single replica.",
+  postgres: "Production. Multi-replica friendly.",
+  in_memory: "Volatile. Lost on restart. Good for dev.",
+  vertex_ai: "Managed. Required for multi-replica ADK.",
+  database: "PostgreSQL session service.",
+};
+
+function memoryIcon(t: MemoryType) {
+  switch (t) {
+    case "memory":
+    case "in_memory":
+      return <MemoryChipIcon size={44} />;
+    case "sqlite":
+      return <SqliteIcon size={44} />;
+    case "postgres":
+    case "database":
+      return <PostgresIcon size={44} />;
+    case "vertex_ai":
+      return <VertexAiIcon size={44} />;
+  }
+}
 
 const formSchema = z
   .object({
@@ -171,6 +201,12 @@ export default function MemoryPage() {
 
   const framework: AgentFramework = data?.agentFramework ?? "LANGGRAPH";
   const types = framework === "ADK" ? ADK_TYPES : LG_TYPES;
+  const typeOptions = types.map((t) => ({
+    id: t,
+    label: TAB_LABELS[t],
+    description: MEMORY_DESCRIPTIONS[t],
+    icon: memoryIcon(t),
+  }));
 
   const initialValues = useMemo(
     () => configToValues(framework, data?.memory),
@@ -267,25 +303,20 @@ export default function MemoryPage() {
               : "LangGraph checkpointer. PostgreSQL is required for multi-replica deployments."}
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <Tabs
+        <CardContent className="space-y-6">
+          <ProviderPicker
             value={activeTab}
-            onValueChange={(t) => setActiveTab(t as MemoryType)}
-          >
-            <TabsList>
-              {types.map((t) => (
-                <TabsTrigger key={t} value={t}>
-                  {TAB_LABELS[t]}
-                </TabsTrigger>
-              ))}
-            </TabsList>
+            onChange={(t) => setActiveTab(t as MemoryType)}
+            options={typeOptions}
+            columns={3}
+          />
 
-            <Form {...form}>
-              <form
-                id="memory-form"
-                onSubmit={form.handleSubmit(onSheetSave)}
-                className="mt-4 space-y-4"
-              >
+          <Form {...form}>
+            <form
+              id="memory-form"
+              onSubmit={form.handleSubmit(onSheetSave)}
+              className="space-y-4"
+            >
                 {(activeTab === "memory" || activeTab === "in_memory") && (
                   <p className="text-sm text-muted-foreground">
                     Volatile backend — state is lost when the process restarts.
@@ -422,9 +453,8 @@ export default function MemoryPage() {
                     />
                   </>
                 )}
-              </form>
-            </Form>
-          </Tabs>
+            </form>
+          </Form>
         </CardContent>
         <CardFooter className="justify-between">
           <Button

--- a/services/idun_agent_standalone_ui/app/admin/memory/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/memory/page.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { RotateCcw } from "lucide-react";
+import { CheckCircle2, RotateCcw, ShieldCheck, XCircle } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -19,6 +19,7 @@ import {
 } from "@/components/admin/provider-icons";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import {
   Card,
   CardContent,
@@ -216,6 +217,15 @@ export default function MemoryPage() {
   const [activeTab, setActiveTab] = useState<MemoryType>(initialValues.type);
   const [yamlOpen, setYamlOpen] = useState(false);
   const [restartRequired, setRestartRequired] = useState(false);
+  const [verifyFeedback, setVerifyFeedback] = useState<"ok" | "fail" | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!verifyFeedback) return;
+    const t = setTimeout(() => setVerifyFeedback(null), 3000);
+    return () => clearTimeout(t);
+  }, [verifyFeedback]);
 
   useEffect(() => {
     setActiveTab(initialValues.type);
@@ -248,6 +258,26 @@ export default function MemoryPage() {
       const message = (detail as { error?: { message?: string } } | undefined)
         ?.error?.message;
       toast.error(message ?? "Save failed");
+    },
+  });
+
+  const verify = useMutation({
+    mutationFn: api.checkMemoryConnection,
+    onSuccess: (result) => {
+      if (result.ok) {
+        setVerifyFeedback("ok");
+      } else {
+        setVerifyFeedback("fail");
+        toast.error(result.error ?? "Connection failed.");
+      }
+    },
+    onError: (e) => {
+      const detail = e instanceof ApiError ? e.detail : undefined;
+      const message =
+        (detail as { error?: { message?: string } } | undefined)?.error
+          ?.message ?? (e instanceof Error ? e.message : "Verify failed");
+      setVerifyFeedback("fail");
+      toast.error(message);
     },
   });
 
@@ -456,7 +486,7 @@ export default function MemoryPage() {
             </form>
           </Form>
         </CardContent>
-        <CardFooter className="justify-between">
+        <CardFooter className="justify-between gap-2">
           <Button
             variant="outline"
             type="button"
@@ -464,12 +494,43 @@ export default function MemoryPage() {
           >
             Edit YAML
           </Button>
-          <Button
-            onClick={form.handleSubmit(onSheetSave)}
-            disabled={save.isPending}
-          >
-            {save.isPending ? "Saving…" : "Save"}
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              type="button"
+              onClick={() => verify.mutate()}
+              disabled={verify.isPending || !data}
+              title={!data ? "Save first" : "Probe the configured backend"}
+              className={cn(
+                "transition-colors",
+                verifyFeedback === "ok" &&
+                  "border-emerald-500/60 bg-emerald-500/15 text-emerald-700 hover:bg-emerald-500/15 hover:text-emerald-700 dark:text-emerald-300",
+                verifyFeedback === "fail" &&
+                  "border-destructive/60 bg-destructive/15 text-destructive hover:bg-destructive/15 hover:text-destructive",
+              )}
+            >
+              {verifyFeedback === "ok" ? (
+                <CheckCircle2 className="mr-2 h-4 w-4" />
+              ) : verifyFeedback === "fail" ? (
+                <XCircle className="mr-2 h-4 w-4" />
+              ) : (
+                <ShieldCheck className="mr-2 h-4 w-4" />
+              )}
+              {verify.isPending
+                ? "Verifying…"
+                : verifyFeedback === "ok"
+                  ? "Verified"
+                  : verifyFeedback === "fail"
+                    ? "Failed"
+                    : "Verify"}
+            </Button>
+            <Button
+              onClick={form.handleSubmit(onSheetSave)}
+              disabled={save.isPending}
+            >
+              {save.isPending ? "Saving…" : "Save"}
+            </Button>
+          </div>
         </CardFooter>
       </Card>
 

--- a/services/idun_agent_standalone_ui/app/admin/observability/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/observability/page.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { RotateCcw } from "lucide-react";
+import { CheckCircle2, RotateCcw, ShieldCheck, XCircle } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 import { EditYamlSheet } from "@/components/admin/EditYamlSheet";
 import { ProviderPicker } from "@/components/admin/ProviderPicker";
+import { cn } from "@/lib/utils";
 import {
   GcpLoggingIcon,
   GcpTraceIcon,
@@ -266,10 +267,19 @@ export default function ObservabilityPage() {
   );
   const [yamlOpen, setYamlOpen] = useState(false);
   const [restartRequired, setRestartRequired] = useState(false);
+  const [verifyFeedback, setVerifyFeedback] = useState<"ok" | "fail" | null>(
+    null,
+  );
 
   useEffect(() => {
     setActiveProvider(initial.provider);
   }, [initial.provider]);
+
+  useEffect(() => {
+    if (!verifyFeedback) return;
+    const t = setTimeout(() => setVerifyFeedback(null), 3000);
+    return () => clearTimeout(t);
+  }, [verifyFeedback]);
 
   const initialValues = useMemo(
     () => configToValues(initial.provider, initial.enabled, initial.config),
@@ -303,6 +313,26 @@ export default function ObservabilityPage() {
       const message = (detail as { error?: { message?: string } } | undefined)?.error
         ?.message;
       toast.error(message ?? "Save failed");
+    },
+  });
+
+  const verify = useMutation({
+    mutationFn: api.checkObservabilityConnection,
+    onSuccess: (result) => {
+      if (result.ok) {
+        setVerifyFeedback("ok");
+      } else {
+        setVerifyFeedback("fail");
+        toast.error(result.error ?? "Connection failed.");
+      }
+    },
+    onError: (e) => {
+      const detail = e instanceof ApiError ? e.detail : undefined;
+      const message =
+        (detail as { error?: { message?: string } } | undefined)?.error
+          ?.message ?? (e instanceof Error ? e.message : "Verify failed");
+      setVerifyFeedback("fail");
+      toast.error(message);
     },
   });
 
@@ -772,7 +802,7 @@ export default function ObservabilityPage() {
             </form>
           </Form>
         </CardContent>
-        <CardFooter className="justify-between">
+        <CardFooter className="justify-between gap-2">
           <Button
             variant="outline"
             type="button"
@@ -780,13 +810,44 @@ export default function ObservabilityPage() {
           >
             Edit YAML
           </Button>
-          <Button
-            type="submit"
-            form={`obs-form-${activeProvider}`}
-            disabled={save.isPending}
-          >
-            {save.isPending ? "Saving…" : "Save"}
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              type="button"
+              onClick={() => verify.mutate()}
+              disabled={verify.isPending || !data}
+              title={!data ? "Save first" : "Probe the configured provider"}
+              className={cn(
+                "transition-colors",
+                verifyFeedback === "ok" &&
+                  "border-emerald-500/60 bg-emerald-500/15 text-emerald-700 hover:bg-emerald-500/15 hover:text-emerald-700 dark:text-emerald-300",
+                verifyFeedback === "fail" &&
+                  "border-destructive/60 bg-destructive/15 text-destructive hover:bg-destructive/15 hover:text-destructive",
+              )}
+            >
+              {verifyFeedback === "ok" ? (
+                <CheckCircle2 className="mr-2 h-4 w-4" />
+              ) : verifyFeedback === "fail" ? (
+                <XCircle className="mr-2 h-4 w-4" />
+              ) : (
+                <ShieldCheck className="mr-2 h-4 w-4" />
+              )}
+              {verify.isPending
+                ? "Verifying…"
+                : verifyFeedback === "ok"
+                  ? "Verified"
+                  : verifyFeedback === "fail"
+                    ? "Failed"
+                    : "Verify"}
+            </Button>
+            <Button
+              type="submit"
+              form={`obs-form-${activeProvider}`}
+              disabled={save.isPending}
+            >
+              {save.isPending ? "Saving…" : "Save"}
+            </Button>
+          </div>
         </CardFooter>
       </Card>
 

--- a/services/idun_agent_standalone_ui/app/admin/observability/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/observability/page.tsx
@@ -94,6 +94,7 @@ const providerSchema = z.object({
   host: z.string().optional().default(""),
   public_key: z.string().optional().default(""),
   secret_key: z.string().optional().default(""),
+  run_name: z.string().optional().default(""),
   // LangSmith fields
   api_key: z.string().optional().default(""),
   endpoint: z.string().optional().default(""),
@@ -140,6 +141,7 @@ function emptyValues(): ProviderValues {
     host: "",
     public_key: "",
     secret_key: "",
+    run_name: "",
     api_key: "",
     endpoint: "",
     project_name: "",
@@ -171,6 +173,7 @@ function configToValues(
     base.host = str(config.host);
     base.public_key = str(config.publicKey) || str(config.public_key);
     base.secret_key = str(config.secretKey) || str(config.secret_key);
+    base.run_name = str(config.runName) || str(config.run_name);
   } else if (provider === "PHOENIX") {
     base.host =
       str(config.collectorEndpoint) || str(config.collector_endpoint);
@@ -214,6 +217,7 @@ function valuesToConfig(
       host: values.host,
       public_key: values.public_key,
       secret_key: values.secret_key,
+      ...(values.run_name ? { run_name: values.run_name } : {}),
     };
   }
   if (provider === "PHOENIX") {
@@ -409,61 +413,361 @@ export default function ObservabilityPage() {
                   </FormItem>
                 )}
               />
-              <FormField
-                control={form.control}
-                name="host"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Host</FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        placeholder={
-                          activeProvider === "LANGFUSE"
-                            ? "https://cloud.langfuse.com"
-                            : activeProvider === "PHOENIX"
-                              ? "https://collector.phoenix.com"
-                              : ""
-                        }
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="public_key"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {activeProvider === "LANGSMITH" ? "API key" : "Public key"}
-                    </FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              {activeProvider !== "LANGSMITH" && (
-                <FormField
-                  control={form.control}
-                  name="secret_key"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Secret key</FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          type="password"
-                          autoComplete="off"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+
+              {activeProvider === "LANGFUSE" && (
+                <>
+                  <FormField
+                    control={form.control}
+                    name="host"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Host</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="https://cloud.langfuse.com"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="public_key"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Public key</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="pk-lf-..." />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="secret_key"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Secret key</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            type="password"
+                            autoComplete="off"
+                            placeholder="sk-lf-..."
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="run_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Run name</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="my-agent-run" />
+                        </FormControl>
+                        <FormDescription>
+                          Optional. Display label for traces in Langfuse.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </>
+              )}
+
+              {activeProvider === "PHOENIX" && (
+                <>
+                  <FormField
+                    control={form.control}
+                    name="host"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Collector endpoint</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="https://collector.phoenix.com"
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          OTLP HTTP endpoint of your Phoenix collector.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="project_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Project name</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="prod-agent" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </>
+              )}
+
+              {activeProvider === "LANGSMITH" && (
+                <>
+                  <FormField
+                    control={form.control}
+                    name="api_key"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>API key</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            type="password"
+                            autoComplete="off"
+                            placeholder="ls-..."
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="endpoint"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Endpoint</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="https://api.smith.langchain.com"
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Only set when self-hosting LangSmith.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="project_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Project name</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="prod-chatbot-v1" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </>
+              )}
+
+              {activeProvider === "GCP_LOGGING" && (
+                <>
+                  <FormField
+                    control={form.control}
+                    name="project_id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>GCP project ID</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="my-gcp-project" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="region"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Region</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="us-central1" />
+                        </FormControl>
+                        <FormDescription>Optional.</FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="log_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Log name</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="application-log" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="resource_type"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Resource type</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="global, gce_instance, cloud_run_revision"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="severity"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Severity</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="INFO" />
+                        </FormControl>
+                        <FormDescription>
+                          Minimum level to record. INFO, WARNING, ERROR, CRITICAL.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </>
+              )}
+
+              {activeProvider === "GCP_TRACE" && (
+                <>
+                  <FormField
+                    control={form.control}
+                    name="project_id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>GCP project ID</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="my-gcp-project" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="region"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Region</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="us-central1" />
+                        </FormControl>
+                        <FormDescription>Optional.</FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="trace_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Trace name</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="my-agent" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="sampling_rate"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Sampling rate</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            step="0.05"
+                            min={0}
+                            max={1}
+                            value={
+                              typeof field.value === "number"
+                                ? String(field.value)
+                                : ""
+                            }
+                            onChange={(e) => {
+                              const next = Number(e.target.value);
+                              field.onChange(Number.isFinite(next) ? next : 0);
+                            }}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          0.0 to 1.0. 1.0 traces every request.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="flush_interval"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Flush interval (seconds)</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            min={0}
+                            value={
+                              typeof field.value === "number"
+                                ? String(field.value)
+                                : ""
+                            }
+                            onChange={(e) => {
+                              const next = Number(e.target.value);
+                              field.onChange(Number.isFinite(next) ? next : 0);
+                            }}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="ignore_urls"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Ignore URLs</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="/health, /metrics"
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Comma-separated URL paths to exclude from tracing.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </>
               )}
             </form>
           </Form>

--- a/services/idun_agent_standalone_ui/app/admin/observability/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/observability/page.tsx
@@ -10,6 +10,14 @@ import { stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 
 import { EditYamlSheet } from "@/components/admin/EditYamlSheet";
+import { ProviderPicker } from "@/components/admin/ProviderPicker";
+import {
+  GcpLoggingIcon,
+  GcpTraceIcon,
+  LangfuseIcon,
+  LangSmithIcon,
+  PhoenixIcon,
+} from "@/components/admin/provider-icons";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,7 +39,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ApiError, api } from "@/lib/api";
 
 type Provider =
@@ -41,21 +48,68 @@ type Provider =
   | "GCP_LOGGING"
   | "GCP_TRACE";
 
-const PROVIDERS: { id: Provider; label: string }[] = [
-  { id: "LANGFUSE", label: "Langfuse" },
-  { id: "PHOENIX", label: "Phoenix" },
-  { id: "LANGSMITH", label: "LangSmith" },
-  { id: "GCP_LOGGING", label: "GCP Logging" },
-  { id: "GCP_TRACE", label: "GCP Trace" },
+const PROVIDERS: {
+  id: Provider;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}[] = [
+  {
+    id: "LANGFUSE",
+    label: "Langfuse",
+    description: "Open-source LLM observability. Hosted or self-hosted.",
+    icon: <LangfuseIcon size={44} />,
+  },
+  {
+    id: "PHOENIX",
+    label: "Phoenix",
+    description: "Arize Phoenix. OTLP collector with rich tracing UI.",
+    icon: <PhoenixIcon size={44} />,
+  },
+  {
+    id: "LANGSMITH",
+    label: "LangSmith",
+    description: "LangChain's hosted tracing and evaluation suite.",
+    icon: <LangSmithIcon size={44} />,
+  },
+  {
+    id: "GCP_LOGGING",
+    label: "GCP Logging",
+    description: "Forward structured logs to Google Cloud Logging.",
+    icon: <GcpLoggingIcon size={44} />,
+  },
+  {
+    id: "GCP_TRACE",
+    label: "GCP Trace",
+    description: "Send spans to Google Cloud Trace.",
+    icon: <GcpTraceIcon size={44} />,
+  },
 ];
 
 const PROVIDER_IDS = PROVIDERS.map((p) => p.id) as [Provider, ...Provider[]];
 
 const providerSchema = z.object({
   enabled: z.boolean(),
-  public_key: z.string(),
-  secret_key: z.string(),
-  host: z.string(),
+  // Langfuse + Phoenix fields
+  host: z.string().optional().default(""),
+  public_key: z.string().optional().default(""),
+  secret_key: z.string().optional().default(""),
+  // LangSmith fields
+  api_key: z.string().optional().default(""),
+  endpoint: z.string().optional().default(""),
+  project_name: z.string().optional().default(""),
+  // GCP shared
+  project_id: z.string().optional().default(""),
+  region: z.string().optional().default(""),
+  // GCP Logging
+  log_name: z.string().optional().default(""),
+  resource_type: z.string().optional().default(""),
+  severity: z.string().optional().default("INFO"),
+  // GCP Trace
+  trace_name: z.string().optional().default(""),
+  sampling_rate: z.number().min(0).max(1).optional().default(1.0),
+  flush_interval: z.number().int().min(0).optional().default(5),
+  ignore_urls: z.string().optional().default(""),
 });
 
 type ProviderValues = z.infer<typeof providerSchema>;
@@ -80,41 +134,119 @@ function readObs(raw: unknown): ObsConfig {
   return { provider, enabled, config };
 }
 
+function emptyValues(): ProviderValues {
+  return {
+    enabled: true,
+    host: "",
+    public_key: "",
+    secret_key: "",
+    api_key: "",
+    endpoint: "",
+    project_name: "",
+    project_id: "",
+    region: "",
+    log_name: "",
+    resource_type: "",
+    severity: "INFO",
+    trace_name: "",
+    sampling_rate: 1.0,
+    flush_interval: 5,
+    ignore_urls: "",
+  };
+}
+
 function configToValues(
+  provider: Provider,
   enabled: boolean,
   config: Record<string, unknown>,
 ): ProviderValues {
   const str = (v: unknown) => (typeof v === "string" ? v : "");
-  const publicKey = str(config.publicKey) || str(config.apiKey);
-  const secretKey = str(config.secretKey);
-  const host =
-    str(config.host) || str(config.endpoint) || str(config.collectorEndpoint);
-  return { enabled, public_key: publicKey, secret_key: secretKey, host };
+  const num = (v: unknown, fallback: number) =>
+    typeof v === "number" && Number.isFinite(v) ? v : fallback;
+
+  const base = emptyValues();
+  base.enabled = enabled;
+
+  if (provider === "LANGFUSE") {
+    base.host = str(config.host);
+    base.public_key = str(config.publicKey) || str(config.public_key);
+    base.secret_key = str(config.secretKey) || str(config.secret_key);
+  } else if (provider === "PHOENIX") {
+    base.host =
+      str(config.collectorEndpoint) || str(config.collector_endpoint);
+    base.project_name = str(config.projectName) || str(config.project_name);
+  } else if (provider === "LANGSMITH") {
+    base.api_key = str(config.apiKey) || str(config.api_key);
+    base.endpoint = str(config.endpoint);
+    base.project_name = str(config.projectName) || str(config.project_name);
+  } else if (provider === "GCP_LOGGING") {
+    base.project_id =
+      str(config.gcpProjectId) || str(config.projectId) || str(config.project_id);
+    base.region = str(config.region);
+    base.log_name = str(config.logName) || str(config.log_name);
+    base.resource_type =
+      str(config.resourceType) || str(config.resource_type);
+    base.severity = str(config.severity) || "INFO";
+  } else if (provider === "GCP_TRACE") {
+    base.project_id =
+      str(config.gcpProjectId) || str(config.projectId) || str(config.project_id);
+    base.region = str(config.region);
+    base.trace_name = str(config.traceName) || str(config.trace_name);
+    base.sampling_rate = num(
+      (config.samplingRate ?? config.sampling_rate) as unknown,
+      1.0,
+    );
+    base.flush_interval = num(
+      (config.flushInterval ?? config.flush_interval) as unknown,
+      5,
+    );
+    base.ignore_urls = str(config.ignoreUrls) || str(config.ignore_urls);
+  }
+  return base;
 }
 
 function valuesToConfig(
   provider: Provider,
   values: ProviderValues,
-  base: Record<string, unknown>,
 ): Record<string, unknown> {
-  const out: Record<string, unknown> = { ...base };
-  // LangSmith historically used `api_key`/`endpoint`; keep that shape.
-  if (provider === "LANGSMITH") {
-    out.api_key = values.public_key;
-    out.endpoint = values.host;
-    delete out.public_key;
-    delete out.host;
-  } else if (provider === "PHOENIX") {
-    out.collector_endpoint = values.host;
-    delete out.host;
-    out.public_key = values.public_key;
-    out.secret_key = values.secret_key;
-  } else {
-    out.host = values.host;
-    out.public_key = values.public_key;
-    out.secret_key = values.secret_key;
+  if (provider === "LANGFUSE") {
+    return {
+      host: values.host,
+      public_key: values.public_key,
+      secret_key: values.secret_key,
+    };
   }
-  return out;
+  if (provider === "PHOENIX") {
+    return {
+      collector_endpoint: values.host,
+      ...(values.project_name ? { project_name: values.project_name } : {}),
+    };
+  }
+  if (provider === "LANGSMITH") {
+    return {
+      api_key: values.api_key,
+      endpoint: values.endpoint,
+      ...(values.project_name ? { project_name: values.project_name } : {}),
+    };
+  }
+  if (provider === "GCP_LOGGING") {
+    return {
+      project_id: values.project_id,
+      region: values.region,
+      log_name: values.log_name,
+      resource_type: values.resource_type,
+      severity: values.severity || "INFO",
+    };
+  }
+  // GCP_TRACE
+  return {
+    project_id: values.project_id,
+    region: values.region,
+    trace_name: values.trace_name,
+    sampling_rate: values.sampling_rate,
+    flush_interval: values.flush_interval,
+    ...(values.ignore_urls ? { ignore_urls: values.ignore_urls } : {}),
+  };
 }
 
 export default function ObservabilityPage() {
@@ -136,7 +268,7 @@ export default function ObservabilityPage() {
   }, [initial.provider]);
 
   const initialValues = useMemo(
-    () => configToValues(initial.enabled, initial.config),
+    () => configToValues(initial.provider, initial.enabled, initial.config),
     [initial],
   );
 
@@ -171,14 +303,10 @@ export default function ObservabilityPage() {
   });
 
   const handleSubmit = (values: ProviderValues) => {
-    // Keep any provider-specific extras the backend already had.
-    const base =
-      activeProvider === initial.provider ? { ...initial.config } : {};
-    const config = valuesToConfig(activeProvider, values, base);
     save.mutate({
       provider: activeProvider,
       enabled: values.enabled,
-      config,
+      config: valuesToConfig(activeProvider, values),
     });
   };
 
@@ -187,25 +315,25 @@ export default function ObservabilityPage() {
     if (next === initial.provider) {
       form.reset(initialValues);
     } else {
-      form.reset({ enabled: true, public_key: "", secret_key: "", host: "" });
+      const cleared = emptyValues();
+      cleared.enabled = true;
+      form.reset(cleared);
     }
   };
 
   const yamlText = useMemo(() => {
     const values = form.getValues();
-    const base =
-      activeProvider === initial.provider ? { ...initial.config } : {};
     return stringifyYaml({
       provider: activeProvider,
       enabled: values.enabled,
-      config: valuesToConfig(activeProvider, values, base),
+      config: valuesToConfig(activeProvider, values),
     });
-  }, [activeProvider, form, initial, yamlOpen]);
+  }, [activeProvider, form, yamlOpen]);
 
   const persistFromYaml = async (parsed: unknown) => {
     const next = readObs(parsed);
     setActiveProvider(next.provider);
-    form.reset(configToValues(next.enabled, next.config));
+    form.reset(configToValues(next.provider, next.enabled, next.config));
     save.mutate({
       provider: next.provider,
       enabled: next.enabled,
@@ -247,108 +375,98 @@ export default function ObservabilityPage() {
             the active exporter on save.
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <Tabs
+        <CardContent className="space-y-6">
+          <ProviderPicker
             value={activeProvider}
-            onValueChange={(t) => handleProviderChange(t as Provider)}
-          >
-            <TabsList>
-              {PROVIDERS.map((p) => (
-                <TabsTrigger key={p.id} value={p.id}>
-                  {p.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
+            onChange={(t) => handleProviderChange(t as Provider)}
+            options={PROVIDERS}
+            columns={3}
+          />
 
-            {PROVIDERS.map((p) => (
-              <TabsContent key={p.id} value={p.id} className="mt-4">
-                <Form {...form}>
-                  <form
-                    id={`obs-form-${p.id}`}
-                    onSubmit={form.handleSubmit(handleSubmit)}
-                    className="space-y-4"
-                  >
-                    <FormField
-                      control={form.control}
-                      name="enabled"
-                      render={({ field }) => (
-                        <FormItem className="flex items-center justify-between gap-4 rounded-lg border border-border bg-muted/30 p-3">
-                          <div className="space-y-0.5">
-                            <FormLabel>Enabled</FormLabel>
-                            <FormDescription>
-                              Toggle to start or stop exporting traces.
-                            </FormDescription>
-                          </div>
-                          <FormControl>
-                            <Switch
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
-                            />
-                          </FormControl>
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name="host"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Host</FormLabel>
-                          <FormControl>
-                            <Input
-                              {...field}
-                              placeholder={
-                                p.id === "LANGFUSE"
-                                  ? "https://cloud.langfuse.com"
-                                  : p.id === "PHOENIX"
-                                    ? "https://collector.phoenix.com"
-                                    : ""
-                              }
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name="public_key"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>
-                            {p.id === "LANGSMITH" ? "API key" : "Public key"}
-                          </FormLabel>
-                          <FormControl>
-                            <Input {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    {p.id !== "LANGSMITH" && (
-                      <FormField
-                        control={form.control}
-                        name="secret_key"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Secret key</FormLabel>
-                            <FormControl>
-                              <Input
-                                {...field}
-                                type="password"
-                                autoComplete="off"
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
+          <Form {...form}>
+            <form
+              id={`obs-form-${activeProvider}`}
+              onSubmit={form.handleSubmit(handleSubmit)}
+              className="space-y-4"
+            >
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between gap-4 rounded-lg border border-border bg-muted/30 p-3">
+                    <div className="space-y-0.5">
+                      <FormLabel>Enabled</FormLabel>
+                      <FormDescription>
+                        Toggle to start or stop exporting traces.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
                       />
-                    )}
-                  </form>
-                </Form>
-              </TabsContent>
-            ))}
-          </Tabs>
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="host"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Host</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder={
+                          activeProvider === "LANGFUSE"
+                            ? "https://cloud.langfuse.com"
+                            : activeProvider === "PHOENIX"
+                              ? "https://collector.phoenix.com"
+                              : ""
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="public_key"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {activeProvider === "LANGSMITH" ? "API key" : "Public key"}
+                    </FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              {activeProvider !== "LANGSMITH" && (
+                <FormField
+                  control={form.control}
+                  name="secret_key"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Secret key</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="password"
+                          autoComplete="off"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </form>
+          </Form>
         </CardContent>
         <CardFooter className="justify-between">
           <Button

--- a/services/idun_agent_standalone_ui/components/admin/ProviderPicker.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/ProviderPicker.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import * as React from "react";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type ProviderOption<T extends string = string> = {
+  id: T;
+  label: string;
+  description?: string;
+  icon: React.ReactNode;
+  badge?: string;
+};
+
+type ProviderPickerProps<T extends string = string> = {
+  value: T;
+  onChange: (id: T) => void;
+  options: ProviderOption<T>[];
+  columns?: 2 | 3 | 4;
+  className?: string;
+};
+
+export function ProviderPicker<T extends string = string>({
+  value,
+  onChange,
+  options,
+  columns = 3,
+  className,
+}: ProviderPickerProps<T>) {
+  return (
+    <div
+      role="radiogroup"
+      className={cn(
+        "grid gap-3",
+        columns === 2 && "sm:grid-cols-2",
+        columns === 3 && "sm:grid-cols-2 lg:grid-cols-3",
+        columns === 4 && "sm:grid-cols-2 lg:grid-cols-4",
+        className,
+      )}
+    >
+      {options.map((opt) => {
+        const selected = opt.id === value;
+        return (
+          <button
+            key={opt.id}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(opt.id)}
+            className={cn(
+              "group relative flex items-start gap-3 rounded-xl border p-4 text-left transition-all",
+              "hover:border-foreground/30 hover:bg-foreground/[0.02]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40",
+              selected
+                ? "border-emerald-500/60 bg-emerald-500/[0.08] ring-2 ring-emerald-500/30 shadow-[0_0_0_1px_rgba(16,185,129,0.25)]"
+                : "border-foreground/10 bg-card",
+            )}
+          >
+            <div className="shrink-0">{opt.icon}</div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    "font-medium",
+                    selected
+                      ? "text-emerald-700 dark:text-emerald-300"
+                      : "text-foreground",
+                  )}
+                >
+                  {opt.label}
+                </span>
+                {opt.badge && (
+                  <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {opt.badge}
+                  </span>
+                )}
+              </div>
+              {opt.description && (
+                <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                  {opt.description}
+                </p>
+              )}
+            </div>
+            {selected && (
+              <div className="absolute right-3 top-3 flex h-5 w-5 items-center justify-center rounded-full bg-emerald-500 text-white">
+                <Check className="h-3 w-3" strokeWidth={3} />
+              </div>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/admin/provider-icons.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/provider-icons.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type IconProps = {
+  size?: number;
+  className?: string;
+};
+
+type RemoteBrandTileProps = IconProps & {
+  domain: string;
+  alt: string;
+  padding?: number;
+};
+
+function brandIconUrl(domain: string): string {
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=128`;
+}
+
+function RemoteBrandTile({
+  domain,
+  alt,
+  size = 40,
+  padding = 6,
+  className,
+}: RemoteBrandTileProps) {
+  const src = brandIconUrl(domain);
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-lg bg-white ring-1 ring-foreground/10 overflow-hidden",
+        className,
+      )}
+      style={{ width: size, height: size }}
+    >
+      <img
+        src={src}
+        alt={alt}
+        loading="lazy"
+        decoding="async"
+        referrerPolicy="no-referrer"
+        style={{ width: size - padding * 2, height: size - padding * 2 }}
+        draggable={false}
+      />
+    </div>
+  );
+}
+
+export function LangChainIcon(p: IconProps) {
+  return (
+    <RemoteBrandTile
+      domain="langchain.com"
+      alt="LangChain"
+      {...p}
+    />
+  );
+}
+
+export const LangGraphIcon = LangChainIcon;
+export const LangSmithIcon = LangChainIcon;
+
+export function GoogleCloudIcon(p: IconProps) {
+  return (
+    <RemoteBrandTile domain="cloud.google.com" alt="Google Cloud" {...p} />
+  );
+}
+
+export const VertexAiIcon = GoogleCloudIcon;
+export const AdkIcon = GoogleCloudIcon;
+
+export function HaystackIcon(p: IconProps) {
+  return (
+    <RemoteBrandTile
+      domain="deepset.ai"
+      alt="Haystack"
+      {...p}
+    />
+  );
+}
+
+export function PostgresIcon(p: IconProps) {
+  return (
+    <RemoteBrandTile domain="postgresql.org" alt="PostgreSQL" {...p} />
+  );
+}
+
+export function SqliteIcon(p: IconProps) {
+  return <RemoteBrandTile domain="sqlite.org" alt="SQLite" {...p} />;
+}
+
+export function MemoryChipIcon(p: IconProps) {
+  return <RemoteBrandTile domain="python.org" alt="In-memory" {...p} />;
+}
+
+export function LangfuseIcon(p: IconProps) {
+  return <RemoteBrandTile domain="langfuse.com" alt="Langfuse" {...p} />;
+}
+
+export function PhoenixIcon(p: IconProps) {
+  return <RemoteBrandTile domain="phoenix.arize.com" alt="Arize Phoenix" {...p} />;
+}
+
+export function GcpLoggingIcon(p: IconProps) {
+  return (
+    <RemoteBrandTile domain="cloud.google.com" alt="Google Cloud Logging" {...p} />
+  );
+}
+
+export function GcpTraceIcon(p: IconProps) {
+  return (
+    <RemoteBrandTile domain="cloud.google.com" alt="Google Cloud Trace" {...p} />
+  );
+}
+
+export function SlackIcon(p: IconProps) {
+  return <RemoteBrandTile domain="slack.com" alt="Slack" {...p} />;
+}
+
+export function DiscordIcon(p: IconProps) {
+  return <RemoteBrandTile domain="discord.com" alt="Discord" {...p} />;
+}
+
+export function WhatsAppIcon(p: IconProps) {
+  return <RemoteBrandTile domain="whatsapp.com" alt="WhatsApp" {...p} />;
+}
+
+export function MicrosoftTeamsIcon(p: IconProps) {
+  return (
+    <RemoteBrandTile domain="teams.microsoft.com" alt="Microsoft Teams" {...p} />
+  );
+}
+
+export function GoogleChatIcon(p: IconProps) {
+  return (
+    <RemoteBrandTile domain="chat.google.com" alt="Google Chat" {...p} />
+  );
+}

--- a/services/idun_agent_standalone_ui/components/admin/provider-icons.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/provider-icons.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { MemoryStick } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -86,12 +87,46 @@ export function PostgresIcon(p: IconProps) {
   );
 }
 
-export function SqliteIcon(p: IconProps) {
-  return <RemoteBrandTile domain="sqlite.org" alt="SQLite" {...p} />;
+export function SqliteIcon({ size = 40, className }: IconProps) {
+  const padding = 6;
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-lg bg-white ring-1 ring-foreground/10 overflow-hidden",
+        className,
+      )}
+      style={{ width: size, height: size }}
+    >
+      <img
+        src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/sqlite/sqlite-original.svg"
+        alt="SQLite"
+        loading="lazy"
+        decoding="async"
+        referrerPolicy="no-referrer"
+        style={{ width: size - padding * 2, height: size - padding * 2 }}
+        draggable={false}
+      />
+    </div>
+  );
 }
 
-export function MemoryChipIcon(p: IconProps) {
-  return <RemoteBrandTile domain="python.org" alt="In-memory" {...p} />;
+export function MemoryChipIcon({ size = 40, className }: IconProps) {
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-lg ring-1 ring-foreground/10",
+        "bg-gradient-to-br from-violet-500/20 to-fuchsia-500/15",
+        className,
+      )}
+      style={{ width: size, height: size }}
+    >
+      <MemoryStick
+        className="text-violet-300"
+        size={Math.round(size * 0.55)}
+        strokeWidth={1.8}
+      />
+    </div>
+  );
 }
 
 export function LangfuseIcon(p: IconProps) {

--- a/services/idun_agent_standalone_ui/lib/api/index.ts
+++ b/services/idun_agent_standalone_ui/lib/api/index.ts
@@ -13,6 +13,7 @@ import type {
   AgentRead,
   AgentSessionDetail,
   AgentSessionSummary,
+  ConnectionCheckResult,
   DeleteResult,
   GuardrailCreate,
   GuardrailPatch,
@@ -75,6 +76,10 @@ export const api = {
     apiFetch<MutationResponse<SingletonDeleteResult>>(`${ADMIN}/memory`, {
       method: "DELETE",
     }),
+  checkMemoryConnection: () =>
+    apiFetch<ConnectionCheckResult>(`${ADMIN}/memory/check-connection`, {
+      method: "POST",
+    }),
 
   // observability (singleton)
   getObservability: () =>
@@ -88,6 +93,11 @@ export const api = {
     apiFetch<MutationResponse<SingletonDeleteResult>>(
       `${ADMIN}/observability`,
       { method: "DELETE" },
+    ),
+  checkObservabilityConnection: () =>
+    apiFetch<ConnectionCheckResult>(
+      `${ADMIN}/observability/check-connection`,
+      { method: "POST" },
     ),
 
   // mcp servers (collection)

--- a/services/idun_agent_standalone_ui/lib/api/types/common.ts
+++ b/services/idun_agent_standalone_ui/lib/api/types/common.ts
@@ -34,3 +34,9 @@ export type AdminErrorBody = {
     fieldErrors?: FieldError[] | null;
   };
 };
+
+export type ConnectionCheckResult = {
+  ok: boolean;
+  details: Record<string, unknown> | null;
+  error: string | null;
+};


### PR DESCRIPTION
## Summary

Tightens the standalone admin UI: replaces the ugly tab/select pickers with a unified brand-icon picker, makes the observability form schema-correct per provider, and wires the existing \`/check-connection\` endpoints to a Verify button on memory + observability.

## Changes

### Provider picker (\`agent\` / \`memory\` / \`observability\` / \`integrations\`)

- New \`components/admin/ProviderPicker.tsx\` — emerald selected state, check badge, configurable column count.
- New \`components/admin/provider-icons.tsx\` — remote brand icons via Google favicon CDN, devicons CDN for SQLite, lucide \`MemoryStick\` on a violet gradient for in-memory.
- Migrated all four admin pages off shadcn \`Tabs\` / \`Select\` and onto \`ProviderPicker\`.
- Integration cards now render the real provider logo instead of the generic \`MessageSquare\` placeholder.

### Observability form (\`/admin/observability\`)

Each provider now sends the right config shape per \`ObservabilityConfig\` in \`idun_agent_schema\`:

| Provider | Fields |
| --- | --- |
| Langfuse | host, public_key, secret_key, run_name |
| Phoenix | collector_endpoint, project_name |
| LangSmith | api_key, endpoint, project_name |
| GCP Logging | project_id, region, log_name, resource_type, severity |
| GCP Trace | project_id, region, trace_name, sampling_rate, flush_interval, ignore_urls |

Previously every provider sent host/public_key/secret_key, which was wrong for GCP and LangSmith.

### Verify buttons

Memory + observability pages get a Verify button next to Save. Calls the existing \`POST /admin/api/v1/{memory,observability}/check-connection\` endpoints (which were already there, just unwired in the UI). On success the button turns emerald with a check icon and \"Verified\" label for 3s, no toast. On failure it flashes red and surfaces the upstream error string via toast. Disabled until a config row exists.

### Schema fix

\`fix(schema): preserve user reject_message in convert_guardrail (#551)\` — every branch in \`convert_guardrail\` was hardcoding \`reject_message\` to a per-guard default, dropping operator input. See #551 for the larger design discussion (most of \`convert_guardrail\`'s transforms are no-ops because engine V2 has defaults + a flattening validator). This commit is the band-aid fix; the bigger refactor stays on the issue.

## Out of scope

- Integration verify button (deferred — would need new per-provider probes against the configured webhook URLs).
- The \`scripts\` field discussion in #551.

## Test plan

- [ ] Restart the standalone, visit each admin page, confirm the new picker renders with brand icons + emerald selected state.
- [ ] On \`/admin/observability\`, switch providers and confirm the right field set renders for each.
- [ ] On \`/admin/memory\` and \`/admin/observability\`, save a config and click Verify. Green button on a reachable backend, red flash + toast on a bad one.
- [ ] On \`/admin/guardrails\`, change a reject_message, save, reload the agent, confirm the new value reaches the engine (was the #551 symptom).