### PR TITLE
feat(engine+ui): graph visualizer + export actions for LangGraph & ADK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,7 @@ poetry.lock
 /.claude/settings.json
 /.claude/scheduled_tasks.lock
 /.claude/worktrees/
+/.claude/smoke-test/
 /.cursor/hooks.json
 
 # Remotion video project

--- a/docs/superpowers/plans/2026-04-30-adk-langgraph-graph-visualizer.md
+++ b/docs/superpowers/plans/2026-04-30-adk-langgraph-graph-visualizer.md
@@ -1,0 +1,2885 @@
+# ADK + LangGraph Graph Visualizer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a framework-agnostic graph visualizer for LangGraph and ADK agents — JSON IR + Mermaid + ASCII engine routes, plus a custom-styled ReactFlow component in the standalone UI rendered on the onboarding success screen and the admin agent page.
+
+**Architecture:** The IR is a versioned Pydantic contract in `idun_agent_schema`. The engine introspects framework runtime objects and exposes three routes (`/agent/graph`, `/agent/graph/mermaid`, `/agent/graph/ascii`). The standalone UI reads the JSON IR and renders it with `@xyflow/react` + `@dagrejs/dagre`. Admin web stays on Mermaid for now via a 3-line URL swap.
+
+**Tech Stack:** Python 3.12, Pydantic 2.11, FastAPI, LangGraph, Google ADK, Next.js 15, React 19, TypeScript, ReactFlow v12 (`@xyflow/react`), `@dagrejs/dagre`, Tailwind v4 + shadcn/ui, vitest + Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-adk-langgraph-graph-visualizer-design.md` — the source of truth. This plan implements that spec verbatim. If the spec and plan disagree, update the spec first.
+
+---
+
+## File Structure
+
+### Schema package
+| File | Status | Responsibility |
+|---|---|---|
+| `libs/idun_agent_schema/src/idun_agent_schema/engine/graph.py` | NEW | Pydantic IR models + enums |
+| `libs/idun_agent_schema/src/idun_agent_schema/engine/__init__.py` | MODIFY | Re-export new graph symbols |
+| `libs/idun_agent_schema/tests/standalone/test_graph.py` | NEW | Round-trip / discriminator / format_version tests |
+
+### Engine
+| File | Status | Responsibility |
+|---|---|---|
+| `libs/idun_agent_engine/src/idun_agent_engine/agent/base.py` | MODIFY | `get_graph_ir()`, `draw_mermaid()`, `draw_ascii()` defaults |
+| `libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py` | MODIFY | `get_graph_ir()` walking `CompiledStateGraph`; native `draw_*` overrides |
+| `libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py` | MODIFY | `get_graph_ir()` walking `App.root_agent` |
+| `libs/idun_agent_engine/src/idun_agent_engine/server/graph/__init__.py` | NEW | Module marker |
+| `libs/idun_agent_engine/src/idun_agent_engine/server/graph/mermaid.py` | NEW | `render_mermaid(graph) -> str` |
+| `libs/idun_agent_engine/src/idun_agent_engine/server/graph/ascii.py` | NEW | `render_ascii(graph) -> str` |
+| `libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py` | MODIFY | Replace `/agent/graph` with three routes |
+| `libs/idun_agent_engine/tests/unit/agent/test_base_graph.py` | NEW | BaseAgent default behavior |
+| `libs/idun_agent_engine/tests/unit/server/graph/__init__.py` | NEW | |
+| `libs/idun_agent_engine/tests/unit/server/graph/test_mermaid.py` | NEW | Renderer golden tests |
+| `libs/idun_agent_engine/tests/unit/server/graph/test_ascii.py` | NEW | Renderer golden tests |
+| `libs/idun_agent_engine/tests/unit/server/graph/fixtures/*.txt` | NEW | Golden output strings |
+| `libs/idun_agent_engine/tests/unit/agent/test_langgraph_graph_ir.py` | NEW | LangGraph adapter introspection |
+| `libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py` | NEW | ADK adapter introspection |
+| `libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py` | MODIFY | Add fixtures for graph-IR tests |
+| `libs/idun_agent_engine/tests/unit/server/routers/agent/test_graph_route.py` | MODIFY | Cover new IR / mermaid / ascii routes |
+
+### Admin web
+| File | Status | Responsibility |
+|---|---|---|
+| `services/idun_agent_web/src/services/agents.ts` | MODIFY | Switch URL + field |
+
+### Standalone UI
+| File | Status | Responsibility |
+|---|---|---|
+| `services/idun_agent_standalone_ui/package.json` | MODIFY | Add `@xyflow/react`, `@dagrejs/dagre` |
+| `services/idun_agent_standalone_ui/lib/api/types/graph.ts` | NEW | TS mirror of IR |
+| `services/idun_agent_standalone_ui/lib/api/types/index.ts` | MODIFY | Re-export graph types |
+| `services/idun_agent_standalone_ui/lib/api/index.ts` | MODIFY | Add `getAgentGraph{,Mermaid,Ascii}()` |
+| `services/idun_agent_standalone_ui/components/graph/irToReactFlow.ts` | NEW | Pure IR → ReactFlow mapper |
+| `services/idun_agent_standalone_ui/components/graph/layout.ts` | NEW | dagre wrapper |
+| `services/idun_agent_standalone_ui/components/graph/nodes/AgentNode.tsx` | NEW | Custom node |
+| `services/idun_agent_standalone_ui/components/graph/nodes/ToolNode.tsx` | NEW | Custom node |
+| `services/idun_agent_standalone_ui/components/graph/edges/PrettyEdge.tsx` | NEW | Edge styling per `EdgeKind` |
+| `services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx` | NEW | ReactFlow canvas |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx` | MODIFY | Embed graph card |
+| `services/idun_agent_standalone_ui/app/admin/agent/page.tsx` | MODIFY | Add Graph tab |
+| `services/idun_agent_standalone_ui/components/graph/__tests__/irToReactFlow.test.ts` | NEW | |
+| `services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx` | NEW | |
+| `services/idun_agent_standalone_ui/e2e/onboarding-detection.spec.ts` (or existing wizard spec) | MODIFY | E2E: graph visible on WizardDone |
+
+---
+
+## Task 1: Schema — `AgentGraph` IR Pydantic models
+
+**Files:**
+- Create: `libs/idun_agent_schema/src/idun_agent_schema/engine/graph.py`
+- Modify: `libs/idun_agent_schema/src/idun_agent_schema/engine/__init__.py`
+- Create: `libs/idun_agent_schema/tests/standalone/test_graph.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `libs/idun_agent_schema/tests/standalone/test_graph.py`:
+
+```python
+"""Tests for the graph IR Pydantic models."""
+
+import json
+import pytest
+from pydantic import ValidationError
+
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphMetadata,
+    AgentKind,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+
+
+def _sample_graph() -> AgentGraph:
+    return AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK,
+            agent_name="root",
+            root_id="agent:root",
+            warnings=[],
+        ),
+        nodes=[
+            AgentNode(
+                id="agent:root",
+                name="root",
+                agent_kind=AgentKind.LLM,
+                is_root=True,
+                model="gemini-2.5-flash",
+            ),
+            ToolNode(
+                id="tool:search@root",
+                name="search",
+                tool_kind=ToolKind.MCP,
+                mcp_server_name="stdio: npx server-filesystem",
+            ),
+        ],
+        edges=[
+            AgentGraphEdge(source="agent:root", target="tool:search@root", kind=EdgeKind.TOOL_ATTACH),
+        ],
+    )
+
+
+def test_agent_graph_round_trips_through_json():
+    graph = _sample_graph()
+    raw = graph.model_dump_json()
+    parsed = AgentGraph.model_validate_json(raw)
+    assert parsed == graph
+
+
+def test_node_discriminator_parses_both_variants():
+    payload = {
+        "format_version": "1",
+        "metadata": {
+            "framework": "ADK",
+            "agent_name": "root",
+            "root_id": "agent:root",
+            "warnings": [],
+        },
+        "nodes": [
+            {"kind": "agent", "id": "agent:root", "name": "root", "agent_kind": "llm", "is_root": True},
+            {"kind": "tool", "id": "tool:t@root", "name": "t", "tool_kind": "native"},
+        ],
+        "edges": [
+            {"source": "agent:root", "target": "tool:t@root", "kind": "tool_attach"},
+        ],
+    }
+    parsed = AgentGraph.model_validate(payload)
+    assert isinstance(parsed.nodes[0], AgentNode)
+    assert isinstance(parsed.nodes[1], ToolNode)
+
+
+def test_format_version_rejects_unknown():
+    payload = {
+        "format_version": "2",
+        "metadata": {
+            "framework": "ADK", "agent_name": "n", "root_id": "agent:r", "warnings": [],
+        },
+        "nodes": [], "edges": [],
+    }
+    with pytest.raises(ValidationError):
+        AgentGraph.model_validate(payload)
+
+
+def test_format_version_defaults_to_1():
+    g = AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.LANGGRAPH, agent_name="n", root_id="r",
+        ),
+        nodes=[], edges=[],
+    )
+    assert g.format_version == "1"
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+uv run pytest libs/idun_agent_schema/tests/standalone/test_graph.py -v
+```
+
+Expected: ImportError / ModuleNotFoundError (`idun_agent_schema.engine.graph` doesn't exist yet).
+
+- [ ] **Step 3: Create the IR module**
+
+Create `libs/idun_agent_schema/src/idun_agent_schema/engine/graph.py`:
+
+```python
+"""Framework-agnostic graph IR shared by engine and UI consumers.
+
+Versioned via `format_version`. New variants ship alongside, never as a
+breaking change.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+from idun_agent_schema.engine.agent_framework import AgentFramework
+
+
+class AgentKind(str, Enum):
+    LLM = "llm"
+    SEQUENTIAL = "sequential"
+    PARALLEL = "parallel"
+    LOOP = "loop"
+    CUSTOM = "custom"
+
+
+class ToolKind(str, Enum):
+    NATIVE = "native"
+    MCP = "mcp"
+    BUILT_IN = "built_in"
+
+
+class EdgeKind(str, Enum):
+    PARENT_CHILD = "parent_child"
+    SEQUENTIAL_STEP = "sequential_step"
+    PARALLEL_BRANCH = "parallel_branch"
+    LOOP_STEP = "loop_step"
+    TOOL_ATTACH = "tool_attach"
+    GRAPH_EDGE = "graph_edge"
+
+
+class AgentNode(BaseModel):
+    kind: Literal["agent"] = "agent"
+    id: str
+    name: str
+    agent_kind: AgentKind
+    is_root: bool = False
+    description: str | None = None
+    model: str | None = None
+    loop_max_iterations: int | None = None
+
+
+class ToolNode(BaseModel):
+    kind: Literal["tool"] = "tool"
+    id: str
+    name: str
+    tool_kind: ToolKind
+    description: str | None = None
+    mcp_server_name: str | None = None
+
+
+AgentGraphNode = Annotated[
+    AgentNode | ToolNode, Field(discriminator="kind")
+]
+
+
+class AgentGraphEdge(BaseModel):
+    source: str
+    target: str
+    kind: EdgeKind
+    order: int | None = None
+    condition: str | None = None
+    label: str | None = None
+
+
+class AgentGraphMetadata(BaseModel):
+    framework: AgentFramework
+    agent_name: str
+    root_id: str
+    warnings: list[str] = Field(default_factory=list)
+
+
+class AgentGraph(BaseModel):
+    format_version: Literal["1"] = "1"
+    metadata: AgentGraphMetadata
+    nodes: list[AgentGraphNode]
+    edges: list[AgentGraphEdge]
+```
+
+- [ ] **Step 4: Re-export from the engine subpackage**
+
+Modify `libs/idun_agent_schema/src/idun_agent_schema/engine/__init__.py` — append the new exports to whatever is already there:
+
+```python
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphMetadata,
+    AgentGraphNode,
+    AgentKind,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+```
+
+(Read the existing file first; add to its `__all__` list if it has one.)
+
+- [ ] **Step 5: Run tests — confirm they pass**
+
+```bash
+uv run pytest libs/idun_agent_schema/tests/standalone/test_graph.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/idun_agent_schema/src/idun_agent_schema/engine/graph.py \
+        libs/idun_agent_schema/src/idun_agent_schema/engine/__init__.py \
+        libs/idun_agent_schema/tests/standalone/test_graph.py
+git commit -m "feat(schema): add framework-agnostic AgentGraph IR (format_version=1)"
+```
+
+---
+
+## Task 2: Engine base — `BaseAgent.get_graph_ir()` + `draw_*` defaults
+
+**Files:**
+- Modify: `libs/idun_agent_engine/src/idun_agent_engine/agent/base.py`
+- Create: `libs/idun_agent_engine/tests/unit/agent/test_base_graph.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `libs/idun_agent_engine/tests/unit/agent/test_base_graph.py`:
+
+```python
+"""Tests for BaseAgent default graph methods (NotImplementedError fallback)."""
+
+import pytest
+
+from idun_agent_engine.agent.base import BaseAgent
+
+
+class _StubAgent(BaseAgent):
+    """Bare BaseAgent subclass that doesn't override graph methods."""
+
+    @property
+    def id(self) -> str: return "stub"
+    @property
+    def agent_type(self) -> str: return "STUB"
+    @property
+    def name(self) -> str: return "stub"
+    @property
+    def agent_instance(self): return None
+    @property
+    def copilotkit_agent_instance(self): return None
+    @property
+    def configuration(self): return None
+    @property
+    def infos(self): return {}
+
+    async def initialize(self, *a, **kw): pass
+    async def invoke(self, message): return None
+    async def stream(self, message):
+        yield None
+    def discover_capabilities(self): return None  # type: ignore[return-value]
+    async def run(self, input_data):
+        yield None
+
+
+def test_get_graph_ir_default_raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        _StubAgent().get_graph_ir()
+
+
+def test_draw_mermaid_default_raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        _StubAgent().draw_mermaid()
+
+
+def test_draw_ascii_default_raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        _StubAgent().draw_ascii()
+```
+
+- [ ] **Step 2: Run test — confirm it fails**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/agent/test_base_graph.py -v
+```
+
+Expected: AttributeError (`'_StubAgent' object has no attribute 'get_graph_ir'`).
+
+- [ ] **Step 3: Add the default methods to BaseAgent**
+
+Modify `libs/idun_agent_engine/src/idun_agent_engine/agent/base.py` — add these three methods to the `BaseAgent` class (location: anywhere at the same indent level as the other concrete methods, e.g. after `discover_capabilities`). Add the `AgentGraph` import inside a `TYPE_CHECKING` block at the top if not already imported:
+
+```python
+# Add to TYPE_CHECKING block at the top of the file (alongside existing imports):
+if TYPE_CHECKING:
+    from idun_agent_schema.engine.graph import AgentGraph
+```
+
+Add to the `BaseAgent` class body:
+
+```python
+def get_graph_ir(self) -> "AgentGraph":
+    """Return a framework-agnostic graph IR.
+
+    Override in subclasses that can introspect their underlying agent.
+    """
+    raise NotImplementedError(
+        f"{self.agent_type} does not support graph introspection"
+    )
+
+def draw_mermaid(self) -> str:
+    """Render the agent graph as a Mermaid source string.
+
+    Default: render the IR via the engine's framework-agnostic renderer.
+    Adapters with native diagram support (e.g. LangGraph) may override.
+    """
+    from idun_agent_engine.server.graph.mermaid import render_mermaid
+
+    return render_mermaid(self.get_graph_ir())
+
+def draw_ascii(self) -> str:
+    """Render the agent graph as ASCII art.
+
+    Default: render the IR via the engine's framework-agnostic renderer.
+    Adapters with native ASCII support (e.g. LangGraph + grandalf) may override.
+    """
+    from idun_agent_engine.server.graph.ascii import render_ascii
+
+    return render_ascii(self.get_graph_ir())
+```
+
+(`render_mermaid` / `render_ascii` are introduced in Tasks 3-4 — leave the imports inside the methods so they don't fire at module-import time.)
+
+- [ ] **Step 4: Run test — confirm it passes**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/agent/test_base_graph.py -v
+```
+
+Expected: 3 passed. (The two `draw_*` defaults raise `NotImplementedError` because they call `get_graph_ir()`, which raises.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_engine/src/idun_agent_engine/agent/base.py \
+        libs/idun_agent_engine/tests/unit/agent/test_base_graph.py
+git commit -m "feat(engine): add BaseAgent.get_graph_ir + draw_mermaid/ascii defaults"
+```
+
+---
+
+## Task 3: Engine — `render_mermaid` (framework-agnostic IR consumer)
+
+**Files:**
+- Create: `libs/idun_agent_engine/src/idun_agent_engine/server/graph/__init__.py`
+- Create: `libs/idun_agent_engine/src/idun_agent_engine/server/graph/mermaid.py`
+- Create: `libs/idun_agent_engine/tests/unit/server/graph/__init__.py`
+- Create: `libs/idun_agent_engine/tests/unit/server/graph/test_mermaid.py`
+- Create: `libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.mermaid`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `libs/idun_agent_engine/tests/unit/server/graph/__init__.py` (empty file).
+
+Create `libs/idun_agent_engine/tests/unit/server/graph/test_mermaid.py`:
+
+```python
+"""Golden tests for render_mermaid (framework-agnostic)."""
+
+from pathlib import Path
+
+import pytest
+
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphMetadata,
+    AgentKind,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+from idun_agent_engine.server.graph.mermaid import render_mermaid
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _build_simple_graph() -> AgentGraph:
+    """root LlmAgent with one native tool and one MCP tool, no sub-agents."""
+    return AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK,
+            agent_name="root",
+            root_id="agent:root",
+        ),
+        nodes=[
+            AgentNode(id="agent:root", name="root", agent_kind=AgentKind.LLM, is_root=True),
+            ToolNode(id="tool:search@root", name="search", tool_kind=ToolKind.MCP),
+            ToolNode(id="tool:lookup@root", name="lookup", tool_kind=ToolKind.NATIVE),
+        ],
+        edges=[
+            AgentGraphEdge(source="agent:root", target="tool:search@root", kind=EdgeKind.TOOL_ATTACH),
+            AgentGraphEdge(source="agent:root", target="tool:lookup@root", kind=EdgeKind.TOOL_ATTACH),
+        ],
+    )
+
+
+@pytest.mark.unit
+def test_render_mermaid_matches_golden():
+    output = render_mermaid(_build_simple_graph())
+    expected = (FIXTURES / "simple.mermaid").read_text()
+    assert output.strip() == expected.strip()
+
+
+@pytest.mark.unit
+def test_render_mermaid_handles_workflow_edges():
+    graph = AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK, agent_name="root", root_id="agent:root",
+        ),
+        nodes=[
+            AgentNode(id="agent:root", name="root", agent_kind=AgentKind.SEQUENTIAL, is_root=True),
+            AgentNode(id="agent:a", name="a", agent_kind=AgentKind.LLM),
+            AgentNode(id="agent:b", name="b", agent_kind=AgentKind.LLM),
+        ],
+        edges=[
+            AgentGraphEdge(source="agent:root", target="agent:a", kind=EdgeKind.SEQUENTIAL_STEP, order=0),
+            AgentGraphEdge(source="agent:root", target="agent:b", kind=EdgeKind.SEQUENTIAL_STEP, order=1),
+        ],
+    )
+    out = render_mermaid(graph)
+    assert "graph TD" in out
+    # Order labels should appear
+    assert "1." in out and "2." in out
+```
+
+Create the golden fixture at `libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.mermaid` (we'll write the implementation to match this output exactly):
+
+```
+graph TD
+  agent_root["root<br/>llm"]:::agentRoot
+  tool_search_root(["search"]):::toolMcp
+  tool_lookup_root(["lookup"]):::toolNative
+  agent_root -.-> tool_search_root
+  agent_root -.-> tool_lookup_root
+  classDef agentRoot fill:#f3efff,stroke:#7a6cf0,stroke-width:1.5px
+  classDef agent fill:#fff,stroke:#cfcfd6
+  classDef toolMcp fill:#eaf3ff,stroke:#5a8de6
+  classDef toolNative fill:#f4faf2,stroke:#7cae5d
+  classDef toolBuiltIn fill:#fff7e6,stroke:#d99b3a
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/server/graph/test_mermaid.py -v
+```
+
+Expected: ModuleNotFoundError (renderer doesn't exist).
+
+- [ ] **Step 3: Implement the renderer**
+
+Create `libs/idun_agent_engine/src/idun_agent_engine/server/graph/__init__.py` (empty file).
+
+Create `libs/idun_agent_engine/src/idun_agent_engine/server/graph/mermaid.py`:
+
+```python
+"""Render an AgentGraph IR as a Mermaid source string.
+
+Framework-agnostic — consumes only the IR. LangGraph adapters override
+draw_mermaid() to use LangGraph's native renderer; ADK uses this.
+"""
+
+from __future__ import annotations
+
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphNode,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+
+
+def _node_id(node_id: str) -> str:
+    """Mermaid identifiers can't contain ':' — convert to underscores."""
+    return node_id.replace(":", "_").replace("@", "_")
+
+
+def _node_class(node: AgentGraphNode) -> str:
+    if isinstance(node, AgentNode):
+        return "agentRoot" if node.is_root else "agent"
+    assert isinstance(node, ToolNode)
+    return {
+        ToolKind.MCP: "toolMcp",
+        ToolKind.NATIVE: "toolNative",
+        ToolKind.BUILT_IN: "toolBuiltIn",
+    }[node.tool_kind]
+
+
+def _node_line(node: AgentGraphNode) -> str:
+    nid = _node_id(node.id)
+    cls = _node_class(node)
+    if isinstance(node, AgentNode):
+        label = f"{node.name}<br/>{node.agent_kind.value}"
+        return f'  {nid}["{label}"]:::{cls}'
+    assert isinstance(node, ToolNode)
+    return f'  {nid}(["{node.name}"]):::{cls}'
+
+
+def _edge_line(edge: AgentGraphEdge, node_lookup: dict[str, AgentGraphNode]) -> str:
+    src = _node_id(edge.source)
+    dst = _node_id(edge.target)
+
+    if edge.kind == EdgeKind.PARENT_CHILD:
+        return f"  {src} --> {dst}"
+    if edge.kind == EdgeKind.TOOL_ATTACH:
+        return f"  {src} -.-> {dst}"
+    if edge.kind == EdgeKind.SEQUENTIAL_STEP:
+        order = (edge.order or 0) + 1
+        return f'  {src} == "{order}." ==> {dst}'
+    if edge.kind == EdgeKind.PARALLEL_BRANCH:
+        return f"  {src} ==> {dst}"
+    if edge.kind == EdgeKind.LOOP_STEP:
+        parent = node_lookup.get(edge.source)
+        max_iter = getattr(parent, "loop_max_iterations", None)
+        label = f"↻ ×{max_iter}" if max_iter else "↻"
+        return f'  {src} -. "{label}" .-> {dst}'
+    if edge.kind == EdgeKind.GRAPH_EDGE:
+        if edge.condition:
+            return f'  {src} -- "{edge.condition}" --> {dst}'
+        return f"  {src} --> {dst}"
+    raise ValueError(f"Unknown edge kind: {edge.kind}")
+
+
+_CLASS_DEFS = [
+    "  classDef agentRoot fill:#f3efff,stroke:#7a6cf0,stroke-width:1.5px",
+    "  classDef agent fill:#fff,stroke:#cfcfd6",
+    "  classDef toolMcp fill:#eaf3ff,stroke:#5a8de6",
+    "  classDef toolNative fill:#f4faf2,stroke:#7cae5d",
+    "  classDef toolBuiltIn fill:#fff7e6,stroke:#d99b3a",
+]
+
+
+def render_mermaid(graph: AgentGraph) -> str:
+    lookup: dict[str, AgentGraphNode] = {n.id: n for n in graph.nodes}
+    lines = ["graph TD"]
+    lines.extend(_node_line(n) for n in graph.nodes)
+    lines.extend(_edge_line(e, lookup) for e in graph.edges)
+    lines.extend(_CLASS_DEFS)
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/server/graph/test_mermaid.py -v
+```
+
+Expected: 2 passed. If the golden file doesn't match exactly, adjust the golden file (not the implementation) — the implementation defines the output, the golden locks it in.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_engine/src/idun_agent_engine/server/graph/__init__.py \
+        libs/idun_agent_engine/src/idun_agent_engine/server/graph/mermaid.py \
+        libs/idun_agent_engine/tests/unit/server/graph/__init__.py \
+        libs/idun_agent_engine/tests/unit/server/graph/test_mermaid.py \
+        libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.mermaid
+git commit -m "feat(engine): add framework-agnostic Mermaid renderer for AgentGraph IR"
+```
+
+---
+
+## Task 4: Engine — `render_ascii` (framework-agnostic IR consumer)
+
+**Files:**
+- Create: `libs/idun_agent_engine/src/idun_agent_engine/server/graph/ascii.py`
+- Create: `libs/idun_agent_engine/tests/unit/server/graph/test_ascii.py`
+- Create: `libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.ascii`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `libs/idun_agent_engine/tests/unit/server/graph/test_ascii.py`:
+
+```python
+"""Golden tests for render_ascii (framework-agnostic)."""
+
+from pathlib import Path
+
+import pytest
+
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphMetadata,
+    AgentKind,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+from idun_agent_engine.server.graph.ascii import render_ascii
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.mark.unit
+def test_render_ascii_matches_golden():
+    graph = AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK,
+            agent_name="root",
+            root_id="agent:root",
+        ),
+        nodes=[
+            AgentNode(id="agent:root", name="root", agent_kind=AgentKind.LLM, is_root=True),
+            ToolNode(id="tool:search@root", name="search", tool_kind=ToolKind.MCP,
+                     mcp_server_name="stdio: npx server-filesystem"),
+            AgentNode(id="agent:child", name="child", agent_kind=AgentKind.LLM),
+            ToolNode(id="tool:fetch@child", name="fetch", tool_kind=ToolKind.NATIVE),
+        ],
+        edges=[
+            AgentGraphEdge(source="agent:root", target="tool:search@root", kind=EdgeKind.TOOL_ATTACH),
+            AgentGraphEdge(source="agent:root", target="agent:child", kind=EdgeKind.PARENT_CHILD),
+            AgentGraphEdge(source="agent:child", target="tool:fetch@child", kind=EdgeKind.TOOL_ATTACH),
+        ],
+    )
+    output = render_ascii(graph)
+    expected = (FIXTURES / "simple.ascii").read_text()
+    assert output.rstrip() == expected.rstrip()
+```
+
+Create golden fixture `libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.ascii`:
+
+```
+ADK · root
+root (LlmAgent, root)
+├─ tools
+│  └─ search (mcp: stdio: npx server-filesystem)
+└─ child (LlmAgent)
+   └─ tools
+      └─ fetch (native)
+```
+
+- [ ] **Step 2: Run test — confirm it fails**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/server/graph/test_ascii.py -v
+```
+
+Expected: ModuleNotFoundError.
+
+- [ ] **Step 3: Implement the renderer**
+
+Create `libs/idun_agent_engine/src/idun_agent_engine/server/graph/ascii.py`:
+
+```python
+"""Render an AgentGraph IR as ASCII art (tree printer).
+
+Framework-agnostic. LangGraph adapters override draw_ascii() to use
+LangGraph's native draw_ascii() (which uses grandalf).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentNode,
+    EdgeKind,
+    ToolNode,
+)
+
+
+def _agent_label(node: AgentNode) -> str:
+    kind_name = {
+        "llm": "LlmAgent",
+        "sequential": "SequentialAgent",
+        "parallel": "ParallelAgent",
+        "loop": "LoopAgent",
+        "custom": "Custom",
+    }[node.agent_kind.value]
+    suffix = ", root" if node.is_root else ""
+    return f"{node.name} ({kind_name}{suffix})"
+
+
+def _tool_label(node: ToolNode) -> str:
+    if node.tool_kind.value == "mcp":
+        server = f": {node.mcp_server_name}" if node.mcp_server_name else ""
+        return f"{node.name} (mcp{server})"
+    return f"{node.name} ({node.tool_kind.value})"
+
+
+def render_ascii(graph: AgentGraph) -> str:
+    nodes_by_id = {n.id: n for n in graph.nodes}
+
+    sub_agents: dict[str, list[str]] = defaultdict(list)
+    tools: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.edges:
+        if edge.kind == EdgeKind.TOOL_ATTACH:
+            tools[edge.source].append(edge.target)
+        elif edge.kind in {
+            EdgeKind.PARENT_CHILD,
+            EdgeKind.SEQUENTIAL_STEP,
+            EdgeKind.PARALLEL_BRANCH,
+            EdgeKind.LOOP_STEP,
+        }:
+            sub_agents[edge.source].append(edge.target)
+        # GRAPH_EDGE handled below by LangGraph native; we still render any sub-agent-style edges if present.
+
+    lines: list[str] = []
+    lines.append(f"{graph.metadata.framework.value} · {graph.metadata.agent_name}")
+    if graph.metadata.warnings:
+        for w in graph.metadata.warnings:
+            lines.append(f"⚠ {w}")
+
+    def _walk(node_id: str, prefix: str, is_last: bool, is_root: bool) -> None:
+        node = nodes_by_id[node_id]
+        connector = "" if is_root else ("└─ " if is_last else "├─ ")
+        if isinstance(node, AgentNode):
+            lines.append(f"{prefix}{connector}{_agent_label(node)}")
+        else:
+            assert isinstance(node, ToolNode)
+            lines.append(f"{prefix}{connector}{_tool_label(node)}")
+            return  # tools are leaves
+
+        child_prefix = prefix + ("" if is_root else ("   " if is_last else "│  "))
+
+        node_tools = tools.get(node_id, [])
+        node_subs = sub_agents.get(node_id, [])
+
+        if node_tools:
+            tools_is_last = not node_subs
+            tools_connector = "└─ " if tools_is_last else "├─ "
+            lines.append(f"{child_prefix}{tools_connector}tools")
+            tool_prefix = child_prefix + ("   " if tools_is_last else "│  ")
+            for i, tid in enumerate(node_tools):
+                _walk(tid, tool_prefix, i == len(node_tools) - 1, is_root=False)
+
+        for i, sid in enumerate(node_subs):
+            _walk(sid, child_prefix, i == len(node_subs) - 1, is_root=False)
+
+    _walk(graph.metadata.root_id, "", True, is_root=True)
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run test — confirm it passes**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/server/graph/test_ascii.py -v
+```
+
+Expected: 1 passed. If the golden differs, adjust the golden file to match the implementation output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_engine/src/idun_agent_engine/server/graph/ascii.py \
+        libs/idun_agent_engine/tests/unit/server/graph/test_ascii.py \
+        libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.ascii
+git commit -m "feat(engine): add framework-agnostic ASCII renderer for AgentGraph IR"
+```
+
+---
+
+## Task 5: Engine — `LanggraphAgent.get_graph_ir()` + native `draw_*` overrides
+
+**Files:**
+- Modify: `libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py`
+- Create: `libs/idun_agent_engine/tests/unit/agent/test_langgraph_graph_ir.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `libs/idun_agent_engine/tests/unit/agent/test_langgraph_graph_ir.py`:
+
+```python
+"""Tests for LanggraphAgent graph introspection."""
+
+from pathlib import Path
+
+import pytest
+
+from idun_agent_engine.core.config_builder import ConfigBuilder
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import AgentGraph, AgentNode, EdgeKind
+
+
+@pytest.mark.asyncio
+async def test_langgraph_get_graph_ir_simple():
+    mock_graph_path = (
+        Path(__file__).parent.parent.parent / "fixtures" / "agents" / "mock_graph.py"
+    )
+    config = {
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "test_agent",
+                "graph_definition": f"{mock_graph_path}:graph",
+            },
+        },
+    }
+    engine_config = ConfigBuilder.from_dict(config).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
+
+    ir = agent.get_graph_ir()
+
+    assert isinstance(ir, AgentGraph)
+    assert ir.metadata.framework == AgentFramework.LANGGRAPH
+    assert ir.format_version == "1"
+    assert any(isinstance(n, AgentNode) and n.is_root for n in ir.nodes)
+    # Every edge has GRAPH_EDGE kind for LangGraph
+    assert all(e.kind == EdgeKind.GRAPH_EDGE for e in ir.edges)
+
+
+@pytest.mark.asyncio
+async def test_langgraph_draw_mermaid_uses_native_output():
+    """LangGraph delegates to native draw_mermaid; output should not contain
+    our renderer's classDef definitions."""
+    mock_graph_path = (
+        Path(__file__).parent.parent.parent / "fixtures" / "agents" / "mock_graph.py"
+    )
+    config = {
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "test_agent",
+                "graph_definition": f"{mock_graph_path}:graph",
+            },
+        },
+    }
+    engine_config = ConfigBuilder.from_dict(config).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
+
+    output = agent.draw_mermaid()
+    assert "graph TD" in output or "%%{init" in output  # LangGraph native marker
+    # Our renderer's classDef sentinels are NOT present
+    assert "classDef agentRoot" not in output
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/agent/test_langgraph_graph_ir.py -v
+```
+
+Expected: AttributeError or NotImplementedError (no get_graph_ir override).
+
+- [ ] **Step 3: Implement on `LanggraphAgent`**
+
+Modify `libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py` — add three methods to the `LanggraphAgent` class:
+
+```python
+def get_graph_ir(self):
+    from langgraph.graph.state import CompiledStateGraph
+    from idun_agent_schema.engine.agent_framework import AgentFramework
+    from idun_agent_schema.engine.graph import (
+        AgentGraph,
+        AgentGraphEdge,
+        AgentGraphMetadata,
+        AgentKind,
+        AgentNode,
+        EdgeKind,
+    )
+
+    if not isinstance(self._agent_instance, CompiledStateGraph):
+        raise NotImplementedError(
+            "LangGraph graph introspection requires a CompiledStateGraph"
+        )
+
+    lg_graph = self._agent_instance.get_graph()
+    nodes: list[AgentNode] = []
+    edges: list[AgentGraphEdge] = []
+
+    for node_id, _ in lg_graph.nodes.items():
+        is_root = node_id == "__start__"
+        nodes.append(AgentNode(
+            id=f"node:{node_id}",
+            name=node_id,
+            agent_kind=AgentKind.CUSTOM,
+            is_root=is_root,
+        ))
+
+    for lg_edge in lg_graph.edges:
+        # Public attrs: source, target. `conditional` and `data` are documented;
+        # if a future LangGraph version renames them, fall back gracefully.
+        condition = None
+        try:
+            if getattr(lg_edge, "conditional", False):
+                data = getattr(lg_edge, "data", None)
+                condition = str(data) if data is not None else None
+        except Exception:
+            condition = None
+        label = getattr(lg_edge, "data", None)
+        edges.append(AgentGraphEdge(
+            source=f"node:{lg_edge.source}",
+            target=f"node:{lg_edge.target}",
+            kind=EdgeKind.GRAPH_EDGE,
+            condition=condition,
+            label=str(label) if label is not None and not condition else None,
+        ))
+
+    return AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.LANGGRAPH,
+            agent_name=self.name,
+            root_id="node:__start__",
+        ),
+        nodes=nodes,
+        edges=edges,
+    )
+
+def draw_mermaid(self) -> str:
+    """Delegate to LangGraph's native draw_mermaid for polish/parity."""
+    from langgraph.graph.state import CompiledStateGraph
+
+    if not isinstance(self._agent_instance, CompiledStateGraph):
+        raise NotImplementedError(
+            "LangGraph mermaid rendering requires a CompiledStateGraph"
+        )
+    return self._agent_instance.get_graph().draw_mermaid()
+
+def draw_ascii(self) -> str:
+    """Delegate to LangGraph's native draw_ascii (grandalf-backed)."""
+    from langgraph.graph.state import CompiledStateGraph
+
+    if not isinstance(self._agent_instance, CompiledStateGraph):
+        raise NotImplementedError(
+            "LangGraph ascii rendering requires a CompiledStateGraph"
+        )
+    return self._agent_instance.get_graph().draw_ascii()
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/agent/test_langgraph_graph_ir.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py \
+        libs/idun_agent_engine/tests/unit/agent/test_langgraph_graph_ir.py
+git commit -m "feat(engine): LangGraph adapter implements get_graph_ir + native draw overrides"
+```
+
+---
+
+## Task 6: Engine — ADK adapter introspection (single agent + tools)
+
+**Files:**
+- Modify: `libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py`
+- Modify: `libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py`
+- Create: `libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py`
+
+- [ ] **Step 1: Extend the mock ADK fixtures**
+
+Modify `libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py` — add new fixture agents at the bottom of the file (keep the existing `MockADKAgent` and `mock_adk_agent_instance`):
+
+```python
+# -----------------------------------------------------------------------------
+# Fixtures for graph IR tests
+# -----------------------------------------------------------------------------
+
+from google.adk.agents import LlmAgent
+
+# Simple LlmAgent, no tools, no sub-agents
+mock_llm_simple = LlmAgent(
+    name="simple",
+    model="gemini-2.5-flash",
+    instruction="You are a test agent.",
+    description="A simple test agent.",
+)
+
+
+def _native_func(x: str) -> str:
+    """A plain function tool."""
+    return x
+
+
+# LlmAgent with one native function tool
+mock_llm_with_native_tool = LlmAgent(
+    name="with_native",
+    model="gemini-2.5-flash",
+    instruction="You are a test agent.",
+    tools=[_native_func],
+)
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py`:
+
+```python
+"""Tests for AdkAgent graph introspection — single agent + tools cases."""
+
+from pathlib import Path
+
+import pytest
+
+from idun_agent_engine.core.config_builder import ConfigBuilder
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+
+
+def _adk_config(agent_var: str) -> dict:
+    fixture_path = (
+        Path(__file__).parent.parent.parent / "fixtures" / "agents" / "mock_adk_agent.py"
+    )
+    return {
+        "agent": {
+            "type": "ADK",
+            "config": {
+                "name": f"adk_{agent_var}",
+                "app_name": f"adk_{agent_var}",
+                "agent": f"{fixture_path}:{agent_var}",
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_adk_simple_llm_agent():
+    config = ConfigBuilder.from_dict(_adk_config("mock_llm_simple")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+
+    assert isinstance(ir, AgentGraph)
+    assert ir.metadata.framework == AgentFramework.ADK
+    agent_nodes = [n for n in ir.nodes if isinstance(n, AgentNode)]
+    tool_nodes = [n for n in ir.nodes if isinstance(n, ToolNode)]
+    assert len(agent_nodes) == 1
+    assert len(tool_nodes) == 0
+    assert agent_nodes[0].is_root is True
+    assert agent_nodes[0].name == "simple"
+    assert agent_nodes[0].model == "gemini-2.5-flash"
+
+
+@pytest.mark.asyncio
+async def test_adk_llm_with_native_tool():
+    config = ConfigBuilder.from_dict(_adk_config("mock_llm_with_native_tool")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+
+    tool_nodes = [n for n in ir.nodes if isinstance(n, ToolNode)]
+    assert len(tool_nodes) == 1
+    assert tool_nodes[0].tool_kind == ToolKind.NATIVE
+    # one tool_attach edge exists
+    attach_edges = [e for e in ir.edges if e.kind == EdgeKind.TOOL_ATTACH]
+    assert len(attach_edges) == 1
+```
+
+- [ ] **Step 3: Run tests — confirm they fail**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py -v
+```
+
+Expected: NotImplementedError (default `BaseAgent.get_graph_ir`).
+
+- [ ] **Step 4: Implement `AdkAgent.get_graph_ir()` (initial scope: single agent + tool kinds)**
+
+Modify `libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py` — add these methods to the `AdkAgent` class. The implementation here covers single agents + tools only; workflow-agent edge dispatch is added in Task 7. We deliberately stage the scope to keep diffs reviewable.
+
+```python
+def get_graph_ir(self):
+    from google.adk.agents import (
+        BaseAgent as ADKBaseAgent,
+        LlmAgent,
+        LoopAgent,
+        ParallelAgent,
+        SequentialAgent,
+    )
+    from idun_agent_schema.engine.agent_framework import AgentFramework
+    from idun_agent_schema.engine.graph import (
+        AgentGraph,
+        AgentGraphEdge,
+        AgentGraphMetadata,
+        AgentGraphNode,
+        AgentKind,
+        AgentNode,
+        EdgeKind,
+        ToolKind,
+        ToolNode,
+    )
+
+    if self._agent_instance is None:
+        raise RuntimeError("Agent not initialized. Call initialize() first.")
+
+    root_agent = self._agent_instance.root_agent
+    nodes: list[AgentGraphNode] = []
+    edges: list[AgentGraphEdge] = []
+    warnings: list[str] = []
+
+    def _agent_kind(a: object) -> AgentKind:
+        if isinstance(a, SequentialAgent): return AgentKind.SEQUENTIAL
+        if isinstance(a, ParallelAgent):   return AgentKind.PARALLEL
+        if isinstance(a, LoopAgent):       return AgentKind.LOOP
+        if isinstance(a, LlmAgent):        return AgentKind.LLM
+        return AgentKind.CUSTOM
+
+    def _classify_tool(tool: object) -> tuple[ToolKind, str | None]:
+        # Try MCP toolset detection — both old and new import paths.
+        for mod_path in (
+            "google.adk.tools.mcp_tool.mcp_toolset",
+            "google.adk.tools",
+        ):
+            try:
+                module = __import__(mod_path, fromlist=["MCPToolset", "McpToolset"])
+                cls = getattr(module, "MCPToolset", None) or getattr(module, "McpToolset", None)
+                if cls is not None and isinstance(tool, cls):
+                    return (ToolKind.MCP, _describe_mcp_params(getattr(tool, "connection_params", None)))
+            except Exception:  # noqa: BLE001 — best-effort import
+                continue
+        # Built-in detection: anything in the google.adk.tools module hierarchy
+        # that wasn't already matched as MCP above. User-defined function tools
+        # live in the user's own module (e.g. their agent module or __main__).
+        module = getattr(tool, "__module__", "") or ""
+        if module.startswith("google.adk.tools"):
+            return (ToolKind.BUILT_IN, None)
+        return (ToolKind.NATIVE, None)
+
+    def _walk(agent: object, is_root: bool = False) -> str:
+        agent_id = f"agent:{agent.name}"
+        kind = _agent_kind(agent)
+        nodes.append(AgentNode(
+            id=agent_id,
+            name=agent.name,
+            agent_kind=kind,
+            is_root=is_root,
+            description=getattr(agent, "description", None),
+            model=getattr(agent, "model", None) if kind == AgentKind.LLM else None,
+            loop_max_iterations=(
+                getattr(agent, "max_iterations", None) if kind == AgentKind.LOOP else None
+            ),
+        ))
+        if kind == AgentKind.CUSTOM:
+            warnings.append(
+                f"Agent '{agent.name}' is a custom BaseAgent subclass; "
+                f"introspected best-effort"
+            )
+
+        for tool in getattr(agent, "tools", None) or []:
+            tool_name = getattr(tool, "name", None) or getattr(tool, "__name__", None) or repr(tool)[:40]
+            tool_id = f"tool:{tool_name}@{agent.name}"
+            tool_kind, server_desc = _classify_tool(tool)
+            nodes.append(ToolNode(
+                id=tool_id,
+                name=tool_name,
+                tool_kind=tool_kind,
+                description=getattr(tool, "description", None),
+                mcp_server_name=server_desc,
+            ))
+            edges.append(AgentGraphEdge(
+                source=agent_id, target=tool_id, kind=EdgeKind.TOOL_ATTACH,
+            ))
+
+        # Sub-agents — Task 7 will add edge-kind dispatch; for now use PARENT_CHILD.
+        for sub in getattr(agent, "sub_agents", None) or []:
+            child_id = _walk(sub, is_root=False)
+            edges.append(AgentGraphEdge(
+                source=agent_id, target=child_id, kind=EdgeKind.PARENT_CHILD,
+            ))
+        return agent_id
+
+    root_id = _walk(root_agent, is_root=True)
+    return AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK,
+            agent_name=self.name,
+            root_id=root_id,
+            warnings=warnings,
+        ),
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+def _describe_mcp_params(params: object) -> str | None:
+    """Best-effort label for an MCPToolset connection params object."""
+    if params is None:
+        return None
+    cmd = getattr(params, "command", None)
+    args = getattr(params, "args", None)
+    if cmd is not None:
+        joined = " ".join(args or [])
+        return f"stdio: {cmd} {joined}".strip()
+    url = getattr(params, "url", None)
+    if url is not None:
+        return f"http: {url}"
+    return type(params).__name__
+```
+
+(The `_describe_mcp_params` helper sits at module level near the other helpers in `adk.py` — not inside the class. Place it adjacent to `_extract_text_from_event`.)
+
+- [ ] **Step 5: Run tests — confirm they pass**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py \
+        libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py \
+        libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py
+git commit -m "feat(engine): ADK adapter get_graph_ir for single agent + tool kinds"
+```
+
+---
+
+## Task 7: Engine — ADK adapter workflow agents (Sequential, Parallel, Loop)
+
+**Files:**
+- Modify: `libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py` (extend `_walk`'s edge-kind dispatch)
+- Modify: `libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py` (add workflow fixtures)
+- Modify: `libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py` (add tests)
+
+- [ ] **Step 1: Add workflow-agent fixtures**
+
+Append to `libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py`:
+
+```python
+from google.adk.agents import LoopAgent, ParallelAgent, SequentialAgent
+
+mock_seq_step_a = LlmAgent(name="seq_a", model="gemini-2.5-flash", instruction="A")
+mock_seq_step_b = LlmAgent(name="seq_b", model="gemini-2.5-flash", instruction="B")
+mock_seq_step_c = LlmAgent(name="seq_c", model="gemini-2.5-flash", instruction="C")
+mock_sequential_agent = SequentialAgent(
+    name="seq_root",
+    sub_agents=[mock_seq_step_a, mock_seq_step_b, mock_seq_step_c],
+)
+
+mock_par_a = LlmAgent(name="par_a", model="gemini-2.5-flash", instruction="A")
+mock_par_b = LlmAgent(name="par_b", model="gemini-2.5-flash", instruction="B")
+mock_parallel_agent = ParallelAgent(name="par_root", sub_agents=[mock_par_a, mock_par_b])
+
+mock_loop_step = LlmAgent(name="loop_step", model="gemini-2.5-flash", instruction="L")
+mock_loop_agent = LoopAgent(
+    name="loop_root",
+    sub_agents=[mock_loop_step],
+    max_iterations=5,
+)
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Append to `libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_adk_sequential_agent():
+    config = ConfigBuilder.from_dict(_adk_config("mock_sequential_agent")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+    seq_edges = sorted(
+        [e for e in ir.edges if e.kind == EdgeKind.SEQUENTIAL_STEP],
+        key=lambda e: e.order or 0,
+    )
+    assert [e.order for e in seq_edges] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_adk_parallel_agent():
+    config = ConfigBuilder.from_dict(_adk_config("mock_parallel_agent")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+    par_edges = [e for e in ir.edges if e.kind == EdgeKind.PARALLEL_BRANCH]
+    assert len(par_edges) == 2
+
+
+@pytest.mark.asyncio
+async def test_adk_loop_agent_max_iterations():
+    config = ConfigBuilder.from_dict(_adk_config("mock_loop_agent")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+    root = next(n for n in ir.nodes if isinstance(n, AgentNode) and n.is_root)
+    assert root.loop_max_iterations == 5
+    assert any(e.kind == EdgeKind.LOOP_STEP for e in ir.edges)
+```
+
+- [ ] **Step 3: Run tests — confirm new ones fail**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py -v
+```
+
+Expected: 3 of the new tests fail (existing 2 still pass) — sub-agent edges are all `parent_child` today.
+
+- [ ] **Step 4: Update `_walk` to dispatch edge kind**
+
+In `libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py`, replace the inner sub-agent loop in `_walk` with:
+
+```python
+# Sub-agents
+for i, sub in enumerate(getattr(agent, "sub_agents", None) or []):
+    child_id = _walk(sub, is_root=False)
+    edge_kind = {
+        AgentKind.SEQUENTIAL: EdgeKind.SEQUENTIAL_STEP,
+        AgentKind.PARALLEL:   EdgeKind.PARALLEL_BRANCH,
+        AgentKind.LOOP:       EdgeKind.LOOP_STEP,
+    }.get(kind, EdgeKind.PARENT_CHILD)
+    edges.append(AgentGraphEdge(
+        source=agent_id,
+        target=child_id,
+        kind=edge_kind,
+        order=i if edge_kind == EdgeKind.SEQUENTIAL_STEP else None,
+    ))
+```
+
+- [ ] **Step 5: Run tests — confirm all 5 pass**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py \
+        libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py \
+        libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py
+git commit -m "feat(engine): ADK adapter encodes Sequential/Parallel/Loop edge kinds"
+```
+
+---
+
+## Task 8: Engine — ADK adapter custom subclass + nested cases
+
+**Files:**
+- Modify: `libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py`
+- Modify: `libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py`
+
+(No production code changes — the existing `_walk` already supports nested + custom; this task locks behavior in tests.)
+
+- [ ] **Step 1: Add fixtures**
+
+Append to `libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py`:
+
+```python
+# Nested: root LlmAgent with a SequentialAgent sub-agent + native tool
+mock_nested_inner_a = LlmAgent(name="inner_a", model="gemini-2.5-flash", instruction="ia")
+mock_nested_inner_b = LlmAgent(name="inner_b", model="gemini-2.5-flash", instruction="ib")
+mock_nested_seq = SequentialAgent(
+    name="inner_seq", sub_agents=[mock_nested_inner_a, mock_nested_inner_b],
+)
+mock_nested_root = LlmAgent(
+    name="nested_root",
+    model="gemini-2.5-flash",
+    instruction="root",
+    tools=[_native_func],
+    sub_agents=[mock_nested_seq],
+)
+
+# Custom subclass — reuse MockADKAgent already defined above.
+mock_custom_root = MockADKAgent(
+    name="custom_root",
+    description="Custom subclass for graph IR test",
+)
+```
+
+- [ ] **Step 2: Add tests**
+
+Append to `libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_adk_nested_root_with_sequential_subagent():
+    config = ConfigBuilder.from_dict(_adk_config("mock_nested_root")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+
+    agent_nodes = [n for n in ir.nodes if isinstance(n, AgentNode)]
+    # nested_root + inner_seq + inner_a + inner_b
+    assert len(agent_nodes) == 4
+    # Root → SequentialAgent uses PARENT_CHILD (root is LLM, not workflow)
+    parent_edges = [e for e in ir.edges if e.kind == EdgeKind.PARENT_CHILD]
+    assert len(parent_edges) == 1
+    # Inner_seq → its 2 children use SEQUENTIAL_STEP
+    seq_edges = [e for e in ir.edges if e.kind == EdgeKind.SEQUENTIAL_STEP]
+    assert len(seq_edges) == 2
+
+
+@pytest.mark.asyncio
+async def test_adk_custom_baseagent_subclass_emits_warning():
+    config = ConfigBuilder.from_dict(_adk_config("mock_custom_root")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+
+    root = next(n for n in ir.nodes if isinstance(n, AgentNode) and n.is_root)
+    from idun_agent_schema.engine.graph import AgentKind
+    assert root.agent_kind == AgentKind.CUSTOM
+    assert any("custom_root" in w for w in ir.metadata.warnings)
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py -v
+```
+
+Expected: 7 passed (5 existing + 2 new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py \
+        libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py
+git commit -m "test(engine): cover nested ADK + custom BaseAgent subclass cases"
+```
+
+---
+
+## Task 9: Engine — replace `/agent/graph` route with three new routes
+
+**Files:**
+- Modify: `libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py`
+- Modify: `libs/idun_agent_engine/tests/unit/server/routers/agent/test_graph_route.py`
+
+- [ ] **Step 1: Update tests for the new contract**
+
+Replace the entire content of `libs/idun_agent_engine/tests/unit/server/routers/agent/test_graph_route.py` with:
+
+```python
+"""Tests for the /agent/graph, /agent/graph/mermaid, /agent/graph/ascii endpoints."""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from idun_agent_engine.core.app_factory import create_app
+from idun_agent_engine.core.config_builder import ConfigBuilder
+
+
+def _langgraph_app():
+    config = ConfigBuilder.from_dict({
+        "server": {"api": {"port": 8000}},
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "Test Agent",
+                "graph_definition": "tests.fixtures.agents.mock_graph:graph",
+            },
+        },
+    }).build()
+    return create_app(engine_config=config)
+
+
+def _haystack_app():
+    mock_path = (
+        Path(__file__).resolve().parent.parent.parent.parent.parent
+        / "fixtures" / "agents" / "mock_haystack_pipeline.py"
+    )
+    config = ConfigBuilder.from_dict({
+        "server": {"api": {"port": 8000}},
+        "agent": {
+            "type": "HAYSTACK",
+            "config": {
+                "name": "Haystack Agent",
+                "component_type": "pipeline",
+                "component_definition": f"{mock_path}:mock_haystack_pipeline",
+            },
+        },
+    }).build()
+    return create_app(engine_config=config)
+
+
+@pytest.mark.unit
+class TestAgentGraphRoutes:
+    def test_ir_route_returns_agent_graph(self):
+        app = _langgraph_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["format_version"] == "1"
+        assert "metadata" in body and "nodes" in body and "edges" in body
+        assert body["metadata"]["framework"] == "LANGGRAPH"
+
+    def test_mermaid_route_returns_string(self):
+        app = _langgraph_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph/mermaid")
+        assert response.status_code == 200
+        body = response.json()
+        assert "mermaid" in body
+        assert isinstance(body["mermaid"], str) and body["mermaid"]
+
+    def test_ascii_route_returns_string(self):
+        app = _langgraph_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph/ascii")
+        assert response.status_code == 200
+        body = response.json()
+        assert "ascii" in body
+        assert isinstance(body["ascii"], str) and body["ascii"]
+
+    def test_ir_route_404_for_haystack(self):
+        app = _haystack_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph")
+        assert response.status_code == 404
+
+    def test_mermaid_route_404_for_haystack(self):
+        app = _haystack_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph/mermaid")
+        assert response.status_code == 404
+
+    def test_ascii_route_404_for_haystack(self):
+        app = _haystack_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph/ascii")
+        assert response.status_code == 404
+```
+
+- [ ] **Step 2: Run tests — confirm IR + ascii routes fail**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/server/routers/agent/test_graph_route.py -v
+```
+
+Expected: ir/ascii routes 404 (don't exist), mermaid passes only for the legacy `{"graph": str}` shape (will fail because we now expect `mermaid` key).
+
+- [ ] **Step 3: Replace the route block in `agent.py`**
+
+In `libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py`, find the existing `@agent_router.get("/graph")` handler (currently at lines ~140-155, returning `{"graph": instance.get_graph().draw_mermaid()}`). Replace that single handler with **three** handlers:
+
+```python
+from idun_agent_schema.engine.graph import AgentGraph
+
+
+@agent_router.get("/graph", response_model=AgentGraph)
+async def get_graph_ir(
+    agent: Annotated[BaseAgent, Depends(get_agent)],
+    _user: Annotated[dict | None, Depends(get_verified_user)],
+) -> AgentGraph:
+    """Framework-agnostic JSON IR — primary contract for UI rendering."""
+    try:
+        return agent.get_graph_ir()
+    except NotImplementedError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception:
+        logger.exception("Graph IR extraction failed")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Graph introspection failed",
+        )
+
+
+@agent_router.get("/graph/mermaid")
+async def get_graph_mermaid(
+    agent: Annotated[BaseAgent, Depends(get_agent)],
+    _user: Annotated[dict | None, Depends(get_verified_user)],
+) -> dict[str, str]:
+    """Mermaid source string."""
+    try:
+        return {"mermaid": agent.draw_mermaid()}
+    except NotImplementedError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception:
+        logger.exception("Mermaid rendering failed")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Mermaid rendering failed",
+        )
+
+
+@agent_router.get("/graph/ascii")
+async def get_graph_ascii(
+    agent: Annotated[BaseAgent, Depends(get_agent)],
+    _user: Annotated[dict | None, Depends(get_verified_user)],
+) -> dict[str, str]:
+    """ASCII art rendering."""
+    try:
+        return {"ascii": agent.draw_ascii()}
+    except NotImplementedError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception:
+        logger.exception("ASCII rendering failed")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ASCII rendering failed",
+        )
+```
+
+(Delete the original handler. Imports for `AgentGraph` and `status` should already be present or covered; add them if not.)
+
+- [ ] **Step 4: Run tests — confirm all 6 pass**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/server/routers/agent/test_graph_route.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Run the full engine test suite to catch regressions**
+
+```bash
+uv run pytest libs/idun_agent_engine/tests/unit/ -v -m "not requires_langfuse and not requires_phoenix and not requires_postgres"
+```
+
+Expected: all green (no regressions in other agent tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py \
+        libs/idun_agent_engine/tests/unit/server/routers/agent/test_graph_route.py
+git commit -m "feat(engine): replace /agent/graph with IR + mermaid + ascii routes"
+```
+
+---
+
+## Task 10: Admin web URL swap (3-line compat fix)
+
+**Files:**
+- Modify: `services/idun_agent_web/src/services/agents.ts` (around line 230-235)
+
+- [ ] **Step 1: Update the API call**
+
+Open `services/idun_agent_web/src/services/agents.ts`, find the `getAgentGraph` function (around lines 225-240, the one calling `buildAgentUrl(baseUrl, '/agent/graph')` and returning `data.graph`). Update:
+
+- Change the URL from `'/agent/graph'` to `'/agent/graph/mermaid'`
+- Change `data.graph ?? null` to `data.mermaid ?? null`
+
+The function shape should now look like:
+
+```ts
+const url = buildAgentUrl(baseUrl, '/agent/graph/mermaid');
+// ... fetch ...
+return data.mermaid ?? null;
+```
+
+- [ ] **Step 2: Verify the consumer still typechecks**
+
+```bash
+cd services/idun_agent_web && npx tsc --noEmit && cd -
+```
+
+Expected: no new TS errors related to this change.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/idun_agent_web/src/services/agents.ts
+git commit -m "fix(web): point graph-section to /agent/graph/mermaid for new engine contract"
+```
+
+---
+
+## Task 11: Standalone-UI — dependencies, types, API client
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/package.json`
+- Create: `services/idun_agent_standalone_ui/lib/api/types/graph.ts`
+- Modify: `services/idun_agent_standalone_ui/lib/api/types/index.ts` (re-export)
+- Modify: `services/idun_agent_standalone_ui/lib/api/index.ts`
+
+- [ ] **Step 1: Install dependencies**
+
+```bash
+cd services/idun_agent_standalone_ui
+npm install --save @xyflow/react @dagrejs/dagre
+cd -
+```
+
+(If the project uses pnpm based on `pnpm-lock.yaml`, swap to `pnpm add @xyflow/react @dagrejs/dagre`. Check which lockfile is committed.)
+
+- [ ] **Step 2: Add TS mirror of the IR**
+
+Create `services/idun_agent_standalone_ui/lib/api/types/graph.ts`:
+
+```ts
+/**
+ * TypeScript mirror of idun_agent_schema.engine.graph (Pydantic).
+ *
+ * The schema package is the source of truth — when those models change, this
+ * file must follow. Discriminated unions on `kind`.
+ */
+
+export type AgentKind =
+  | "llm"
+  | "sequential"
+  | "parallel"
+  | "loop"
+  | "custom";
+
+export type ToolKind = "native" | "mcp" | "built_in";
+
+export type EdgeKind =
+  | "parent_child"
+  | "sequential_step"
+  | "parallel_branch"
+  | "loop_step"
+  | "tool_attach"
+  | "graph_edge";
+
+export interface AgentNode {
+  kind: "agent";
+  id: string;
+  name: string;
+  agent_kind: AgentKind;
+  is_root: boolean;
+  description: string | null;
+  model: string | null;
+  loop_max_iterations: number | null;
+}
+
+export interface ToolNode {
+  kind: "tool";
+  id: string;
+  name: string;
+  tool_kind: ToolKind;
+  description: string | null;
+  mcp_server_name: string | null;
+}
+
+export type AgentGraphNode = AgentNode | ToolNode;
+
+export interface AgentGraphEdge {
+  source: string;
+  target: string;
+  kind: EdgeKind;
+  order: number | null;
+  condition: string | null;
+  label: string | null;
+}
+
+export interface AgentGraphMetadata {
+  framework: "LANGGRAPH" | "ADK" | "HAYSTACK";
+  agent_name: string;
+  root_id: string;
+  warnings: string[];
+}
+
+export interface AgentGraph {
+  format_version: "1";
+  metadata: AgentGraphMetadata;
+  nodes: AgentGraphNode[];
+  edges: AgentGraphEdge[];
+}
+```
+
+- [ ] **Step 3: Re-export from the types barrel**
+
+Open `services/idun_agent_standalone_ui/lib/api/types/index.ts` (or whichever file aggregates type re-exports — check for one near `lib/api/types/`). Append:
+
+```ts
+export type {
+  AgentGraph,
+  AgentGraphEdge,
+  AgentGraphMetadata,
+  AgentGraphNode,
+  AgentKind,
+  AgentNode,
+  EdgeKind,
+  ToolKind,
+  ToolNode,
+} from "./graph";
+```
+
+If no `index.ts` exists, create one that re-exports the existing typed sub-files plus this one.
+
+- [ ] **Step 4: Add API client methods**
+
+Open `services/idun_agent_standalone_ui/lib/api/index.ts`. Add an import for `AgentGraph`:
+
+```ts
+import type { AgentGraph } from "./types/graph";
+```
+
+Inside the `api` object literal (near the bottom), add three methods. **Important:** these hit the engine surface (`/agent/graph`), not `${ADMIN}/...`:
+
+```ts
+  // Engine surface — graph visualizer (LangGraph + ADK)
+  getAgentGraph: () => apiFetch<AgentGraph>("/agent/graph"),
+  getAgentGraphMermaid: () =>
+    apiFetch<{ mermaid: string }>("/agent/graph/mermaid"),
+  getAgentGraphAscii: () =>
+    apiFetch<{ ascii: string }>("/agent/graph/ascii"),
+```
+
+- [ ] **Step 5: Verify build**
+
+```bash
+cd services/idun_agent_standalone_ui && npm run typecheck && cd -
+```
+
+Expected: `tsc --noEmit` passes (the project has `ignoreBuildErrors: true` for builds, but `npm run typecheck` is cleaner).
+
+If the project's pre-existing TS errors block this, manually scope the check:
+
+```bash
+cd services/idun_agent_standalone_ui && npx tsc --noEmit lib/api/types/graph.ts && cd -
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/package.json \
+        services/idun_agent_standalone_ui/package-lock.json \
+        services/idun_agent_standalone_ui/lib/api/types/graph.ts \
+        services/idun_agent_standalone_ui/lib/api/types/index.ts \
+        services/idun_agent_standalone_ui/lib/api/index.ts
+# (or pnpm-lock.yaml if pnpm)
+git commit -m "feat(standalone-ui): add ReactFlow deps, IR types, graph API methods"
+```
+
+---
+
+## Task 12: Standalone-UI — `irToReactFlow` pure mapping function
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/components/graph/irToReactFlow.ts`
+- Create: `services/idun_agent_standalone_ui/components/graph/__tests__/irToReactFlow.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/idun_agent_standalone_ui/components/graph/__tests__/irToReactFlow.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import type { AgentGraph } from "@/lib/api/types/graph";
+import { irToReactFlow } from "../irToReactFlow";
+
+const SAMPLE: AgentGraph = {
+  format_version: "1",
+  metadata: {
+    framework: "ADK",
+    agent_name: "root",
+    root_id: "agent:root",
+    warnings: [],
+  },
+  nodes: [
+    {
+      kind: "agent",
+      id: "agent:root",
+      name: "root",
+      agent_kind: "llm",
+      is_root: true,
+      description: null,
+      model: "gemini-2.5-flash",
+      loop_max_iterations: null,
+    },
+    {
+      kind: "tool",
+      id: "tool:search@root",
+      name: "search",
+      tool_kind: "mcp",
+      description: null,
+      mcp_server_name: "stdio: x",
+    },
+  ],
+  edges: [
+    {
+      source: "agent:root",
+      target: "tool:search@root",
+      kind: "tool_attach",
+      order: null,
+      condition: null,
+      label: null,
+    },
+  ],
+};
+
+describe("irToReactFlow", () => {
+  it("maps every IR node to one ReactFlow node with the IR id", () => {
+    const { nodes, edges } = irToReactFlow(SAMPLE);
+    expect(nodes).toHaveLength(2);
+    expect(nodes.map((n) => n.id).sort()).toEqual(
+      ["agent:root", "tool:search@root"].sort(),
+    );
+  });
+
+  it("uses 'agent' / 'tool' for ReactFlow node types", () => {
+    const { nodes } = irToReactFlow(SAMPLE);
+    expect(nodes.find((n) => n.id === "agent:root")?.type).toBe("agent");
+    expect(nodes.find((n) => n.id === "tool:search@root")?.type).toBe("tool");
+  });
+
+  it("maps every IR edge to one ReactFlow edge", () => {
+    const { edges } = irToReactFlow(SAMPLE);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      source: "agent:root",
+      target: "tool:search@root",
+      type: "pretty",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test — confirm it fails**
+
+```bash
+cd services/idun_agent_standalone_ui && npx vitest run components/graph/__tests__/irToReactFlow.test.ts && cd -
+```
+
+Expected: FAIL — `irToReactFlow` not found.
+
+- [ ] **Step 3: Implement the mapper**
+
+Create `services/idun_agent_standalone_ui/components/graph/irToReactFlow.ts`:
+
+```ts
+import type { Edge, Node } from "@xyflow/react";
+
+import type {
+  AgentGraph,
+  AgentGraphEdge,
+  AgentGraphNode,
+} from "@/lib/api/types/graph";
+
+export interface ReactFlowGraph {
+  nodes: Node<AgentGraphNode>[];
+  edges: Edge<AgentGraphEdge>[];
+}
+
+export function irToReactFlow(graph: AgentGraph): ReactFlowGraph {
+  const nodes: Node<AgentGraphNode>[] = graph.nodes.map((n) => ({
+    id: n.id,
+    type: n.kind, // "agent" | "tool"
+    position: { x: 0, y: 0 }, // dagre layout fills these in later
+    data: n,
+  }));
+
+  const edges: Edge<AgentGraphEdge>[] = graph.edges.map((e) => ({
+    id: `${e.source}->${e.target}`,
+    source: e.source,
+    target: e.target,
+    type: "pretty", // single custom edge component dispatches on data.kind
+    data: e,
+  }));
+
+  return { nodes, edges };
+}
+```
+
+- [ ] **Step 4: Run test — confirm pass**
+
+```bash
+cd services/idun_agent_standalone_ui && npx vitest run components/graph/__tests__/irToReactFlow.test.ts && cd -
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/components/graph/irToReactFlow.ts \
+        services/idun_agent_standalone_ui/components/graph/__tests__/irToReactFlow.test.ts
+git commit -m "feat(standalone-ui): add pure IR→ReactFlow mapping function"
+```
+
+---
+
+## Task 13: Standalone-UI — `AgentNode` and `ToolNode` components
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/components/graph/nodes/AgentNode.tsx`
+- Create: `services/idun_agent_standalone_ui/components/graph/nodes/ToolNode.tsx`
+- Create: `services/idun_agent_standalone_ui/components/graph/__tests__/nodes.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `services/idun_agent_standalone_ui/components/graph/__tests__/nodes.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+
+import type { AgentNode as AgentNodeData, ToolNode as ToolNodeData } from "@/lib/api/types/graph";
+
+import { AgentNode } from "../nodes/AgentNode";
+import { ToolNode } from "../nodes/ToolNode";
+
+const wrap = (ui: React.ReactNode) => render(<ReactFlowProvider>{ui}</ReactFlowProvider>);
+
+describe("AgentNode", () => {
+  it("renders name, kind chip, and root indicator", () => {
+    const data: AgentNodeData = {
+      kind: "agent",
+      id: "agent:root",
+      name: "support_agent",
+      agent_kind: "llm",
+      is_root: true,
+      description: null,
+      model: "gemini-2.5-flash",
+      loop_max_iterations: null,
+    };
+    wrap(<AgentNode data={data} id={data.id} selected={false} />);
+    expect(screen.getByText("support_agent")).toBeInTheDocument();
+    expect(screen.getByText(/LlmAgent/i)).toBeInTheDocument();
+    expect(screen.getByText(/root/i)).toBeInTheDocument();
+  });
+});
+
+describe("ToolNode", () => {
+  it("renders MCP server name when tool_kind=mcp", () => {
+    const data: ToolNodeData = {
+      kind: "tool",
+      id: "tool:search@root",
+      name: "search_faq",
+      tool_kind: "mcp",
+      description: null,
+      mcp_server_name: "stdio: npx server-filesystem",
+    };
+    wrap(<ToolNode data={data} id={data.id} selected={false} />);
+    expect(screen.getByText("search_faq")).toBeInTheDocument();
+    expect(screen.getByText(/stdio: npx server-filesystem/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd services/idun_agent_standalone_ui && npx vitest run components/graph/__tests__/nodes.test.tsx && cd -
+```
+
+Expected: imports fail.
+
+- [ ] **Step 3: Implement `AgentNode`**
+
+Create `services/idun_agent_standalone_ui/components/graph/nodes/AgentNode.tsx`:
+
+```tsx
+"use client";
+
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Bot, Crown } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { AgentNode as AgentNodeData, AgentKind } from "@/lib/api/types/graph";
+
+const KIND_LABEL: Record<AgentKind, string> = {
+  llm: "LlmAgent",
+  sequential: "SequentialAgent",
+  parallel: "ParallelAgent",
+  loop: "LoopAgent",
+  custom: "Custom",
+};
+
+export function AgentNode({ data, selected }: NodeProps<AgentNodeData>) {
+  return (
+    <div
+      className={cn(
+        "min-w-[200px] rounded-lg border bg-card px-3 py-2 shadow-sm",
+        data.is_root
+          ? "border-accent/60 bg-accent/5"
+          : "border-border",
+        selected && "ring-2 ring-accent",
+      )}
+    >
+      <Handle type="target" position={Position.Top} className="!bg-accent/40" />
+      <div className="flex items-start gap-2">
+        <div className="mt-0.5 text-accent">
+          {data.is_root ? <Crown size={16} /> : <Bot size={16} />}
+        </div>
+        <div className="flex-1">
+          <div className="text-sm font-semibold leading-tight text-foreground">
+            {data.name}
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-1">
+            <Badge variant="secondary" className="text-[10px]">
+              {KIND_LABEL[data.agent_kind]}
+            </Badge>
+            {data.is_root && (
+              <Badge variant="outline" className="text-[10px]">
+                root
+              </Badge>
+            )}
+            {data.model && (
+              <Badge variant="outline" className="text-[10px] font-mono">
+                {data.model}
+              </Badge>
+            )}
+            {data.loop_max_iterations != null && (
+              <Badge variant="outline" className="text-[10px]">
+                ×{data.loop_max_iterations}
+              </Badge>
+            )}
+          </div>
+        </div>
+      </div>
+      <Handle type="source" position={Position.Bottom} className="!bg-accent/40" />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Implement `ToolNode`**
+
+Create `services/idun_agent_standalone_ui/components/graph/nodes/ToolNode.tsx`:
+
+```tsx
+"use client";
+
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Plug, Sparkles, Wrench } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { ToolKind, ToolNode as ToolNodeData } from "@/lib/api/types/graph";
+
+const ICON: Record<ToolKind, React.ReactNode> = {
+  native: <Wrench size={12} />,
+  mcp: <Plug size={12} />,
+  built_in: <Sparkles size={12} />,
+};
+
+const ACCENT: Record<ToolKind, string> = {
+  native: "border-emerald-500/50 bg-emerald-500/5 text-emerald-700 dark:text-emerald-300",
+  mcp: "border-sky-500/50 bg-sky-500/5 text-sky-700 dark:text-sky-300",
+  built_in: "border-amber-500/50 bg-amber-500/5 text-amber-700 dark:text-amber-300",
+};
+
+export function ToolNode({ data, selected }: NodeProps<ToolNodeData>) {
+  return (
+    <div
+      className={cn(
+        "min-w-[140px] rounded-full border px-2.5 py-1 text-xs shadow-sm",
+        ACCENT[data.tool_kind],
+        selected && "ring-2 ring-accent",
+      )}
+    >
+      <Handle type="target" position={Position.Top} className="!bg-current opacity-40" />
+      <div className="flex items-center gap-1.5">
+        {ICON[data.tool_kind]}
+        <span className="font-medium">{data.name}</span>
+      </div>
+      {data.mcp_server_name && (
+        <div className="mt-0.5 truncate text-[10px] opacity-70">
+          {data.mcp_server_name}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run tests — confirm pass**
+
+```bash
+cd services/idun_agent_standalone_ui && npx vitest run components/graph/__tests__/nodes.test.tsx && cd -
+```
+
+Expected: 2 passed. (If `Badge` / `cn` paths differ in this codebase, adjust the imports — read the existing `components/ui/badge.tsx` and `lib/utils.ts` to confirm.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/components/graph/nodes/ \
+        services/idun_agent_standalone_ui/components/graph/__tests__/nodes.test.tsx
+git commit -m "feat(standalone-ui): add AgentNode + ToolNode custom ReactFlow nodes"
+```
+
+---
+
+## Task 14: Standalone-UI — `PrettyEdge` (per-`EdgeKind` styling)
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/components/graph/edges/PrettyEdge.tsx`
+
+(Edge appearance is hard to assert in unit tests cheaply — visual quality is verified by Task 15's integration test and the E2E in Task 18. We commit this without a dedicated test.)
+
+- [ ] **Step 1: Implement the edge component**
+
+Create `services/idun_agent_standalone_ui/components/graph/edges/PrettyEdge.tsx`:
+
+```tsx
+"use client";
+
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getBezierPath,
+  type EdgeProps,
+} from "@xyflow/react";
+
+import type { AgentGraphEdge, EdgeKind } from "@/lib/api/types/graph";
+
+interface StylePreset {
+  stroke: string;
+  strokeWidth: number;
+  strokeDasharray?: string;
+}
+
+const STYLES: Record<EdgeKind, StylePreset> = {
+  parent_child:    { stroke: "var(--accent, #7a6cf0)", strokeWidth: 1.5 },
+  sequential_step: { stroke: "var(--accent, #7a6cf0)", strokeWidth: 1.5 },
+  parallel_branch: { stroke: "var(--accent, #7a6cf0)", strokeWidth: 2 },
+  loop_step:       { stroke: "var(--accent, #7a6cf0)", strokeWidth: 1.5, strokeDasharray: "5 4" },
+  tool_attach:     { stroke: "currentColor", strokeWidth: 1.2, strokeDasharray: "4 3" },
+  graph_edge:      { stroke: "var(--accent, #7a6cf0)", strokeWidth: 1.2 },
+};
+
+function edgeLabel(data: AgentGraphEdge | undefined, sourceLoopMax: number | null = null): string | null {
+  if (!data) return null;
+  if (data.kind === "sequential_step" && data.order != null) {
+    return `${data.order + 1}.`;
+  }
+  if (data.kind === "loop_step") {
+    return sourceLoopMax != null ? `↻ ×${sourceLoopMax}` : "↻";
+  }
+  if (data.kind === "graph_edge" && data.condition) {
+    return data.condition;
+  }
+  return data.label ?? null;
+}
+
+export function PrettyEdge(props: EdgeProps<AgentGraphEdge>) {
+  const { sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, data } = props;
+  const [path, labelX, labelY] = getBezierPath({
+    sourceX, sourceY, sourcePosition,
+    targetX, targetY, targetPosition,
+  });
+  const style = data ? STYLES[data.kind] : STYLES.parent_child;
+  const label = edgeLabel(data);
+
+  return (
+    <>
+      <BaseEdge id={props.id} path={path} style={style} />
+      {label && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+            className="pointer-events-none rounded bg-card px-1.5 py-0.5 text-[10px] font-medium text-foreground shadow-sm"
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/components/graph/edges/PrettyEdge.tsx
+git commit -m "feat(standalone-ui): add PrettyEdge custom edge with per-kind styling"
+```
+
+---
+
+## Task 15: Standalone-UI — `AgentGraph` main canvas (dagre + ReactFlow)
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/components/graph/layout.ts`
+- Create: `services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx`
+- Create: `services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { AgentGraph as AgentGraphIR } from "@/lib/api/types/graph";
+
+import { AgentGraph } from "../AgentGraph";
+
+const FIXTURE: AgentGraphIR = {
+  format_version: "1",
+  metadata: {
+    framework: "ADK",
+    agent_name: "root",
+    root_id: "agent:root",
+    warnings: [],
+  },
+  nodes: [
+    {
+      kind: "agent", id: "agent:root", name: "root", agent_kind: "llm",
+      is_root: true, description: null, model: null, loop_max_iterations: null,
+    },
+  ],
+  edges: [],
+};
+
+describe("AgentGraph", () => {
+  it("renders a single-node graph without crashing", () => {
+    render(<AgentGraph graph={FIXTURE} />);
+    expect(screen.getByText("root")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — confirm it fails**
+
+```bash
+cd services/idun_agent_standalone_ui && npx vitest run components/graph/__tests__/AgentGraph.test.tsx && cd -
+```
+
+Expected: import error.
+
+- [ ] **Step 3: Implement the dagre layout helper**
+
+Create `services/idun_agent_standalone_ui/components/graph/layout.ts`:
+
+```ts
+import dagre from "@dagrejs/dagre";
+import type { Edge, Node } from "@xyflow/react";
+
+const NODE_WIDTH = 220;
+const NODE_HEIGHT = 60;
+
+export function applyDagreLayout<TN, TE>(
+  nodes: Node<TN>[],
+  edges: Edge<TE>[],
+): Node<TN>[] {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({ rankdir: "TB", nodesep: 40, ranksep: 60 });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const n of nodes) {
+    g.setNode(n.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  }
+  for (const e of edges) {
+    g.setEdge(e.source, e.target);
+  }
+
+  dagre.layout(g);
+
+  return nodes.map((n) => {
+    const pos = g.node(n.id);
+    return {
+      ...n,
+      position: {
+        x: pos.x - NODE_WIDTH / 2,
+        y: pos.y - NODE_HEIGHT / 2,
+      },
+    };
+  });
+}
+```
+
+- [ ] **Step 4: Implement the canvas component**
+
+Create `services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx`:
+
+```tsx
+"use client";
+
+import "@xyflow/react/dist/style.css";
+
+import {
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+} from "@xyflow/react";
+import { useMemo } from "react";
+
+import type { AgentGraph as AgentGraphIR } from "@/lib/api/types/graph";
+
+import { PrettyEdge } from "./edges/PrettyEdge";
+import { irToReactFlow } from "./irToReactFlow";
+import { applyDagreLayout } from "./layout";
+import { AgentNode } from "./nodes/AgentNode";
+import { ToolNode } from "./nodes/ToolNode";
+
+interface AgentGraphProps {
+  graph: AgentGraphIR;
+  /** Height of the canvas. Defaults to a sensible value for a card embed. */
+  height?: number;
+}
+
+const NODE_TYPES = { agent: AgentNode, tool: ToolNode };
+const EDGE_TYPES = { pretty: PrettyEdge };
+
+export function AgentGraph({ graph, height = 420 }: AgentGraphProps) {
+  const { nodes, edges } = useMemo(() => {
+    const mapped = irToReactFlow(graph);
+    return { nodes: applyDagreLayout(mapped.nodes, mapped.edges), edges: mapped.edges };
+  }, [graph]);
+
+  return (
+    <div style={{ height }} className="w-full overflow-hidden rounded-md border bg-background">
+      <ReactFlowProvider>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={NODE_TYPES}
+          edgeTypes={EDGE_TYPES}
+          fitView
+          minZoom={0.4}
+          maxZoom={1.5}
+          proOptions={{ hideAttribution: true }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+        >
+          <Background />
+          <Controls showInteractive={false} />
+          <MiniMap pannable zoomable />
+        </ReactFlow>
+      </ReactFlowProvider>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run test — confirm pass**
+
+```bash
+cd services/idun_agent_standalone_ui && npx vitest run components/graph/__tests__/AgentGraph.test.tsx && cd -
+```
+
+Expected: 1 passed.
+
+(Note: `@xyflow/react` requires a `width` and `height` on its parent in jsdom; the wrapper div above provides height. If the test errors with "container has no width", wrap the component in `<div style={{ width: 800 }}>` in the test.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/components/graph/layout.ts \
+        services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx \
+        services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx
+git commit -m "feat(standalone-ui): add AgentGraph ReactFlow canvas with dagre layout"
+```
+
+---
+
+## Task 16: Standalone-UI — embed graph in `WizardDone`
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx`
+
+- [ ] **Step 1: Update the component**
+
+Open `services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx`. Wrap the existing `<Card>` in a `<div className="space-y-4 w-full max-w-lg">` and add a second card below containing the graph. Add the necessary imports:
+
+```tsx
+"use client";
+
+import dynamic from "next/dynamic";
+import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { api, ApiError, type AgentRead, type Framework } from "@/lib/api";
+
+const AgentGraph = dynamic(
+  () => import("@/components/graph/AgentGraph").then((m) => m.AgentGraph),
+  { ssr: false, loading: () => <div className="h-[420px] animate-pulse rounded-md bg-muted" /> },
+);
+
+// ... (existing Mode type, envReminder helper, props interface — keep as-is) ...
+
+export function WizardDone({
+  agent,
+  framework,
+  mode,
+  onGoToChat,
+}: WizardDoneProps) {
+  const graphQuery = useQuery({
+    queryKey: ["agent-graph"],
+    queryFn: () => api.getAgentGraph(),
+    retry: (failureCount, err) => {
+      // Don't retry on 404 (framework not supported)
+      if (err instanceof ApiError && err.status === 404) return false;
+      return failureCount < 2;
+    },
+  });
+
+  return (
+    <div className="w-full max-w-lg space-y-4">
+      <Card className="w-full">
+        {/* ... existing CardHeader/CardContent/CardFooter — keep as-is ... */}
+      </Card>
+
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle className="text-base">Your agent</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {graphQuery.isLoading && (
+            <div className="h-[420px] animate-pulse rounded-md bg-muted" />
+          )}
+          {graphQuery.isError && graphQuery.error instanceof ApiError && graphQuery.error.status === 404 && (
+            <p className="text-sm text-muted-foreground">
+              Graph view isn&apos;t available for this agent type yet.
+            </p>
+          )}
+          {graphQuery.isError && !(graphQuery.error instanceof ApiError && graphQuery.error.status === 404) && (
+            <Alert>
+              <AlertTitle>Graph unavailable</AlertTitle>
+              <AlertDescription>Try reloading the page.</AlertDescription>
+            </Alert>
+          )}
+          {graphQuery.data && <AgentGraph graph={graphQuery.data} />}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+(Keep the existing `envReminder` helper, the `Mode` type, and the props interface unchanged. Only the JSX and the imports change.)
+
+- [ ] **Step 2: Manual smoke test (optional but recommended)**
+
+```bash
+cd services/idun_agent_standalone_ui && npm run typecheck && cd -
+```
+
+Expected: no new TS errors related to this change.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
+git commit -m "feat(standalone-ui): show agent graph on WizardDone success screen"
+```
+
+---
+
+## Task 17: Standalone-UI — add Graph tab to admin agent page
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/app/admin/agent/page.tsx`
+
+- [ ] **Step 1: Add the new tab**
+
+Open `services/idun_agent_standalone_ui/app/admin/agent/page.tsx`. Find the `<Tabs>` component and its `<TabsList>` / `<TabsContent>` blocks. Add:
+
+1. Import `useQuery` from `@tanstack/react-query` (likely already imported), `dynamic` from `next/dynamic`, and `ApiError` from `@/lib/api`.
+
+2. Add a lazy-loaded `AgentGraph` import near the top of the file:
+
+```tsx
+const AgentGraph = dynamic(
+  () => import("@/components/graph/AgentGraph").then((m) => m.AgentGraph),
+  { ssr: false, loading: () => <div className="h-[480px] animate-pulse rounded-md bg-muted" /> },
+);
+```
+
+3. Inside the component, alongside the existing queries, add:
+
+```tsx
+const graphQuery = useQuery({
+  queryKey: ["admin-agent-graph"],
+  queryFn: () => api.getAgentGraph(),
+  retry: (failureCount, err) => {
+    if (err instanceof ApiError && err.status === 404) return false;
+    return failureCount < 2;
+  },
+});
+```
+
+4. In `<TabsList>`, append:
+
+```tsx
+<TabsTrigger value="graph">Graph</TabsTrigger>
+```
+
+5. After the existing `<TabsContent>` blocks, append:
+
+```tsx
+<TabsContent value="graph">
+  <Card>
+    <CardHeader>
+      <CardTitle>Agent graph</CardTitle>
+      <CardDescription>
+        A visual map of this agent&apos;s sub-agents and tools.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      {graphQuery.isLoading && (
+        <div className="h-[480px] animate-pulse rounded-md bg-muted" />
+      )}
+      {graphQuery.isError && graphQuery.error instanceof ApiError && graphQuery.error.status === 404 && (
+        <p className="text-sm text-muted-foreground">
+          Graph view isn&apos;t available for this agent type yet.
+        </p>
+      )}
+      {graphQuery.isError && !(graphQuery.error instanceof ApiError && graphQuery.error.status === 404) && (
+        <Alert>
+          <AlertTitle>Graph unavailable</AlertTitle>
+          <AlertDescription>Try reloading the page.</AlertDescription>
+        </Alert>
+      )}
+      {graphQuery.data && <AgentGraph graph={graphQuery.data} height={480} />}
+    </CardContent>
+  </Card>
+</TabsContent>
+```
+
+(Adjust the `<CardDescription>` import if not already present.)
+
+- [ ] **Step 2: Verify typecheck**
+
+```bash
+cd services/idun_agent_standalone_ui && npm run typecheck && cd -
+```
+
+Expected: no new TS errors related to this change.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/app/admin/agent/page.tsx
+git commit -m "feat(standalone-ui): add Graph tab to admin agent page"
+```
+
+---
+
+## Task 18: Standalone-UI — extend wizard E2E test
+
+**Files:**
+- Locate the existing playwright spec under `services/idun_agent_standalone_ui/e2e/` that exercises the onboarding wizard. The spec name varies by setup — check `e2e/` for `wizard.spec.ts`, `onboarding.spec.ts`, or similar.
+- Modify whichever existing spec drives the wizard to `WizardDone`.
+
+- [ ] **Step 1: Discover the existing wizard E2E**
+
+```bash
+ls services/idun_agent_standalone_ui/e2e/
+```
+
+If multiple specs exist, the right one is the one whose existing assertions reach the `WizardDone` screen (look for assertions about "Set up your model credentials" or the "Go to chat" button).
+
+- [ ] **Step 2: Add an assertion after `WizardDone` is visible**
+
+Inside the existing test (after the assertions that confirm `WizardDone` rendered), append:
+
+```ts
+// Graph card visible with at least one agent node rendered by ReactFlow
+const graphCard = page.getByText("Your agent", { exact: true });
+await expect(graphCard).toBeVisible();
+// ReactFlow renders nodes with [data-id="..."] attributes matching the IR ids
+await expect(page.locator('[data-id^="agent:"]').first()).toBeVisible({ timeout: 10_000 });
+```
+
+- [ ] **Step 3: Run the spec locally to confirm**
+
+```bash
+cd services/idun_agent_standalone_ui && npm run test:e2e -- <spec-file> && cd -
+```
+
+Expected: spec passes including the new assertion. (If E2E requires a running standalone server fixture, follow the project's existing pattern — likely the spec already starts it via `playwright.config.ts` or a `before` hook.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/idun_agent_standalone_ui/e2e/<spec-file>
+git commit -m "test(standalone-ui): assert graph card renders on WizardDone"
+```
+
+---
+
+## Final verification — full suite
+
+After Task 18, run end-to-end checks:
+
+- [ ] **Engine + schema lint + tests**
+
+```bash
+make lint
+make pytest -- -m "not requires_langfuse and not requires_phoenix and not requires_postgres"
+```
+
+Expected: all green.
+
+- [ ] **Engine type check**
+
+```bash
+make mypy
+```
+
+Expected: no new errors.
+
+- [ ] **Standalone UI typecheck + unit tests**
+
+```bash
+cd services/idun_agent_standalone_ui
+npm run typecheck
+npx vitest run
+cd -
+```
+
+Expected: no new TS errors; all vitest tests pass.
+
+- [ ] **Standalone UI build (catches lazy-load issues)**
+
+```bash
+cd services/idun_agent_standalone_ui && npm run build && cd -
+```
+
+Expected: clean build, no runtime errors. Inspect `out/` size — confirm the chunk split for `@xyflow/react` is reasonable (lazy-loaded chunk, not in main bundle).
+
+- [ ] **Manual smoke test against a real ADK agent**
+
+```bash
+# In one terminal: serve a sample ADK agent
+uv run idun agent serve --source file --path examples/adk-config.yaml
+
+# In another: visit http://localhost:<port>/admin/agent and click the Graph tab
+# Visit http://localhost:<port>/onboarding (if accessible) and complete the wizard
+```
+
+Expected: graph renders; nodes show correct names/types; tools show MCP server name when applicable.
+
+---
+
+## Self-review against the spec
+
+Quick coverage check (run mentally before claiming done):
+
+| Spec section | Implemented in task |
+|---|---|
+| §5 IR data model | Task 1 |
+| §6.1 BaseAgent defaults | Task 2 |
+| §6.2 LangGraph adapter | Task 5 |
+| §6.3 ADK adapter (single + tools) | Task 6 |
+| §6.3 ADK adapter (workflow agents) | Task 7 |
+| §6.3 ADK adapter (custom + nested) | Task 8 |
+| §6.4 Haystack 404 | Task 9 (route 404 test) |
+| §7.1 render_mermaid | Task 3 |
+| §7.2 render_ascii | Task 4 |
+| §8 HTTP routes | Task 9 |
+| §8 admin web URL swap | Task 10 |
+| §9.1 deps | Task 11 |
+| §9.2 TS types | Task 11 |
+| §9.3 API client | Task 11 |
+| §9.4 components (nodes) | Task 13 |
+| §9.4 components (edges) | Task 14 |
+| §9.4 components (canvas + layout) | Task 15 |
+| §9.4 IR mapper | Task 12 |
+| §9.5 WizardDone integration | Task 16 |
+| §9.5 admin agent page Graph tab | Task 17 |
+| §9.7 lazy-loading | Task 16, 17 (`dynamic` imports) |
+| §10.6 E2E | Task 18 |
+
+If a spec requirement isn't covered, add or extend a task — don't quietly drop it.
+
+---
+
+## Execution
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-30-adk-langgraph-graph-visualizer.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-05-graph-export-actions.md
+++ b/docs/superpowers/plans/2026-05-05-graph-export-actions.md
@@ -1,0 +1,1148 @@
+# Graph Export Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an "Export ▾" dropdown to the Agent graph card in the standalone UI with four actions (copy PNG to clipboard, download PNG, download SVG, copy Mermaid source).
+
+**Architecture:** Pure helpers in `lib/graph-export.ts` perform the file/clipboard side effects. `<AgentGraph>` becomes a `forwardRef` component exposing a handle so the menu (rendered in the card header, outside the canvas's ReactFlowProvider) can reach the canvas DOM and node bounds. `<ExportMenu>` is the shadcn `<DropdownMenu>` shell that calls the helpers and surfaces sonner toasts.
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, Tailwind v4, shadcn `<DropdownMenu>` (already installed), `lucide-react` (already installed), `sonner` (already installed), `@xyflow/react v12`, **new:** `html-to-image ^1.x` (~20KB gz, MIT).
+
+**Spec:** `docs/superpowers/specs/2026-05-05-graph-export-actions-design.md`. If the spec and plan disagree, update the spec first.
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `services/idun_agent_standalone_ui/package.json` | MODIFY | Add `html-to-image` dependency |
+| `services/idun_agent_standalone_ui/lib/graph-export.ts` | NEW | Pure helpers: `slugifyAgentName`, `exportToPng`, `exportToSvg`, `copyPngToClipboard`, `copyMermaidToClipboard` |
+| `services/idun_agent_standalone_ui/lib/__tests__/graph-export.test.ts` | NEW | Unit tests for slug + helpers |
+| `services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx` | MODIFY | Wrap in `forwardRef`, expose `AgentGraphHandle` via `useImperativeHandle` |
+| `services/idun_agent_standalone_ui/components/graph/ExportMenu.tsx` | NEW | Dropdown UI + click handlers + toast feedback |
+| `services/idun_agent_standalone_ui/components/graph/__tests__/ExportMenu.test.tsx` | NEW | Component tests for menu rendering + click → helper dispatch |
+| `services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx` | MODIFY | Mount `<ExportMenu>` in the "Your agent" card header, ref into `<AgentGraph>` |
+| `services/idun_agent_standalone_ui/app/admin/agent/page.tsx` | MODIFY | Same: mount `<ExportMenu>` in the "Agent graph" card header |
+| `services/idun_agent_standalone_ui/e2e/onboarding.spec.ts` | MODIFY | Light E2E assertion: Export button is visible on WizardDone |
+
+---
+
+## Task 1: Add `html-to-image` dependency
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/package.json`
+- Modify: `services/idun_agent_standalone_ui/pnpm-lock.yaml` (regenerated)
+
+This is a single-step task — the lib is needed by Task 2's tests, which mock it.
+
+- [ ] **Step 1: Install the dep**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm add html-to-image
+```
+
+Expected: `html-to-image` appears in `package.json` `dependencies`. Lockfile updated.
+
+- [ ] **Step 2: Verify install**
+
+```bash
+node -e "console.log(require('html-to-image').toPng.toString().slice(0, 40))"
+```
+
+Expected: prints the first ~40 chars of the `toPng` function source — proves the module resolves.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display
+git add services/idun_agent_standalone_ui/package.json \
+        services/idun_agent_standalone_ui/pnpm-lock.yaml
+git commit -m "build(standalone-ui): add html-to-image for graph export"
+```
+
+---
+
+## Task 2: `lib/graph-export.ts` — pure helpers + slugify
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/lib/graph-export.ts`
+- Create: `services/idun_agent_standalone_ui/lib/__tests__/graph-export.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `services/idun_agent_standalone_ui/lib/__tests__/graph-export.test.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("html-to-image", () => ({
+  toPng: vi.fn().mockResolvedValue("data:image/png;base64,FAKEPNG"),
+  toSvg: vi.fn().mockResolvedValue("data:image/svg+xml;FAKESVG"),
+  toBlob: vi.fn().mockResolvedValue(new Blob(["x"], { type: "image/png" })),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getAgentGraphMermaid: vi.fn().mockResolvedValue({ mermaid: "graph TD\n  a-->b" }),
+  },
+}));
+
+import * as htmlToImage from "html-to-image";
+import {
+  copyMermaidToClipboard,
+  copyPngToClipboard,
+  exportToPng,
+  exportToSvg,
+  slugifyAgentName,
+} from "../graph-export";
+
+const sampleBounds = { x: 0, y: 0, width: 100, height: 100 };
+
+describe("slugifyAgentName", () => {
+  it("lowercases and replaces spaces with dashes", () => {
+    expect(slugifyAgentName("My Cool Agent")).toBe("my-cool-agent");
+  });
+  it("collapses non-ASCII", () => {
+    expect(slugifyAgentName("naïve Agent")).toBe("nave-agent");
+  });
+  it("collapses multiple consecutive dashes", () => {
+    expect(slugifyAgentName("foo   bar")).toBe("foo-bar");
+  });
+  it("strips leading/trailing dashes", () => {
+    expect(slugifyAgentName("--foo--")).toBe("foo");
+  });
+  it("falls back to 'agent' for empty result", () => {
+    expect(slugifyAgentName("***")).toBe("agent");
+    expect(slugifyAgentName("")).toBe("agent");
+  });
+});
+
+describe("exportToPng", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls html-to-image.toPng with bounds-derived dimensions", async () => {
+    const canvas = document.createElement("div");
+    await exportToPng(canvas, "Test", { bounds: sampleBounds });
+    expect(htmlToImage.toPng).toHaveBeenCalledOnce();
+    const opts = vi.mocked(htmlToImage.toPng).mock.calls[0][1]!;
+    // 100 + 2 * 24 padding = 148
+    expect(opts.width).toBe(148);
+    expect(opts.height).toBe(148);
+    expect(opts.pixelRatio).toBe(2);
+    expect(opts.backgroundColor).toBe("#ffffff");
+  });
+
+  it("triggers an anchor download with slugified filename", async () => {
+    const canvas = document.createElement("div");
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    await exportToPng(canvas, "My Agent", { bounds: sampleBounds });
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+});
+
+describe("exportToSvg", () => {
+  beforeEach(() => vi.clearAllMocks());
+  it("calls html-to-image.toSvg", async () => {
+    const canvas = document.createElement("div");
+    await exportToSvg(canvas, "Test", { bounds: sampleBounds });
+    expect(htmlToImage.toSvg).toHaveBeenCalledOnce();
+  });
+});
+
+describe("copyPngToClipboard", () => {
+  it("writes a PNG ClipboardItem to navigator.clipboard", async () => {
+    const writeSpy = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { write: writeSpy },
+      configurable: true,
+    });
+    // jsdom doesn't ship ClipboardItem; stub it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).ClipboardItem = class {
+      constructor(public payload: Record<string, Blob>) {}
+    };
+    const canvas = document.createElement("div");
+    await copyPngToClipboard(canvas, { bounds: sampleBounds });
+    expect(writeSpy).toHaveBeenCalledOnce();
+  });
+
+  it("throws when clipboard image API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    const canvas = document.createElement("div");
+    await expect(
+      copyPngToClipboard(canvas, { bounds: sampleBounds }),
+    ).rejects.toThrow(/clipboard/i);
+  });
+});
+
+describe("copyMermaidToClipboard", () => {
+  it("writes the mermaid source via clipboard.writeText", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    await copyMermaidToClipboard();
+    expect(writeText).toHaveBeenCalledWith("graph TD\n  a-->b");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests — confirm they fail**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run lib/__tests__/graph-export.test.ts
+```
+
+Expected: import errors / module-not-found for `../graph-export`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `services/idun_agent_standalone_ui/lib/graph-export.ts`:
+
+```ts
+/**
+ * Pure helpers for exporting the AgentGraph canvas as image / clipboard data.
+ *
+ * Side effects (clipboard writes, anchor downloads) happen here so the
+ * `<ExportMenu>` UI shell stays free of DOM trickery and easy to test.
+ */
+
+import { toBlob, toPng, toSvg } from "html-to-image";
+
+import { api } from "@/lib/api";
+
+export interface ExportConfig {
+  bounds: { x: number; y: number; width: number; height: number };
+  /** px around the fitted bounds. Default 24. */
+  padding?: number;
+  /** Raster scale factor. Default 2. SVG ignores this. */
+  pixelRatio?: number;
+  /** Background fill. Default white. */
+  background?: string;
+}
+
+export function slugifyAgentName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return slug || "agent";
+}
+
+function htmlToImageOpts(cfg: ExportConfig) {
+  const padding = cfg.padding ?? 24;
+  const w = cfg.bounds.width + 2 * padding;
+  const h = cfg.bounds.height + 2 * padding;
+  return {
+    width: w,
+    height: h,
+    pixelRatio: cfg.pixelRatio ?? 2,
+    backgroundColor: cfg.background ?? "#ffffff",
+    style: {
+      transform: `translate(${-cfg.bounds.x + padding}px, ${
+        -cfg.bounds.y + padding
+      }px)`,
+      transformOrigin: "0 0",
+      width: `${w}px`,
+      height: `${h}px`,
+    },
+    filter: (node: HTMLElement) => {
+      const cls = node.classList;
+      if (!cls) return true;
+      // Strip ReactFlow chrome from the export — we want just nodes + edges
+      // on a clean white plate, not the dotted background, minimap, controls,
+      // or the attribution badge.
+      return !(
+        cls.contains("react-flow__minimap") ||
+        cls.contains("react-flow__controls") ||
+        cls.contains("react-flow__attribution") ||
+        cls.contains("react-flow__background")
+      );
+    },
+  };
+}
+
+function triggerDownload(dataUrl: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = dataUrl;
+  a.download = filename;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+export async function exportToPng(
+  canvas: HTMLElement,
+  agentName: string,
+  cfg: ExportConfig,
+): Promise<void> {
+  const dataUrl = await toPng(canvas, htmlToImageOpts(cfg));
+  triggerDownload(dataUrl, `${slugifyAgentName(agentName)}-graph.png`);
+}
+
+export async function exportToSvg(
+  canvas: HTMLElement,
+  agentName: string,
+  cfg: ExportConfig,
+): Promise<void> {
+  const dataUrl = await toSvg(canvas, htmlToImageOpts(cfg));
+  triggerDownload(dataUrl, `${slugifyAgentName(agentName)}-graph.svg`);
+}
+
+export async function copyPngToClipboard(
+  canvas: HTMLElement,
+  cfg: ExportConfig,
+): Promise<void> {
+  if (!navigator.clipboard?.write) {
+    throw new Error("Clipboard image API not available");
+  }
+  const blob = await toBlob(canvas, htmlToImageOpts(cfg));
+  if (!blob) throw new Error("Failed to render image blob");
+  await navigator.clipboard.write([
+    new ClipboardItem({ "image/png": blob }),
+  ]);
+}
+
+export async function copyMermaidToClipboard(): Promise<void> {
+  if (!navigator.clipboard?.writeText) {
+    throw new Error("Clipboard API not available");
+  }
+  const { mermaid } = await api.getAgentGraphMermaid();
+  await navigator.clipboard.writeText(mermaid);
+}
+```
+
+- [ ] **Step 4: Run the tests — confirm they pass**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run lib/__tests__/graph-export.test.ts
+```
+
+Expected: 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display
+git add services/idun_agent_standalone_ui/lib/graph-export.ts \
+        services/idun_agent_standalone_ui/lib/__tests__/graph-export.test.ts
+git commit -m "feat(standalone-ui): add pure helpers for graph image + mermaid export"
+```
+
+---
+
+## Task 3: `AgentGraph` exposes a handle via `forwardRef`
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx`
+- Modify: `services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx`
+
+The existing `<AgentGraph>` is a plain function component. We change it to a `forwardRef` so a parent (the card header containing `<ExportMenu>`) can pull the canvas DOM element and the dagre-positioned node bounds at click time.
+
+`getNodesBounds` from `@xyflow/react` lives outside `<ReactFlowProvider>` (it's a pure function over an array of nodes), so we can call it on our memoized `nodes` without needing `useReactFlow()`.
+
+- [ ] **Step 1: Write the failing test addition**
+
+Open `services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx`. Add this test alongside the existing one:
+
+```tsx
+import { useRef } from "react";
+
+it("exposes a handle with getCanvasElement and getNodesBounds via ref", () => {
+  function Probe() {
+    const ref = useRef<import("../AgentGraph").AgentGraphHandle>(null);
+    return (
+      <div style={{ width: 800, height: 400 }}>
+        <AgentGraph ref={ref} graph={FIXTURE} />
+        <button
+          data-testid="probe"
+          onClick={() => {
+            const el = ref.current?.getCanvasElement();
+            const bounds = ref.current?.getNodesBounds();
+            (window as unknown as { _probe: unknown })._probe = {
+              hasEl: el instanceof HTMLElement,
+              bounds,
+            };
+          }}
+        />
+      </div>
+    );
+  }
+  render(<Probe />);
+  screen.getByTestId("probe").click();
+  const probe = (window as unknown as { _probe: { hasEl: boolean; bounds: unknown } })._probe;
+  expect(probe.hasEl).toBe(true);
+  expect(probe.bounds).toMatchObject({
+    x: expect.any(Number),
+    y: expect.any(Number),
+    width: expect.any(Number),
+    height: expect.any(Number),
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run components/graph/__tests__/AgentGraph.test.tsx
+```
+
+Expected: TS error or runtime error — `<AgentGraph>` doesn't accept a `ref` and doesn't export `AgentGraphHandle`.
+
+- [ ] **Step 3: Convert `<AgentGraph>` to `forwardRef`**
+
+Replace the entire content of `services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx`:
+
+```tsx
+"use client";
+
+import "@xyflow/react/dist/style.css";
+
+import {
+  Background,
+  Controls,
+  getNodesBounds,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+} from "@xyflow/react";
+import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
+
+import type { AgentGraph as AgentGraphIR } from "@/lib/api/types/graph";
+
+import { PrettyEdge } from "./edges/PrettyEdge";
+import { irToReactFlow } from "./irToReactFlow";
+import { applyDagreLayout } from "./layout";
+import { AgentNode } from "./nodes/AgentNode";
+import { ToolNode } from "./nodes/ToolNode";
+
+interface AgentGraphProps {
+  graph: AgentGraphIR;
+  /** Height of the canvas. Defaults to a sensible value for a card embed. */
+  height?: number;
+}
+
+export interface AgentGraphHandle {
+  /** The .react-flow root DOM element (for html-to-image), or null pre-mount. */
+  getCanvasElement(): HTMLElement | null;
+  /** World-coordinate bounding box of all nodes; null if no nodes. */
+  getNodesBounds(): { x: number; y: number; width: number; height: number } | null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const NODE_TYPES = { agent: AgentNode, tool: ToolNode } as Record<string, React.ComponentType<any>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const EDGE_TYPES = { pretty: PrettyEdge } as Record<string, React.ComponentType<any>>;
+
+export const AgentGraph = forwardRef<AgentGraphHandle, AgentGraphProps>(
+  function AgentGraph({ graph, height = 420 }, ref) {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
+    const { nodes, edges } = useMemo(() => {
+      const mapped = irToReactFlow(graph);
+      return {
+        nodes: applyDagreLayout(mapped.nodes, mapped.edges),
+        edges: mapped.edges,
+      };
+    }, [graph]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        getCanvasElement(): HTMLElement | null {
+          // The .react-flow div is the deepest stable DOM ancestor of all
+          // rendered nodes/edges. html-to-image walks down from here.
+          return containerRef.current?.querySelector<HTMLElement>(".react-flow") ?? null;
+        },
+        getNodesBounds() {
+          if (nodes.length === 0) return null;
+          const b = getNodesBounds(nodes);
+          return { x: b.x, y: b.y, width: b.width, height: b.height };
+        },
+      }),
+      [nodes],
+    );
+
+    return (
+      <div
+        ref={containerRef}
+        style={{ height }}
+        className="w-full overflow-hidden rounded-md border bg-background"
+      >
+        <ReactFlowProvider>
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={NODE_TYPES}
+            edgeTypes={EDGE_TYPES}
+            fitView
+            minZoom={0.4}
+            maxZoom={1.5}
+            proOptions={{ hideAttribution: true }}
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable={false}
+          >
+            <Background />
+            <Controls showInteractive={false} />
+            <MiniMap pannable zoomable />
+          </ReactFlow>
+        </ReactFlowProvider>
+      </div>
+    );
+  },
+);
+```
+
+- [ ] **Step 4: Run the tests — confirm they pass**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run components/graph/__tests__/AgentGraph.test.tsx
+```
+
+Expected: all tests pass (existing single-node + new ref/handle test = 2 tests).
+
+If the new test fails because `containerRef.current?.querySelector(".react-flow")` returns null in jsdom (the `<MiniMap pannable>` calls `ResizeObserver` which the existing setup stubs, but ReactFlow may or may not render a `.react-flow` class on the empty wrapper), relax the test to just assert `getNodesBounds()` returns a numeric box — `getCanvasElement()` correctness is verified end-to-end by Task 8's E2E.
+
+- [ ] **Step 5: Run the full vitest suite — no regressions**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display
+git add services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx \
+        services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx
+git commit -m "feat(standalone-ui): expose AgentGraphHandle via forwardRef for export menu"
+```
+
+---
+
+## Task 4: `<ExportMenu>` dropdown component
+
+**Files:**
+- Create: `services/idun_agent_standalone_ui/components/graph/ExportMenu.tsx`
+- Create: `services/idun_agent_standalone_ui/components/graph/__tests__/ExportMenu.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `services/idun_agent_standalone_ui/components/graph/__tests__/ExportMenu.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/graph-export", () => ({
+  copyMermaidToClipboard: vi.fn().mockResolvedValue(undefined),
+  copyPngToClipboard: vi.fn().mockResolvedValue(undefined),
+  exportToPng: vi.fn().mockResolvedValue(undefined),
+  exportToSvg: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import * as exporters from "@/lib/graph-export";
+import { toast } from "sonner";
+import type { AgentGraphHandle } from "../AgentGraph";
+import { ExportMenu } from "../ExportMenu";
+
+const mkRef = (): { current: AgentGraphHandle | null } => ({
+  current: {
+    getCanvasElement: () => document.createElement("div"),
+    getNodesBounds: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+  },
+});
+
+describe("ExportMenu", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders 4 menu items when opened", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    expect(screen.getByText("Copy as image")).toBeInTheDocument();
+    expect(screen.getByText("Download PNG")).toBeInTheDocument();
+    expect(screen.getByText("Download SVG")).toBeInTheDocument();
+    expect(screen.getByText("Copy Mermaid source")).toBeInTheDocument();
+  });
+
+  it("calls exportToPng on Download PNG and toasts on success", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="my agent" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Download PNG"));
+    expect(exporters.exportToPng).toHaveBeenCalledOnce();
+    expect(toast.success).toHaveBeenCalledWith("Downloaded PNG");
+  });
+
+  it("calls exportToSvg on Download SVG", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Download SVG"));
+    expect(exporters.exportToSvg).toHaveBeenCalledOnce();
+  });
+
+  it("calls copyPngToClipboard on Copy as image", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Copy as image"));
+    expect(exporters.copyPngToClipboard).toHaveBeenCalledOnce();
+    expect(toast.success).toHaveBeenCalledWith("Copied graph image to clipboard");
+  });
+
+  it("calls copyMermaidToClipboard on Copy Mermaid source", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Copy Mermaid source"));
+    expect(exporters.copyMermaidToClipboard).toHaveBeenCalledOnce();
+    expect(toast.success).toHaveBeenCalledWith("Copied Mermaid source");
+  });
+
+  it("surfaces an error toast when an exporter rejects", async () => {
+    vi.mocked(exporters.exportToPng).mockRejectedValueOnce(new Error("boom"));
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Download PNG"));
+    expect(toast.error).toHaveBeenCalledWith("Couldn't export PNG");
+  });
+
+  it("disables the trigger button when disabled prop is true", () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" disabled />);
+    expect(screen.getByRole("button", { name: /export/i })).toBeDisabled();
+  });
+
+  it("toasts an error when the canvas/bounds aren't ready", async () => {
+    const ref: { current: AgentGraphHandle | null } = {
+      current: {
+        getCanvasElement: () => null,
+        getNodesBounds: () => null,
+      },
+    };
+    render(<ExportMenu graphRef={ref} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Download PNG"));
+    expect(exporters.exportToPng).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Graph not ready");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run components/graph/__tests__/ExportMenu.test.tsx
+```
+
+Expected: cannot find module `../ExportMenu`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `services/idun_agent_standalone_ui/components/graph/ExportMenu.tsx`:
+
+```tsx
+"use client";
+
+import {
+  ChevronDown,
+  Download,
+  FileImage,
+  FileText,
+  Image as ImageIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  copyMermaidToClipboard,
+  copyPngToClipboard,
+  exportToPng,
+  exportToSvg,
+} from "@/lib/graph-export";
+
+import type { AgentGraphHandle } from "./AgentGraph";
+
+interface ExportMenuProps {
+  graphRef: { current: AgentGraphHandle | null };
+  agentName: string;
+  /** Hide the menu while the graph query is loading or errored. */
+  disabled?: boolean;
+}
+
+export function ExportMenu({ graphRef, agentName, disabled }: ExportMenuProps) {
+  const guarded = (
+    action: () => Promise<void>,
+    success: string,
+    failure: string,
+  ) =>
+    async () => {
+      try {
+        await action();
+        toast.success(success);
+      } catch (err) {
+        console.error(err);
+        toast.error(failure);
+      }
+    };
+
+  // Resolve canvas + bounds at click time. The menu trigger's `disabled`
+  // prop is the primary guard; this branch is defense in depth in case
+  // the user clicks before the graph mounts (or html-to-image's bounds
+  // helper fails for an empty IR).
+  const withCanvas = (kind: "png-clip" | "png-dl" | "svg-dl") => async () => {
+    const canvas = graphRef.current?.getCanvasElement();
+    const bounds = graphRef.current?.getNodesBounds();
+    if (!canvas || !bounds) {
+      toast.error("Graph not ready");
+      return;
+    }
+    const cfg = { bounds };
+    if (kind === "png-clip")
+      await guarded(
+        () => copyPngToClipboard(canvas, cfg),
+        "Copied graph image to clipboard",
+        "Clipboard not available — try downloading instead",
+      )();
+    if (kind === "png-dl")
+      await guarded(
+        () => exportToPng(canvas, agentName, cfg),
+        "Downloaded PNG",
+        "Couldn't export PNG",
+      )();
+    if (kind === "svg-dl")
+      await guarded(
+        () => exportToSvg(canvas, agentName, cfg),
+        "Downloaded SVG",
+        "Couldn't export SVG",
+      )();
+  };
+
+  const onCopyMermaid = guarded(
+    copyMermaidToClipboard,
+    "Copied Mermaid source",
+    "Couldn't copy Mermaid source",
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" disabled={disabled}>
+          <Download className="mr-1 h-3.5 w-3.5" />
+          Export
+          <ChevronDown className="ml-1 h-3.5 w-3.5 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={withCanvas("png-clip")}>
+          <ImageIcon className="mr-2 h-4 w-4" /> Copy as image
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={withCanvas("png-dl")}>
+          <FileImage className="mr-2 h-4 w-4" /> Download PNG
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={withCanvas("svg-dl")}>
+          <FileImage className="mr-2 h-4 w-4" /> Download SVG
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onCopyMermaid}>
+          <FileText className="mr-2 h-4 w-4" /> Copy Mermaid source
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run components/graph/__tests__/ExportMenu.test.tsx
+```
+
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Run the full vitest suite — no regressions**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display
+git add services/idun_agent_standalone_ui/components/graph/ExportMenu.tsx \
+        services/idun_agent_standalone_ui/components/graph/__tests__/ExportMenu.test.tsx
+git commit -m "feat(standalone-ui): add ExportMenu dropdown for graph actions"
+```
+
+---
+
+## Task 5: Wire `<ExportMenu>` into `WizardDone`
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx`
+
+The "Your agent" card currently has a simple `<CardHeader><CardTitle>Your agent</CardTitle></CardHeader>` and a body with `<AgentGraph graph={data} />`. We add a ref to access the handle, a flex header to place the menu next to the title, and pass the ref to `<AgentGraph>`.
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
+```
+
+Identify the second `<Card>` block (titled "Your agent") and the imports.
+
+- [ ] **Step 2: Add the import for `useRef`, the menu, and the handle type**
+
+Near the top of the file, add to the existing imports:
+
+```tsx
+import { useRef } from "react";
+
+import type { AgentGraphHandle } from "@/components/graph/AgentGraph";
+import { ExportMenu } from "@/components/graph/ExportMenu";
+```
+
+(Adjust grouping to match the file's existing import-sort convention.)
+
+- [ ] **Step 3: Add the ref and update the second card**
+
+Inside the `WizardDone` component body, near the other hooks, add:
+
+```tsx
+const graphRef = useRef<AgentGraphHandle | null>(null);
+```
+
+Replace the second `<Card>` block (the "Your agent" one) with:
+
+```tsx
+<Card className="w-full">
+  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+    <CardTitle className="text-base">Your agent</CardTitle>
+    <ExportMenu
+      graphRef={graphRef}
+      agentName={agent.name}
+      disabled={
+        graphQuery.isLoading || graphQuery.isError || !graphQuery.data
+      }
+    />
+  </CardHeader>
+  <CardContent>
+    {graphQuery.isLoading && (
+      <div className="h-[420px] animate-pulse rounded-md bg-muted" />
+    )}
+    {graphQuery.isError &&
+      graphQuery.error instanceof ApiError &&
+      graphQuery.error.status === 404 && (
+        <p className="text-sm text-muted-foreground">
+          Graph view isn&apos;t available for this agent type yet.
+        </p>
+      )}
+    {graphQuery.isError &&
+      !(
+        graphQuery.error instanceof ApiError &&
+        graphQuery.error.status === 404
+      ) && (
+        <Alert>
+          <AlertTitle>Graph unavailable</AlertTitle>
+          <AlertDescription>Try reloading the page.</AlertDescription>
+        </Alert>
+      )}
+    {graphQuery.data && <AgentGraph ref={graphRef} graph={graphQuery.data} />}
+  </CardContent>
+</Card>
+```
+
+(The only changes vs. the existing block: `flex flex-row items-center justify-between space-y-0 pb-2` on the header, the `<ExportMenu>` element, and `ref={graphRef}` on `<AgentGraph>`.)
+
+- [ ] **Step 4: Verify typecheck on the touched file**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec tsc --noEmit components/onboarding/WizardDone.tsx
+```
+
+Expected: no new errors specific to this file. Pre-existing project-wide errors are tracked in `next.config.mjs` (`ignoreBuildErrors: true`) — only flag NEW ones.
+
+- [ ] **Step 5: Run the existing WizardDone tests — no regressions**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run __tests__/onboarding/WizardDone.test.tsx
+```
+
+Expected: all existing tests still pass. (The previous task added the graph-card and 404 cases; they should still hold.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display
+git add services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
+git commit -m "feat(standalone-ui): mount ExportMenu in WizardDone graph card"
+```
+
+---
+
+## Task 6: Wire `<ExportMenu>` into the admin agent page
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/app/admin/agent/page.tsx`
+
+Same pattern as Task 5, in the Graph card section that was added in Task 17 of the prior plan.
+
+- [ ] **Step 1: Read the file's current Graph card section**
+
+```bash
+grep -n "Agent graph\|graphQuery\|AgentGraph" /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
+```
+
+Identify the imports and the Graph card block.
+
+- [ ] **Step 2: Add the imports**
+
+Near the top of the file, add:
+
+```tsx
+import { useRef } from "react";
+
+import type { AgentGraphHandle } from "@/components/graph/AgentGraph";
+import { ExportMenu } from "@/components/graph/ExportMenu";
+```
+
+(`useRef` may already be imported from React in this file — if so, just add the new symbols to the existing import.)
+
+- [ ] **Step 3: Add the ref + update the Graph card**
+
+Inside the page component's body, add:
+
+```tsx
+const graphRef = useRef<AgentGraphHandle | null>(null);
+```
+
+(Place near other hooks like `graphQuery`.)
+
+Update the Graph card's `<CardHeader>` to use a flex layout and include the menu. The exact structure depends on the existing block; preserve the `<CardDescription>` if present. Example shape:
+
+```tsx
+<Card>
+  <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+    <div className="space-y-1.5">
+      <CardTitle>Agent graph</CardTitle>
+      <CardDescription>
+        A visual map of this agent&apos;s sub-agents and tools.
+      </CardDescription>
+    </div>
+    <ExportMenu
+      graphRef={graphRef}
+      agentName={agent.name}
+      disabled={
+        graphQuery.isLoading || graphQuery.isError || !graphQuery.data
+      }
+    />
+  </CardHeader>
+  <CardContent>
+    {/* ... existing loading / 404 / error / data branches, unchanged ... */}
+    {graphQuery.data && (
+      <AgentGraph ref={graphRef} graph={graphQuery.data} height={480} />
+    )}
+  </CardContent>
+</Card>
+```
+
+`agent.name` should be whatever this page already uses to display the agent's name (likely `agentQuery.data?.name` or similar — read the file for the exact identifier and substitute). If the agent name is not yet fetched at render time, fall back to `"agent"` so the slug still works.
+
+- [ ] **Step 4: Typecheck the touched file**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec tsc --noEmit app/admin/agent/page.tsx
+```
+
+Expected: no new errors.
+
+- [ ] **Step 5: Run the full vitest suite — no regressions**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display
+git add services/idun_agent_standalone_ui/app/admin/agent/page.tsx
+git commit -m "feat(standalone-ui): mount ExportMenu in admin agent Graph card"
+```
+
+---
+
+## Task 7: E2E — Export button visible after WizardDone
+
+**Files:**
+- Modify: `services/idun_agent_standalone_ui/e2e/onboarding.spec.ts`
+
+Light-touch assertion. We do NOT click-through to a real download (Playwright supports it but adds 5+ seconds for marginal coverage; the unit tests already verify dispatch).
+
+- [ ] **Step 1: Locate the WizardDone-reaching test**
+
+```bash
+grep -n "Your agent\|Go to chat\|Set up your model" /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
+```
+
+Pick a test that already asserts WizardDone rendered (the existing graph-visible assertions added in the prior plan's Task 18 are good landmarks).
+
+- [ ] **Step 2: Add the assertion**
+
+Inside the chosen test, after the existing graph-visibility assertion (`page.locator('.react-flow__node').first()` or similar), append:
+
+```ts
+// Export dropdown is rendered in the "Your agent" card header.
+await expect(
+  page.getByRole("button", { name: /export/i }),
+).toBeVisible();
+```
+
+If the test already has an explicit `expect(...).toBeVisible({ timeout })` pattern around the graph, mirror it here for consistency.
+
+- [ ] **Step 3: Try to run the spec**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec playwright test e2e/onboarding.spec.ts
+```
+
+Expected: the spec passes including the new assertion. If the boot script fails locally with a stale `idun-standalone` (the published wheel without the post-rework CLI), report the failure — the assertion is still semantically correct and will pass in CI where the boot script's `uv run --project ROOT idun-standalone setup` resolves to the worktree's editable install.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display
+git add services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
+git commit -m "test(standalone-ui): assert Export dropdown is visible on WizardDone"
+```
+
+---
+
+## Final verification
+
+- [ ] **Standalone-UI typecheck (scoped to graph + onboarding)**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec tsc --noEmit
+```
+
+Expected: no NEW errors specific to the files added/modified by this plan. Pre-existing tracked errors are unchanged.
+
+- [ ] **Full vitest suite**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/services/idun_agent_standalone_ui
+pnpm exec vitest run
+```
+
+Expected: all green. Specifically: 9 new graph-export tests + 8 new ExportMenu tests + 1 new AgentGraph ref test + all pre-existing tests.
+
+- [ ] **Standalone-UI build (catches lazy-load + bundle issues)**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display
+make build-standalone-ui
+```
+
+Expected: clean build. Confirm `out/` contains the new bundle. The `html-to-image` chunk should appear in a chunk file (likely lazy-bundled with `<AgentGraph>`).
+
+- [ ] **Manual smoke (optional, recommended)**
+
+```bash
+cd /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display
+
+# Reuse the smoke-test orchestrator from .claude/smoke-test/ if available;
+# otherwise spin up a single fixture:
+mkdir -p /tmp/idun-export-smoke && cd /tmp/idun-export-smoke
+cp /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/.claude/smoke-test/fixtures/adk_nested.py agent.py
+cat > config.yaml <<EOF
+agent:
+  type: ADK
+  config:
+    name: smoke
+    app_name: smoke
+    agent: $(pwd)/agent.py:root_agent
+EOF
+PYTHONPATH=/Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/libs/idun_agent_engine/src:/Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/libs/idun_agent_schema/src:/Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/libs/idun_agent_standalone/src \
+  IDUN_PORT=8000 IDUN_HOST=127.0.0.1 IDUN_ADMIN_AUTH_MODE=none \
+  IDUN_CONFIG_PATH=$(pwd)/config.yaml \
+  DATABASE_URL=sqlite+aiosqlite:///$(pwd)/standalone.db \
+  /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/.venv/bin/idun-standalone setup --config $(pwd)/config.yaml
+PYTHONPATH=/Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/libs/idun_agent_engine/src:/Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/libs/idun_agent_schema/src:/Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/libs/idun_agent_standalone/src \
+  IDUN_PORT=8000 IDUN_HOST=127.0.0.1 IDUN_ADMIN_AUTH_MODE=none \
+  IDUN_CONFIG_PATH=$(pwd)/config.yaml \
+  DATABASE_URL=sqlite+aiosqlite:///$(pwd)/standalone.db \
+  /Users/geoffreyharrazi/Documents/GitHub/idun-agent-platform/.claude/worktrees/graph-display/.venv/bin/idun-standalone serve
+```
+
+Visit `http://localhost:8000/admin/agent/`. Verify:
+- "Export ▾" button visible in the Agent graph card header.
+- Click → 4 menu items appear.
+- Click "Download PNG" → file downloads as `smoke-graph.png`. Open it: white background, fitted to all nodes, no minimap.
+- Click "Download SVG" → file downloads. Open it: vector, scales cleanly.
+- Click "Copy as image" → toast "Copied graph image to clipboard". Paste into a chat / image viewer.
+- Click "Copy Mermaid source" → toast "Copied Mermaid source". Paste into a text editor.
+
+---
+
+## Self-review against the spec
+
+| Spec section | Implemented in task |
+|---|---|
+| §4 Architecture (3 new units, 4 modified files) | Tasks 1-7 |
+| §5 Dependency `html-to-image` | Task 1 |
+| §6 `AgentGraphHandle` via forwardRef | Task 3 |
+| §7 `lib/graph-export.ts` (5 functions) | Task 2 |
+| §8 `<ExportMenu>` UI | Task 4 |
+| §9 Render-point integration (WizardDone + admin page) | Tasks 5, 6 |
+| §10 Tests (lib + ExportMenu + E2E) | Tasks 2, 4, 7 |
+| §3 Out of scope (PDF, theme picker, resolution picker, server-side, admin web, permalink, viewport-only) | Honored — no tasks for these |
+
+If a spec requirement isn't covered, add or extend a task — don't quietly drop it.
+
+---
+
+## Execution
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-05-graph-export-actions.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-30-adk-langgraph-graph-visualizer-design.md
+++ b/docs/superpowers/specs/2026-04-30-adk-langgraph-graph-visualizer-design.md
@@ -1,0 +1,547 @@
+# ADK + LangGraph Graph Visualizer Design
+
+> **Status:** Locked — ready for implementation plan
+> **Branch:** `worktree-graph-display` (based on `feat/onboarding-mvp`)
+> **Depends on:** `feat/onboarding-mvp` (engine `agent_not_ready` boot mode + standalone UI shell)
+
+---
+
+## 1. Goal
+
+Build a framework-agnostic graph visualizer for agents loaded by the Idun engine. Three deliverables:
+
+1. **Engine routes** — `GET /agent/graph` (JSON IR), `/agent/graph/mermaid` (str), `/agent/graph/ascii` (str) — supporting both LangGraph and ADK agents.
+2. **Schema-package IR** — versioned Pydantic models in `idun_agent_schema` describing agents (LlmAgent, Sequential, Parallel, Loop, Custom), tools (native, MCP, built-in), and edges (parent_child, sequential_step, parallel_branch, loop_step, tool_attach, graph_edge).
+3. **Standalone-UI rendering** — a custom React component using ReactFlow + dagre layout. Mounts on `WizardDone` (post-onboarding success) and `app/admin/agent` (admin tab). Pan + zoom + minimap; no inspection panel in v1.
+
+The admin web (`services/idun_agent_web`) is not migrated in this branch — it keeps its existing Mermaid graph section, with a **3-line URL update** to point at `/agent/graph/mermaid` so it stays functional through the contract change.
+
+## 2. Why
+
+The engine currently exposes `GET /agent/graph` returning `{"graph": "<mermaid>"}` for LangGraph only (PR #312). ADK has no equivalent. After the onboarding wizard detects an existing agent, the user has no visual confirmation of what was found beyond a name — no surface that says "here's what your agent looks like." This branch closes that gap for ADK and standardizes both frameworks on a single UI-renderable contract.
+
+A custom UI component (rather than Mermaid pass-through) was a deliberate choice — Mermaid's visual language constrains us to its primitives; ReactFlow + custom node components let us render agents and tools as branded cards that adapt to user-themed standalone deployments.
+
+## 3. Out of scope
+
+- **Wizard pre-detection preview** (graph in `WizardOneDetected` before agent is materialized). Engine has no loaded agent at that point; preview would need a separate dynamic-import-and-introspect path. Deferred.
+- **Inspection side panel** (click a node → drawer with details). The IR carries the data; a follow-up branch adds the panel.
+- **Admin-web ReactFlow swap**. The `graph-section.tsx` component in `idun_agent_web` keeps using Mermaid; this branch only updates its URL to the new mermaid endpoint.
+- **Haystack support**. `HaystackAgent.get_graph_ir()` is not implemented; the routes 404 for Haystack agents.
+- **Server-rendered images** (PNG/SVG from the engine). All rendering is client-side.
+- **Editable graph** — read-only forever.
+- **Live updates / streaming** — graph fetched once per page; React Query handles invalidation on `/reload`.
+- **Layout direction toggle, search, expand/collapse subtrees** — possible follow-ups; not in this scope.
+
+## 4. Architecture
+
+Three packages collaborate. Each owns one slice; nothing leaks.
+
+```
+libs/idun_agent_schema/
+  └─ engine/graph.py                  NEW — Pydantic IR models (versioned)
+
+libs/idun_agent_engine/
+  ├─ agent/base.py                    MODIFY — add get_graph_ir(), draw_mermaid(), draw_ascii()
+  ├─ agent/langgraph/langgraph.py     MODIFY — implement get_graph_ir(); override draw_* to native
+  ├─ agent/adk/adk.py                 MODIFY — implement get_graph_ir() walking App.root_agent
+  ├─ server/graph/__init__.py         NEW
+  ├─ server/graph/mermaid.py          NEW — render_mermaid(graph) -> str (framework-agnostic)
+  ├─ server/graph/ascii.py            NEW — render_ascii(graph) -> str (framework-agnostic)
+  └─ server/routers/agent.py          MODIFY — replace /agent/graph with three routes
+
+services/idun_agent_standalone_ui/
+  ├─ package.json                     MODIFY — add @xyflow/react, @dagrejs/dagre
+  ├─ lib/api/types/graph.ts           NEW — hand-written TS mirror of schema models
+  ├─ lib/api/index.ts                 MODIFY — add api.getAgentGraph{,Mermaid,Ascii}()
+  ├─ components/graph/AgentGraph.tsx  NEW — ReactFlow canvas + dagre layout
+  ├─ components/graph/nodes/AgentNode.tsx  NEW — agent card
+  ├─ components/graph/nodes/ToolNode.tsx   NEW — tool pill
+  ├─ components/graph/edges/index.tsx      NEW — edge styles per EdgeKind
+  ├─ components/onboarding/WizardDone.tsx  MODIFY — embed <AgentGraph>
+  └─ app/admin/agent/page.tsx         MODIFY — add "Graph" tab with <AgentGraph>
+
+services/idun_agent_web/
+  └─ src/pages/agent-detail/tabs/overview-tab/sections/graph-section.tsx  MODIFY (3 lines)
+                                      Switch URL to /agent/graph/mermaid; read data.mermaid
+```
+
+Boundary: **engine produces the IR; UI knows how to render it**. Mermaid/ASCII are convenience renderings emitted by the engine for debug/copy-paste — the UI doesn't consume them. The engine stays UI-agnostic; the UI stays framework-agnostic (it never imports `langgraph`/`google-adk`).
+
+## 5. JSON IR data model
+
+New file: `libs/idun_agent_schema/src/idun_agent_schema/engine/graph.py`.
+
+```python
+from enum import Enum
+from typing import Annotated, Literal
+from pydantic import BaseModel, Field
+from idun_agent_schema.engine.agent_framework import AgentFramework
+
+
+class AgentKind(str, Enum):
+    LLM = "llm"
+    SEQUENTIAL = "sequential"
+    PARALLEL = "parallel"
+    LOOP = "loop"
+    CUSTOM = "custom"  # subclasses we don't recognize
+
+
+class ToolKind(str, Enum):
+    NATIVE = "native"      # plain function tool or unknown
+    MCP = "mcp"            # MCPToolset instance
+    BUILT_IN = "built_in"  # ADK built-in (google_search, load_artifacts, etc.)
+
+
+class EdgeKind(str, Enum):
+    PARENT_CHILD = "parent_child"          # generic agent → sub-agent
+    SEQUENTIAL_STEP = "sequential_step"    # SequentialAgent → step (order set)
+    PARALLEL_BRANCH = "parallel_branch"    # ParallelAgent → branch
+    LOOP_STEP = "loop_step"                # LoopAgent → step
+    TOOL_ATTACH = "tool_attach"            # agent → tool
+    GRAPH_EDGE = "graph_edge"              # LangGraph edge (condition optional)
+
+
+class AgentNode(BaseModel):
+    kind: Literal["agent"] = "agent"
+    id: str
+    name: str
+    agent_kind: AgentKind
+    is_root: bool = False
+    description: str | None = None
+    model: str | None = None              # LlmAgent only
+    loop_max_iterations: int | None = None  # LoopAgent only
+
+
+class ToolNode(BaseModel):
+    kind: Literal["tool"] = "tool"
+    id: str
+    name: str
+    tool_kind: ToolKind
+    description: str | None = None
+    mcp_server_name: str | None = None    # MCP tools only — descriptive (stdio cmd or URL)
+
+
+AgentGraphNode = Annotated[AgentNode | ToolNode, Field(discriminator="kind")]
+
+
+class AgentGraphEdge(BaseModel):
+    source: str           # node id
+    target: str
+    kind: EdgeKind
+    order: int | None = None       # SEQUENTIAL_STEP only
+    condition: str | None = None   # GRAPH_EDGE only (LangGraph conditional)
+    label: str | None = None       # display override
+
+
+class AgentGraphMetadata(BaseModel):
+    framework: AgentFramework
+    agent_name: str
+    root_id: str                       # entry point for layout
+    warnings: list[str] = Field(default_factory=list)
+
+
+class AgentGraph(BaseModel):
+    format_version: Literal["1"] = "1"
+    metadata: AgentGraphMetadata
+    nodes: list[AgentGraphNode]
+    edges: list[AgentGraphEdge]
+```
+
+**Notes:**
+
+- `format_version: "1"` is the migration anchor. v2 (when we add it) lives alongside, not as a breaking change.
+- `id` is stable within a single response (e.g., `"agent:billing_agent"`, `"tool:refund@billing_agent"`) — collision-safe even when two agents use a tool with the same name. Not stable across requests.
+- `warnings` lists best-effort introspection issues: e.g., `"Agent 'X' is a custom BaseAgent subclass; introspected as 'custom'"` or `"MCP toolset detection fell back to duck-typing"`.
+
+## 6. Engine: introspection
+
+### 6.1 `BaseAgent.get_graph_ir()` (`agent/base.py`)
+
+```python
+def get_graph_ir(self) -> AgentGraph:
+    """Return a framework-agnostic graph IR. Default: not supported."""
+    raise NotImplementedError(
+        f"{self.agent_type} does not support graph introspection"
+    )
+
+def draw_mermaid(self) -> str:
+    """Default: render the IR with the engine's framework-agnostic renderer."""
+    from idun_agent_engine.server.graph.mermaid import render_mermaid
+    return render_mermaid(self.get_graph_ir())
+
+def draw_ascii(self) -> str:
+    """Default: render the IR with the engine's framework-agnostic renderer."""
+    from idun_agent_engine.server.graph.ascii import render_ascii
+    return render_ascii(self.get_graph_ir())
+```
+
+`NotImplementedError` (not `@abstractmethod`) so Haystack stays valid without a stub. The route translates `NotImplementedError` → 404.
+
+### 6.2 `LanggraphAgent.get_graph_ir()`
+
+Walk `CompiledStateGraph.get_graph(xray=False)`:
+
+- Each entry in `lg_graph.nodes.items()` becomes one `AgentNode` with `agent_kind=AgentKind.CUSTOM` (LangGraph nodes don't map to ADK kinds), `is_root=True` for the `__start__` node.
+- Each entry in `lg_graph.edges` becomes one `AgentGraphEdge(kind=GRAPH_EDGE)`. Populate `condition` from the edge's conditional metadata if present (verify exact attribute name against pinned `langgraph` version during implementation; fall back to `condition=None` and emit a warning if the API differs). Populate `label` from the edge's display label.
+- `metadata.framework=AgentFramework.LANGGRAPH`, `metadata.root_id="node:__start__"`.
+- **Override `draw_mermaid()` and `draw_ascii()`** to delegate to LangGraph's native `instance.get_graph().draw_mermaid()` and `draw_ascii()`. They produce polished, battle-tested output for LangGraph specifically; we don't reinvent.
+- `xray=False` matches the existing route's behavior (PR #312). A future query-param toggle (`?xray=true`) can expose subgraph internals; not in v1.
+
+### 6.3 `AdkAgent.get_graph_ir()`
+
+Recursive walk from `self._agent_instance.root_agent`. The `_agent_instance` is a `google.adk.apps.app.App`; the root is `App.root_agent`.
+
+The pseudo-code below illustrates shape and decision points; helper functions (`_describe_mcp_params`, `_looks_like_user_function`) are private implementation details to be defined during the implementation pass.
+
+```python
+def get_graph_ir(self) -> AgentGraph:
+    from google.adk.agents import (
+        BaseAgent as ADKBaseAgent, LlmAgent,
+        SequentialAgent, ParallelAgent, LoopAgent,
+    )
+    # ... import IR models ...
+
+    if self._agent_instance is None:
+        raise RuntimeError("Agent not initialized")
+
+    nodes: list[AgentGraphNode] = []
+    edges: list[AgentGraphEdge] = []
+    warnings: list[str] = []
+
+    def _agent_kind(a: object) -> AgentKind:
+        if isinstance(a, SequentialAgent): return AgentKind.SEQUENTIAL
+        if isinstance(a, ParallelAgent):   return AgentKind.PARALLEL
+        if isinstance(a, LoopAgent):       return AgentKind.LOOP
+        if isinstance(a, LlmAgent):        return AgentKind.LLM
+        return AgentKind.CUSTOM
+
+    def _classify_tool(tool: object) -> tuple[ToolKind, str | None]:
+        # MCP toolset detection
+        try:
+            from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
+            if isinstance(tool, MCPToolset):
+                # Describe the toolset (stdio cmd or URL)
+                params = getattr(tool, "connection_params", None)
+                desc = _describe_mcp_params(params)
+                return (ToolKind.MCP, desc)
+        except ImportError:
+            pass
+        # Built-in detection: ADK ships these in google.adk.tools
+        module = getattr(tool, "__module__", "") or ""
+        if module.startswith("google.adk.tools") and not _looks_like_user_function(tool):
+            return (ToolKind.BUILT_IN, None)
+        return (ToolKind.NATIVE, None)
+
+    def _walk(agent, is_root: bool = False) -> str:
+        agent_id = f"agent:{agent.name}"
+        kind = _agent_kind(agent)
+
+        nodes.append(AgentNode(
+            id=agent_id, name=agent.name, agent_kind=kind, is_root=is_root,
+            description=getattr(agent, "description", None),
+            model=getattr(agent, "model", None) if kind == AgentKind.LLM else None,
+            loop_max_iterations=getattr(agent, "max_iterations", None) if kind == AgentKind.LOOP else None,
+        ))
+        if kind == AgentKind.CUSTOM:
+            warnings.append(f"Agent '{agent.name}' is a custom BaseAgent subclass; introspected best-effort")
+
+        # Tools
+        for tool in getattr(agent, "tools", None) or []:
+            tool_name = getattr(tool, "name", None) or getattr(tool, "__name__", None) or repr(tool)[:40]
+            tool_id = f"tool:{tool_name}@{agent.name}"
+            tool_kind, server_desc = _classify_tool(tool)
+            nodes.append(ToolNode(
+                id=tool_id, name=tool_name, tool_kind=tool_kind,
+                description=getattr(tool, "description", None),
+                mcp_server_name=server_desc,
+            ))
+            edges.append(AgentGraphEdge(
+                source=agent_id, target=tool_id, kind=EdgeKind.TOOL_ATTACH,
+            ))
+
+        # Sub-agents
+        for i, sub in enumerate(getattr(agent, "sub_agents", None) or []):
+            child_id = _walk(sub, is_root=False)
+            edge_kind = {
+                AgentKind.SEQUENTIAL: EdgeKind.SEQUENTIAL_STEP,
+                AgentKind.PARALLEL:   EdgeKind.PARALLEL_BRANCH,
+                AgentKind.LOOP:       EdgeKind.LOOP_STEP,
+            }.get(kind, EdgeKind.PARENT_CHILD)
+            edges.append(AgentGraphEdge(
+                source=agent_id, target=child_id, kind=edge_kind,
+                order=i if edge_kind == EdgeKind.SEQUENTIAL_STEP else None,
+            ))
+        return agent_id
+
+    root_id = _walk(self._agent_instance.root_agent, is_root=True)
+    return AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK, agent_name=self.name,
+            root_id=root_id, warnings=warnings,
+        ),
+        nodes=nodes, edges=edges,
+    )
+```
+
+**Tool granularity (v1)**: one `ToolNode` per entry in `agent.tools`. If the entry is an `MCPToolset`, the node represents the toolset as a whole (label: stdio command or SSE URL), **not** the tools inside it. Enumerating tools inside a toolset requires async connection (`await toolset.get_tools()`) at introspection time and is deferred to v1.5.
+
+**Stable tool IDs**: scoped by owner agent (`tool:{name}@{owner}`) so two agents using `google_search` don't collide on a shared id.
+
+### 6.4 `HaystackAgent`
+
+No override. Default `NotImplementedError` from `BaseAgent` stands → route returns 404.
+
+## 7. Engine: renderers
+
+New module: `libs/idun_agent_engine/src/idun_agent_engine/server/graph/`.
+
+### 7.1 `mermaid.py` — `render_mermaid(graph: AgentGraph) -> str`
+
+Pure function. Emits a Mermaid `graph TD` source string from any `AgentGraph` (framework-agnostic). Edge styles:
+
+- `PARENT_CHILD`: `A --> B`
+- `TOOL_ATTACH`: `A -.-> T`
+- `SEQUENTIAL_STEP`: `A == "1." ==> B` (order in label)
+- `PARALLEL_BRANCH`: `A ==> B` (thicker)
+- `LOOP_STEP`: `A -. "↻ ×N" .-> B` (where N is parent's `loop_max_iterations`)
+- `GRAPH_EDGE`: `A --> B` or `A -- "{condition}" --> B`
+
+Mermaid node style:
+
+- `AgentNode`: `id["{name}<br/>{agent_kind}"]` with class for root vs non-root.
+- `ToolNode`: `id(["{name}"])` (rounded) with class differentiating native/mcp/built_in.
+
+LangGraph delegates to native `draw_mermaid()` instead of using this — its native output is preferred.
+
+### 7.2 `ascii.py` — `render_ascii(graph: AgentGraph) -> str`
+
+Pure function. Tree printer rooted at `metadata.root_id`, using `├─` / `└─` / `│  ` connectors. Tools shown as leaves under each agent.
+
+```
+support_agent (LlmAgent, root)
+├─ tools
+│  └─ search_faq (mcp: stdio: npx ... server-filesystem)
+├─ billing_agent (LlmAgent)
+│  └─ tools
+│     └─ refund (native)
+└─ tech_support_agent (LlmAgent)
+   └─ tools
+      └─ create_ticket (native)
+```
+
+Adds a header line with framework, agent name, and any warnings. LangGraph delegates to native `draw_ascii()` (which uses `grandalf` — already a transitive dep via langgraph).
+
+## 8. Engine: HTTP routes
+
+`libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py`. Replace the existing `/agent/graph` route (which returned `{"graph": "<mermaid>"}`) with three:
+
+```python
+@agent_router.get("/graph", response_model=AgentGraph)
+async def get_graph_ir(
+    agent: Annotated[BaseAgent, Depends(get_agent)],
+    _user: Annotated[dict | None, Depends(get_verified_user)],
+) -> AgentGraph:
+    try:
+        return agent.get_graph_ir()
+    except NotImplementedError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception:
+        logger.exception("Graph IR extraction failed")
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail="Graph introspection failed")
+
+
+@agent_router.get("/graph/mermaid")
+async def get_graph_mermaid(
+    agent: Annotated[BaseAgent, Depends(get_agent)],
+    _user: Annotated[dict | None, Depends(get_verified_user)],
+) -> dict[str, str]:
+    try:
+        return {"mermaid": agent.draw_mermaid()}
+    except NotImplementedError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@agent_router.get("/graph/ascii")
+async def get_graph_ascii(
+    agent: Annotated[BaseAgent, Depends(get_agent)],
+    _user: Annotated[dict | None, Depends(get_verified_user)],
+) -> dict[str, str]:
+    try:
+        return {"ascii": agent.draw_ascii()}
+    except NotImplementedError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
+```
+
+**Auth**: same `get_verified_user` dep as `/agent/run`. Reused, not duplicated.
+
+**Status codes**:
+
+- `200` — success
+- `401`/`403` — auth failure (handled by dep)
+- `404` — `NotImplementedError` from adapter (Haystack today, custom adapters in future)
+- `503` — `agent_not_ready` (`get_agent` dep raises this from `feat/onboarding-mvp`'s unconfigured boot mode)
+- `500` — unexpected introspection error, with safe public message and full traceback in logs
+
+**Response shapes**:
+
+- IR route: `AgentGraph` (FastAPI `response_model` = OpenAPI auto-doc + Pydantic validation)
+- Mermaid/ASCII routes: JSON-wrapped `{"mermaid": str}` / `{"ascii": str}` to stay consistent with existing API conventions
+
+**Backward-compat** (admin web): the existing `services/idun_agent_web/src/pages/agent-detail/tabs/overview-tab/sections/graph-section.tsx` consumes `{"graph": str}`. Update it to call `/agent/graph/mermaid` and read `data.mermaid` — a 3-line change. No UI behavior change; the admin web continues to render via `mermaid` lib until the follow-up branch swaps in `<AgentGraph>`.
+
+## 9. Standalone-UI integration
+
+### 9.1 Dependencies
+
+Add to `services/idun_agent_standalone_ui/package.json`:
+
+- `@xyflow/react` (^12.x, MIT) — graph rendering
+- `@dagrejs/dagre` (^1.x, MIT) — hierarchical layout
+
+### 9.2 TypeScript types
+
+New `lib/api/types/graph.ts` — hand-written mirror of the schema-package Pydantic models. The standalone-UI's CLAUDE.md establishes hand-written types as the convention; codegen is not in place. Discriminated union via TS literal types — `AgentGraphNode = AgentNode | ToolNode` narrowed on `kind`.
+
+### 9.3 API client
+
+In `lib/api/index.ts`:
+
+```ts
+api.getAgentGraph        = () => apiFetch<AgentGraph>("/agent/graph")
+api.getAgentGraphMermaid = () => apiFetch<{mermaid: string}>("/agent/graph/mermaid")
+api.getAgentGraphAscii   = () => apiFetch<{ascii: string}>("/agent/graph/ascii")
+```
+
+These hit the **engine surface** (`/agent/*`), not the standalone admin (`/admin/api/v1/*`). The same FastAPI app serves both — `apiFetch` already handles relative paths correctly.
+
+### 9.4 Components
+
+`components/graph/AgentGraph.tsx` — main canvas. Props: `graph: AgentGraph`. Behavior:
+
+1. Map IR → ReactFlow `nodes` and `edges` (a pure function `irToReactFlow(graph)` so we can unit-test the mapping).
+2. Compute positions with `dagre` (`rankdir: "TB"`, `nodesep: 40`, `ranksep: 60`).
+3. Render `<ReactFlow nodeTypes={...} edgeTypes={...} fitView proOptions={{ hideAttribution: true }}>` with `<Background>`, `<Controls>`, `<MiniMap>`.
+4. Pan + zoom default; no click handlers in v1.
+
+`components/graph/nodes/AgentNode.tsx` — custom React Flow node for `kind: "agent"`. Renders a card with: framework icon (lucide), name (semibold), `agent_kind` chip, `model` badge (LlmAgent), root indicator. Color accent uses theme CSS variables (`--accent`, `--card`, `--border`) so user-themed deployments inherit branding.
+
+`components/graph/nodes/ToolNode.tsx` — custom node for `kind: "tool"`. Pill shape, smaller. Tool icon by `tool_kind` (function for native, plug for MCP, sparkle for built-in). Optional `mcp_server_name` chip below name.
+
+`components/graph/edges/index.tsx` — single custom edge component that picks style per `EdgeKind`:
+
+| `EdgeKind` | Style | Label |
+|---|---|---|
+| `parent_child` | solid 1.5px, `--accent` | none |
+| `tool_attach` | dashed 1.2px, `--muted-foreground` | none |
+| `sequential_step` | solid 1.5px | `"{order+1}."` |
+| `parallel_branch` | solid 1.5px, slightly thicker | none |
+| `loop_step` | dashed 1.5px | `"×{loop_max_iterations}"` if set |
+| `graph_edge` | solid 1.2px | `condition` if set |
+
+### 9.5 Render points
+
+**`components/onboarding/WizardDone.tsx`** — currently a single `Card` ("Agent is ready" + framework badge + env reminder + "Go to chat"). Add a second `Card` titled **"Your agent"** below it, body is `<AgentGraph graph={data} />`. Fetched via `useQuery(["agent-graph"], () => api.getAgentGraph())`. Loading: skeleton card. Error 404: friendly text "Graph view isn't available for this agent type yet." Error other: muted alert + retry.
+
+**`app/admin/agent/page.tsx`** — already uses a `<Tabs>` component (Identity / Config / etc.). Add a new tab **"Graph"** as the last tab. Body is the same `<AgentGraph>` with the same query (cache key shared). Same error UX.
+
+### 9.6 Theming
+
+Cards use existing shadcn/ui tokens (`bg-card`, `border-border`, `text-foreground`). Accent color reads `var(--accent)` from `ThemeLoader` so a self-hosted standalone with custom branding inherits the user's accent in the graph automatically — no extra wiring.
+
+### 9.7 Bundle size
+
+`@xyflow/react` + `@dagrejs/dagre` adds ~250KB gzipped to the static export. Two mitigations if it bites first-paint budget:
+
+1. **Lazy-load**: the graph component is only used on `WizardDone` (wizard flow) and `app/admin/agent` (admin). Neither is the chat first paint. Use `dynamic(() => import("@/components/graph/AgentGraph"), { ssr: false })`.
+2. **Tree-shake**: import only the React Flow primitives we use (`ReactFlow`, `Background`, `Controls`, `MiniMap`); avoid `@xyflow/react/full`.
+
+Decision: ship lazy-loaded by default. Measure before merge; revisit if needed.
+
+## 10. Testing
+
+### 10.1 Schema package — `libs/idun_agent_schema/tests/`
+
+- `AgentNode` and `ToolNode` round-trip via `model_dump()` / `model_validate()`.
+- Discriminated `AgentGraphNode` parses both variants from JSON correctly.
+- `format_version` rejects unknown versions.
+
+### 10.2 Engine — adapter introspection
+
+`libs/idun_agent_engine/tests/unit/agent/test_graph_ir_langgraph.py`:
+
+- Single-node graph (`START → my_node → END`).
+- Multi-node graph with `add_conditional_edges` — `condition` populated per branch label.
+- Edge labels preserved in `label`.
+
+`libs/idun_agent_engine/tests/unit/agent/test_graph_ir_adk.py`:
+
+- Root `LlmAgent` only.
+- `LlmAgent` with native function tool — `tool_kind=native`.
+- `LlmAgent` with `MCPToolset` — `tool_kind=mcp`, `mcp_server_name` populated.
+- `LlmAgent` with `google_search` — `tool_kind=built_in`.
+- `SequentialAgent` with 3 sub-agents — three `sequential_step` edges with `order=0,1,2`.
+- `ParallelAgent` with 2 sub-agents — `parallel_branch` edges.
+- `LoopAgent` with 1 sub-agent and `max_iterations=5` — parent's `loop_max_iterations=5`, edge `loop_step`.
+- Nested: root `LlmAgent` → `SequentialAgent` → 2 `LlmAgent` leaves with tools.
+- Custom `BaseAgent` subclass — `agent_kind=custom`, warning emitted.
+
+For each: assert node count, edge count, root id, and that specific edges/nodes exist with the right `kind`. Don't assert exhaustive structure — keep tests readable.
+
+### 10.3 Engine — renderers
+
+`tests/unit/server/graph/test_mermaid.py` and `test_ascii.py`. Build hand-crafted `AgentGraph` fixtures (no framework imports — these tests stay framework-agnostic) and assert renderer output. Plain string-equality with file fixtures (`.txt`); no `syrupy` dep introduced.
+
+LangGraph's native delegations don't need new tests — they're thin pass-throughs to LangGraph's tested code.
+
+### 10.4 Engine — routes
+
+Extend `libs/idun_agent_engine/tests/unit/server/routers/agent/test_graph_route.py` (already 55 lines covering the legacy mermaid path):
+
+- `GET /agent/graph` → `200`, body validates as `AgentGraph`.
+- `GET /agent/graph/mermaid` → `200`, `{"mermaid": str}` non-empty.
+- `GET /agent/graph/ascii` → `200`, `{"ascii": str}` non-empty.
+- All three → `404` when adapter raises `NotImplementedError` (mock a Haystack agent).
+- All three → `503` when agent unconfigured.
+- All three → `401` when auth dep rejects.
+
+Mock `get_agent` to return a fake `BaseAgent` with canned IR / strings — keeps route tests fast and decoupled from introspection tests.
+
+### 10.5 Standalone-UI — components
+
+`components/graph/__tests__/AgentGraph.test.tsx` (vitest + jsdom):
+
+- `irToReactFlow` (pure function) — assert it produces the right number of nodes and edges from a fixture IR.
+- `<AgentGraph>` renders without throwing for the same fixture.
+- `<AgentNode>` renders agent name + type chip text.
+- `<ToolNode>` renders MCP server chip when `tool_kind="mcp"`.
+
+Skip a heavy snapshot of the SVG — ReactFlow's DOM is verbose and brittle.
+
+### 10.6 Standalone-UI — E2E (light touch)
+
+Extend the existing wizard playwright spec (`e2e/wizard.spec.ts`): after `WizardDone` appears, the graph card is visible and contains at least one element matching `[data-id^="agent:"]`. One assertion, no introspection details. Skip a separate admin-page E2E for v1.
+
+### 10.7 Out of scope for testing
+
+- Visual regression on the rendered graph (would need Playwright + screenshot diffing).
+- Performance benchmarks for graphs with 100+ nodes.
+- Tool-discovery edge cases for unrecognized tool subclasses (we log a warning, don't error).
+
+## 11. Known unknowns to validate during implementation
+
+1. **LangGraph `Graph` edge attributes**: the runtime Graph object's edge representation has evolved (older versions: `Edge` dataclass with `source`, `target`, `data`, `conditional`; newer: includes Command-based routing surfaced as edges via `xray=True`). Verify against the version pinned by this repo before writing the walker. Fall back to `condition=None` and emit a warning if the API shifted.
+2. **ADK `MCPToolset` import path**: snippets show both `from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset` (older) and `from google.adk.tools import McpToolset` (newer). Try both imports; if both fail, fall back to duck-typed check (`hasattr(tool, "connection_params")`) and emit a warning.
+3. **ADK built-in tool detection heuristic**: the current heuristic ("module starts with `google.adk.tools` and not a user function") is conservative. Edge case: a user reimports `google_search` and wraps it. Acceptable false-positive rate for v1; revisit if needed.
+4. **`@xyflow/react` v12 attribution**: `proOptions={{ hideAttribution: true }}` is acceptable for self-hosted MIT use only when the legal terms are met. Verify license before merging — likely fine, but worth a 1-minute check.
+
+## 12. Follow-ups (out of scope for this branch)
+
+- **Wizard pre-detection preview** (`WizardOneDetected`): introspect the agent before materialization. Needs a `POST /agent/graph/preview` route that takes `{type, agent_path}` and runs an isolated import + introspection. Engine surface +1 route, IR consumer reused.
+- **Inspection side panel** (Q5 option C): click handlers + a sheet/drawer with node details (model, instructions excerpt, tool description, MCP server). UI only; the IR already carries the data.
+- **Admin-web ReactFlow swap**: replace `services/idun_agent_web`'s mermaid `graph-section.tsx` with the new `<AgentGraph>` component. Port to admin-web's styled-components conventions.
+- **Haystack support**: walk `Pipeline` graph; produce a different IR variant (Haystack pipelines aren't agent trees).
+- **MCP tool enumeration**: for MCPToolset entries, list the tools inside the toolset as individual ToolNodes (requires async toolset connection at introspection time).
+- **`xray=true` toggle**: query parameter on the IR/Mermaid routes to expose LangGraph subgraph internals.
+- **Layout interaction polish**: TB/LR direction toggle, expand/collapse subtrees, search.

--- a/docs/superpowers/specs/2026-05-05-graph-export-actions-design.md
+++ b/docs/superpowers/specs/2026-05-05-graph-export-actions-design.md
@@ -1,0 +1,459 @@
+# Graph Export Actions Design
+
+> **Status:** Locked — ready for implementation plan
+> **Branch:** `worktree-graph-display` (continues the ADK + LangGraph graph visualizer work)
+> **Depends on:** the AgentGraph ReactFlow canvas shipped on this branch (`5da1b5f9`)
+
+---
+
+## 1. Goal
+
+Add a small "Export ▾" dropdown to the Agent graph card in the standalone UI (both `WizardDone` and `app/admin/agent`). Four menu items:
+
+1. **Copy as image** — copies the graph as a PNG to the OS clipboard.
+2. **Download PNG** — downloads `<agent-slug>-graph.png` (raster, 2x retina-friendly).
+3. **Download SVG** — downloads `<agent-slug>-graph.svg` (vector).
+4. **Copy Mermaid source** — copies the engine's Mermaid source string (calls the existing `/agent/graph/mermaid` route) to the clipboard as text.
+
+All exports capture the **whole graph** regardless of current pan/zoom (24px padding around the fitted bounds, white background for raster).
+
+## 2. Why
+
+The graph is the demo target — users want to drop it into Slack, slide decks, design docs, and markdown READMEs. Today the only path is OS-level screenshot, which captures whatever is on screen, fights browser chrome, and looks unprofessional. Native export from inside the app removes friction and produces deterministic results regardless of viewport.
+
+Mermaid copy is included because the engine already exposes the source via `/agent/graph/mermaid`; piping it to the clipboard turns "use this in markdown" into a single click for technical users.
+
+## 3. Out of scope
+
+- **PDF export** — no current demand, would add another dependency.
+- **Background-color picker / theme-aware (dark-mode) export** — locked to white background for raster. SVG keeps `currentColor` where applicable so it inherits the embedding context. Configurable in v2 if asked.
+- **Resolution picker / @1x toggle** — locked to 2x device pixel ratio.
+- **Bulk export across multiple agents** — single-graph only.
+- **Server-side rendering of images in the engine** — explicit non-goal per `2026-04-30-adk-langgraph-graph-visualizer-design.md` §3 ("the engine never renders an image; UI does"). Stays client-only.
+- **Admin web (`services/idun_agent_web`) propagation** — that surface still uses Mermaid; adding the Export dropdown there is a follow-up branch.
+- **Permalink / shareable URL copy** — standalone has no shareable URLs.
+- **Current-viewport-only export** — covered by Q3 of the brainstorm; rejected because the "share my agent" use case wants completeness.
+
+## 4. Architecture
+
+Three new units, two existing components touched, one new dependency.
+
+```
+services/idun_agent_standalone_ui/
+  ├─ package.json                               MODIFY — add html-to-image
+  ├─ lib/graph-export.ts                        NEW    — pure helpers (4 functions + slug)
+  ├─ components/graph/
+  │   ├─ AgentGraph.tsx                         MODIFY — wrap in forwardRef, expose handle
+  │   └─ ExportMenu.tsx                         NEW    — dropdown UI + click handlers
+  ├─ components/onboarding/WizardDone.tsx       MODIFY — render <ExportMenu> in card header
+  └─ app/admin/agent/page.tsx                   MODIFY — same
+```
+
+**Boundary**: `lib/graph-export.ts` is pure — takes a DOM element + IR + name, performs file/clipboard side-effects. `<ExportMenu>` is the UI shell. `<AgentGraph>` exposes a handle (`forwardRef` + `useImperativeHandle`) so the menu — which lives in the card *header*, outside the ReactFlowProvider tree — can reach the canvas DOM and node bounds at click time.
+
+The ref handle is the load-bearing decision: it's chosen over a compound component or render prop so the two consumers (`WizardDone`, `app/admin/agent`) keep their existing card layouts and only add `<ExportMenu>` next to their existing title.
+
+## 5. Dependencies
+
+Add to `services/idun_agent_standalone_ui/package.json`:
+
+- `html-to-image` (^1.x, MIT) — ~20KB gzipped. ReactFlow v12 docs' recommended companion for image export. Provides `toPng`, `toSvg`, `toBlob`.
+
+No other dependencies needed. Sonner (toast), shadcn `<DropdownMenu>`, lucide icons (`Download`, `Image`, `FileImage`, `FileText`) are already in the codebase.
+
+## 6. AgentGraph handle
+
+Modify `components/graph/AgentGraph.tsx`. Wrap the existing component in `forwardRef`, add `useImperativeHandle`:
+
+```ts
+export interface AgentGraphHandle {
+  /** The .react-flow root DOM element (for html-to-image), or null before mount. */
+  getCanvasElement(): HTMLElement | null;
+  /** World-coordinate bounding box of all nodes; null if no nodes. */
+  getNodesBounds(): { x: number; y: number; width: number; height: number } | null;
+}
+
+export const AgentGraph = forwardRef<AgentGraphHandle, AgentGraphProps>(
+  function AgentGraph({ graph, height = 420 }, ref) {
+    // Inside ReactFlowProvider — useReactFlow() works here.
+    // useImperativeHandle exposes the two methods using the existing
+    // `nodes` array and a `containerRef` on the canvas div.
+    ...
+  },
+);
+```
+
+`getNodesBounds` uses ReactFlow's `getNodesBounds` helper from `@xyflow/react` against the layout-positioned nodes (post-dagre).
+
+## 7. `lib/graph-export.ts` — pure helpers
+
+Single module, four exports plus the slug helper.
+
+```ts
+import { toPng, toSvg, toBlob } from "html-to-image";
+import { api } from "@/lib/api";
+
+export function slugifyAgentName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return slug || "agent";
+}
+
+interface ExportConfig {
+  bounds: { x: number; y: number; width: number; height: number };
+  padding?: number;        // default 24
+  pixelRatio?: number;     // default 2 (PNG only; SVG ignores)
+  background?: string;     // default "#ffffff"
+}
+
+function htmlToImageOpts(cfg: ExportConfig) {
+  const padding = cfg.padding ?? 24;
+  const w = cfg.bounds.width + 2 * padding;
+  const h = cfg.bounds.height + 2 * padding;
+  return {
+    width: w,
+    height: h,
+    pixelRatio: cfg.pixelRatio ?? 2,
+    backgroundColor: cfg.background ?? "#ffffff",
+    style: {
+      transform: `translate(${-cfg.bounds.x + padding}px, ${
+        -cfg.bounds.y + padding
+      }px)`,
+      transformOrigin: "0 0",
+      width: `${w}px`,
+      height: `${h}px`,
+    },
+    filter: (node: HTMLElement) => {
+      // Strip ReactFlow chrome from the export.
+      const cls = node.classList;
+      if (!cls) return true;
+      return !(
+        cls.contains("react-flow__minimap") ||
+        cls.contains("react-flow__controls") ||
+        cls.contains("react-flow__attribution") ||
+        cls.contains("react-flow__background")
+      );
+    },
+  };
+}
+
+function triggerDownload(dataUrl: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = dataUrl;
+  a.download = filename;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+export async function exportToPng(
+  canvas: HTMLElement,
+  agentName: string,
+  cfg: ExportConfig,
+): Promise<void> {
+  const dataUrl = await toPng(canvas, htmlToImageOpts(cfg));
+  triggerDownload(dataUrl, `${slugifyAgentName(agentName)}-graph.png`);
+}
+
+export async function exportToSvg(
+  canvas: HTMLElement,
+  agentName: string,
+  cfg: ExportConfig,
+): Promise<void> {
+  const dataUrl = await toSvg(canvas, htmlToImageOpts(cfg));
+  triggerDownload(dataUrl, `${slugifyAgentName(agentName)}-graph.svg`);
+}
+
+export async function copyPngToClipboard(
+  canvas: HTMLElement,
+  cfg: ExportConfig,
+): Promise<void> {
+  if (!navigator.clipboard?.write) {
+    throw new Error("Clipboard image API not available");
+  }
+  const blob = await toBlob(canvas, htmlToImageOpts(cfg));
+  if (!blob) throw new Error("Failed to render image blob");
+  await navigator.clipboard.write([
+    new ClipboardItem({ "image/png": blob }),
+  ]);
+}
+
+export async function copyMermaidToClipboard(): Promise<void> {
+  if (!navigator.clipboard?.writeText) {
+    throw new Error("Clipboard API not available");
+  }
+  const { mermaid } = await api.getAgentGraphMermaid();
+  await navigator.clipboard.writeText(mermaid);
+}
+```
+
+**Notes**:
+
+- `htmlToImageOpts` centralizes the bounds/transform/filter logic so all four entry points behave identically.
+- The `filter` predicate strips minimap/controls/attribution/dotted-background so the exported image shows just the graph on a clean plate.
+- Errors propagate as rejected promises; the UI layer (`<ExportMenu>`) handles them with toasts.
+
+## 8. `<ExportMenu>` UI
+
+New file `components/graph/ExportMenu.tsx`. Uses shadcn `<DropdownMenu>` (already in codebase per existing admin pages). Lucide icons for the trigger and items.
+
+```tsx
+"use client";
+
+import { Download, Image as ImageIcon, FileImage, FileText, ChevronDown } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  copyMermaidToClipboard,
+  copyPngToClipboard,
+  exportToPng,
+  exportToSvg,
+} from "@/lib/graph-export";
+import type { AgentGraphHandle } from "./AgentGraph";
+
+interface ExportMenuProps {
+  graphRef: React.RefObject<AgentGraphHandle | null>;
+  agentName: string;
+  disabled?: boolean;
+}
+
+export function ExportMenu({ graphRef, agentName, disabled }: ExportMenuProps) {
+  const guard = (action: () => Promise<void>, success: string, failure: string) =>
+    async () => {
+      try {
+        await action();
+        toast.success(success);
+      } catch (err) {
+        console.error(err);
+        toast.error(failure);
+      }
+    };
+
+  const withCanvas = (kind: "png-clip" | "png-dl" | "svg-dl") => async () => {
+    const canvas = graphRef.current?.getCanvasElement();
+    const bounds = graphRef.current?.getNodesBounds();
+    if (!canvas || !bounds) {
+      toast.error("Graph not ready");
+      return;
+    }
+    const cfg = { bounds };
+    if (kind === "png-clip")
+      await guard(
+        () => copyPngToClipboard(canvas, cfg),
+        "Copied graph image to clipboard",
+        "Clipboard not available — try downloading instead",
+      )();
+    if (kind === "png-dl")
+      await guard(
+        () => exportToPng(canvas, agentName, cfg),
+        "Downloaded PNG",
+        "Couldn't export PNG",
+      )();
+    if (kind === "svg-dl")
+      await guard(
+        () => exportToSvg(canvas, agentName, cfg),
+        "Downloaded SVG",
+        "Couldn't export SVG",
+      )();
+  };
+
+  const onCopyMermaid = guard(
+    copyMermaidToClipboard,
+    "Copied Mermaid source",
+    "Couldn't copy Mermaid source",
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" disabled={disabled}>
+          <Download className="mr-1 h-3.5 w-3.5" />
+          Export
+          <ChevronDown className="ml-1 h-3.5 w-3.5 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={withCanvas("png-clip")}>
+          <ImageIcon className="mr-2 h-4 w-4" /> Copy as image
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={withCanvas("png-dl")}>
+          <FileImage className="mr-2 h-4 w-4" /> Download PNG
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={withCanvas("svg-dl")}>
+          <FileImage className="mr-2 h-4 w-4" /> Download SVG
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onCopyMermaid}>
+          <FileText className="mr-2 h-4 w-4" /> Copy Mermaid source
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+```
+
+The `disabled` prop is wired by the parent based on `graphQuery.isLoading || isError`. The `withCanvas` guard handles the rare race where the menu opens before the canvas mounted (button disabled state should already prevent it; defense in depth).
+
+## 9. Render-point integration
+
+### `WizardDone.tsx`
+
+Current state (post-Task 16): the second card has `<CardHeader><CardTitle>Your agent</CardTitle></CardHeader>` and a body with `<AgentGraph graph={data} />`. Diff:
+
+1. `import { ExportMenu } from "@/components/graph/ExportMenu";`
+2. Add `const graphRef = useRef<AgentGraphHandle>(null);`.
+3. Replace the title-only header with a flex header:
+   ```tsx
+   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+     <CardTitle className="text-base">Your agent</CardTitle>
+     <ExportMenu
+       graphRef={graphRef}
+       agentName={agent.name}
+       disabled={graphQuery.isLoading || graphQuery.isError}
+     />
+   </CardHeader>
+   ```
+4. Pass `ref={graphRef}` to `<AgentGraph>`.
+
+### `app/admin/agent/page.tsx`
+
+Same pattern. The "Agent graph" card already has a `<CardHeader>` with title + description; we add `<ExportMenu>` to the right of the title using the same flex layout (or keep description in a second row).
+
+## 10. Testing
+
+### `lib/__tests__/graph-export.test.ts`
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { slugifyAgentName, exportToPng, copyMermaidToClipboard } from "../graph-export";
+
+vi.mock("html-to-image", () => ({
+  toPng: vi.fn().mockResolvedValue("data:image/png;base64,FAKE"),
+  toSvg: vi.fn().mockResolvedValue("data:image/svg+xml;FAKE"),
+  toBlob: vi.fn().mockResolvedValue(new Blob(["x"], { type: "image/png" })),
+}));
+vi.mock("@/lib/api", () => ({
+  api: { getAgentGraphMermaid: vi.fn().mockResolvedValue({ mermaid: "graph TD\n  a-->b" }) },
+}));
+
+describe("slugifyAgentName", () => {
+  it("lowercases + dashes spaces", () => {
+    expect(slugifyAgentName("My Cool Agent")).toBe("my-cool-agent");
+  });
+  it("strips non-ASCII", () => {
+    expect(slugifyAgentName("naïve Agent")).toBe("nave-agent");
+  });
+  it("falls back to 'agent' for empty result", () => {
+    expect(slugifyAgentName("***")).toBe("agent");
+  });
+});
+
+describe("exportToPng", () => {
+  it("triggers a download with slug-based filename", async () => {
+    const canvas = document.createElement("div");
+    const clickSpy = vi.fn();
+    document.createElement = ((orig) =>
+      function (tag: string) {
+        const el = orig.call(document, tag);
+        if (tag === "a") (el as HTMLAnchorElement).click = clickSpy;
+        return el;
+      })(document.createElement.bind(document));
+    await exportToPng(canvas, "My Agent", {
+      bounds: { x: 0, y: 0, width: 100, height: 100 },
+    });
+    expect(clickSpy).toHaveBeenCalled();
+  });
+});
+
+describe("copyMermaidToClipboard", () => {
+  it("writes mermaid text to clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    await copyMermaidToClipboard();
+    expect(writeText).toHaveBeenCalledWith("graph TD\n  a-->b");
+  });
+});
+```
+
+### `components/graph/__tests__/ExportMenu.test.tsx`
+
+```ts
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/graph-export", () => ({
+  copyPngToClipboard: vi.fn().mockResolvedValue(undefined),
+  copyMermaidToClipboard: vi.fn().mockResolvedValue(undefined),
+  exportToPng: vi.fn().mockResolvedValue(undefined),
+  exportToSvg: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { ExportMenu } from "../ExportMenu";
+import * as exporters from "@/lib/graph-export";
+import { toast } from "sonner";
+
+const mkRef = () => ({
+  current: {
+    getCanvasElement: () => document.createElement("div"),
+    getNodesBounds: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+  },
+});
+
+describe("ExportMenu", () => {
+  it("renders 4 menu items when opened", async () => {
+    render(<ExportMenu graphRef={mkRef() as any} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    expect(screen.getByText("Copy as image")).toBeInTheDocument();
+    expect(screen.getByText("Download PNG")).toBeInTheDocument();
+    expect(screen.getByText("Download SVG")).toBeInTheDocument();
+    expect(screen.getByText("Copy Mermaid source")).toBeInTheDocument();
+  });
+
+  it("calls exportToPng on Download PNG click", async () => {
+    render(<ExportMenu graphRef={mkRef() as any} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Download PNG"));
+    expect(exporters.exportToPng).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith("Downloaded PNG");
+  });
+
+  it("button is disabled when disabled prop set", () => {
+    render(<ExportMenu graphRef={mkRef() as any} agentName="x" disabled />);
+    expect(screen.getByRole("button", { name: /export/i })).toBeDisabled();
+  });
+});
+```
+
+### E2E
+
+Extend `e2e/onboarding.spec.ts` with one assertion: the Export button is visible after `WizardDone` renders the graph. **No** click-through (Playwright's download API works but adds 5+ seconds for marginal value over the unit tests).
+
+## 11. Known unknowns to verify during implementation
+
+1. **Minimap / controls in the export**: the `filter` predicate in `htmlToImageOpts` strips them; verify against actual output. If anything leaks (e.g., handle dots, inline SVG of edges), extend the filter list.
+2. **SVG `currentColor` handling**: html-to-image inlines computed styles; some `currentColor` references may resolve to whatever the page's foreground is at export time. Acceptable for v1 — the SVG is meant to be rendered, not edited.
+3. **Safari clipboard image API**: `ClipboardItem` with image/png blobs is supported in Safari 13.4+ but historically flaky for async paths. The destructive toast fallback covers this; verify behavior on Safari before claiming "all browsers".
+4. **html-to-image and `<canvas>` tainting**: ReactFlow renders nodes as DOM, not canvas, so no CORS taint. Confirmed safe.
+
+## 12. Follow-ups (out of scope)
+
+- **Admin web (`idun_agent_web`) propagation**: when that surface migrates from Mermaid to `<AgentGraph>` (already a follow-up from the original visualizer spec), wire up the same Export dropdown.
+- **PDF export, theme-aware export, resolution picker**: see §3.
+- **Server-side export endpoint**: explicit non-goal; the engine never renders images.
+- **"Copy as Markdown" with embedded base64 PNG**: trivial future v2 if asked.

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
@@ -667,13 +667,20 @@ class AdkAgent(agent_base.BaseAgent):
                     )
                 )
 
-            # Sub-agents — Task 7 will add edge-kind dispatch.
-            # For Task 6 we use PARENT_CHILD for all sub-agent edges.
-            for sub in getattr(agent, "sub_agents", None) or []:
+            # Sub-agents — edge kind picked from the parent's agent_kind.
+            for i, sub in enumerate(getattr(agent, "sub_agents", None) or []):
                 child_id = _walk(sub, is_root=False)
+                edge_kind = {
+                    AgentKind.SEQUENTIAL: EdgeKind.SEQUENTIAL_STEP,
+                    AgentKind.PARALLEL: EdgeKind.PARALLEL_BRANCH,
+                    AgentKind.LOOP: EdgeKind.LOOP_STEP,
+                }.get(kind, EdgeKind.PARENT_CHILD)
                 edges.append(
                     AgentGraphEdge(
-                        source=agent_id, target=child_id, kind=EdgeKind.PARENT_CHILD
+                        source=agent_id,
+                        target=child_id,
+                        kind=edge_kind,
+                        order=i if edge_kind == EdgeKind.SEQUENTIAL_STEP else None,
                     )
                 )
             return agent_id

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
@@ -101,6 +101,21 @@ def _events_to_messages(events: list[Any]) -> list[SessionMessage]:
     return msgs
 
 
+def _describe_mcp_params(params: object) -> str | None:
+    """Best-effort label for an MCPToolset connection params object."""
+    if params is None:
+        return None
+    cmd = getattr(params, "command", None)
+    args = getattr(params, "args", None)
+    if cmd is not None:
+        joined = " ".join(args or [])
+        return f"stdio: {cmd} {joined}".strip()
+    url = getattr(params, "url", None)
+    if url is not None:
+        return f"http: {url}"
+    return type(params).__name__
+
+
 class AdkAgent(agent_base.BaseAgent):
     """ADK agent adapter implementing the BaseAgent protocol."""
 
@@ -412,20 +427,6 @@ class AdkAgent(agent_base.BaseAgent):
             memory_service=self._memory_service,
         )
 
-    def _describe_mcp_params(self, params: object) -> str | None:
-        """Best-effort label for an MCPToolset connection params object."""
-        if params is None:
-            return None
-        cmd = getattr(params, "command", None)
-        args = getattr(params, "args", None)
-        if cmd is not None:
-            joined = " ".join(args or [])
-            return f"stdio: {cmd} {joined}".strip()
-        url = getattr(params, "url", None)
-        if url is not None:
-            return f"http: {url}"
-        return type(params).__name__
-
     def _extract_text_from_event(self, event: Event) -> str | None:
         if not event.content or not event.content.parts:
             return None
@@ -604,7 +605,7 @@ class AdkAgent(agent_base.BaseAgent):
                     if cls is not None and isinstance(tool, cls):
                         return (
                             ToolKind.MCP,
-                            self._describe_mcp_params(
+                            _describe_mcp_params(
                                 getattr(tool, "connection_params", None)
                             ),
                         )

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
@@ -412,6 +412,20 @@ class AdkAgent(agent_base.BaseAgent):
             memory_service=self._memory_service,
         )
 
+    def _describe_mcp_params(self, params: object) -> str | None:
+        """Best-effort label for an MCPToolset connection params object."""
+        if params is None:
+            return None
+        cmd = getattr(params, "command", None)
+        args = getattr(params, "args", None)
+        if cmd is not None:
+            joined = " ".join(args or [])
+            return f"stdio: {cmd} {joined}".strip()
+        url = getattr(params, "url", None)
+        if url is not None:
+            return f"http: {url}"
+        return type(params).__name__
+
     def _extract_text_from_event(self, event: Event) -> str | None:
         if not event.content or not event.content.parts:
             return None
@@ -537,6 +551,144 @@ class AdkAgent(agent_base.BaseAgent):
         self._cached_capabilities = result
         return result
 
+    def get_graph_ir(self):
+        from google.adk.agents import (
+            LlmAgent,
+            LoopAgent,
+            ParallelAgent,
+            SequentialAgent,
+        )
+        from idun_agent_schema.engine.agent_framework import AgentFramework
+        from idun_agent_schema.engine.graph import (
+            AgentGraph,
+            AgentGraphEdge,
+            AgentGraphMetadata,
+            AgentGraphNode,
+            AgentKind,
+            AgentNode,
+            EdgeKind,
+            ToolKind,
+            ToolNode,
+        )
+
+        if self._agent_instance is None:
+            raise RuntimeError("Agent not initialized. Call initialize() first.")
+
+        root_agent = self._agent_instance.root_agent
+        nodes: list[AgentGraphNode] = []
+        edges: list[AgentGraphEdge] = []
+        warnings: list[str] = []
+
+        def _agent_kind(a: object) -> AgentKind:
+            if isinstance(a, SequentialAgent):
+                return AgentKind.SEQUENTIAL
+            if isinstance(a, ParallelAgent):
+                return AgentKind.PARALLEL
+            if isinstance(a, LoopAgent):
+                return AgentKind.LOOP
+            if isinstance(a, LlmAgent):
+                return AgentKind.LLM
+            return AgentKind.CUSTOM
+
+        def _classify_tool(tool: object) -> tuple[ToolKind, str | None]:
+            # Try MCP toolset detection — both old and new import paths.
+            for mod_path in (
+                "google.adk.tools.mcp_tool.mcp_toolset",
+                "google.adk.tools",
+            ):
+                try:
+                    module = __import__(mod_path, fromlist=["MCPToolset", "McpToolset"])
+                    cls = getattr(module, "MCPToolset", None) or getattr(
+                        module, "McpToolset", None
+                    )
+                    if cls is not None and isinstance(tool, cls):
+                        return (
+                            ToolKind.MCP,
+                            self._describe_mcp_params(
+                                getattr(tool, "connection_params", None)
+                            ),
+                        )
+                except Exception:
+                    continue
+            # Built-in detection: anything in google.adk.tools.* not matched as MCP.
+            # User functions live in their own module.
+            module_name = getattr(tool, "__module__", "") or ""
+            if module_name.startswith("google.adk.tools"):
+                return (ToolKind.BUILT_IN, None)
+            return (ToolKind.NATIVE, None)
+
+        def _walk(agent: object, is_root: bool = False) -> str:
+            agent_id = f"agent:{agent.name}"
+            kind = _agent_kind(agent)
+            nodes.append(
+                AgentNode(
+                    id=agent_id,
+                    name=agent.name,
+                    agent_kind=kind,
+                    is_root=is_root,
+                    description=getattr(agent, "description", None),
+                    model=(
+                        getattr(agent, "model", None) if kind == AgentKind.LLM else None
+                    ),
+                    loop_max_iterations=(
+                        getattr(agent, "max_iterations", None)
+                        if kind == AgentKind.LOOP
+                        else None
+                    ),
+                )
+            )
+            if kind == AgentKind.CUSTOM:
+                warnings.append(
+                    f"Agent '{agent.name}' is a custom BaseAgent subclass; "
+                    f"introspected best-effort"
+                )
+
+            for tool in getattr(agent, "tools", None) or []:
+                tool_name = (
+                    getattr(tool, "name", None)
+                    or getattr(tool, "__name__", None)
+                    or repr(tool)[:40]
+                )
+                tool_id = f"tool:{tool_name}@{agent.name}"
+                tool_kind, server_desc = _classify_tool(tool)
+                nodes.append(
+                    ToolNode(
+                        id=tool_id,
+                        name=tool_name,
+                        tool_kind=tool_kind,
+                        description=getattr(tool, "description", None),
+                        mcp_server_name=server_desc,
+                    )
+                )
+                edges.append(
+                    AgentGraphEdge(
+                        source=agent_id, target=tool_id, kind=EdgeKind.TOOL_ATTACH
+                    )
+                )
+
+            # Sub-agents — Task 7 will add edge-kind dispatch.
+            # For Task 6 we use PARENT_CHILD for all sub-agent edges.
+            for sub in getattr(agent, "sub_agents", None) or []:
+                child_id = _walk(sub, is_root=False)
+                edges.append(
+                    AgentGraphEdge(
+                        source=agent_id, target=child_id, kind=EdgeKind.PARENT_CHILD
+                    )
+                )
+            return agent_id
+
+        root_id = _walk(root_agent, is_root=True)
+        return AgentGraph(
+            metadata=AgentGraphMetadata(
+                framework=AgentFramework.ADK,
+                agent_name=self.name,
+                root_id=root_id,
+                warnings=warnings,
+            ),
+            nodes=nodes,
+            edges=edges,
+        )
+
     def history_capabilities(self) -> HistoryCapabilities:
         """Declare ADK session-history support.
 
@@ -581,7 +733,9 @@ class AdkAgent(agent_base.BaseAgent):
             if full is None:
                 continue
             state = getattr(full, "state", None)
-            thread_id_value = state.get("_ag_ui_thread_id") if isinstance(state, dict) else None
+            thread_id_value = (
+                state.get("_ag_ui_thread_id") if isinstance(state, dict) else None
+            )
             if not isinstance(thread_id_value, str):
                 continue
             out.append(

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/base.py
@@ -3,9 +3,14 @@
 Defines the abstract `BaseAgent` used by all agent implementations.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from idun_agent_schema.engine.graph import AgentGraph
 
 from ag_ui.core import BaseEvent
 from ag_ui.core.types import RunAgentInput
@@ -133,9 +138,7 @@ class BaseAgent[ConfigType: BaseAgentConfig](ABC):
         # For the ABC, we can't have a `yield` directly in the abstract method body.
         # The signature itself defines it as an async generator.
         # Example: async for chunk in agent.stream(message): ...
-        if (
-            False
-        ):  # pragma: no cover (This is just to make it a generator type for static analysis)
+        if False:  # pragma: no cover (This is just to make it a generator type for static analysis)
             yield
 
     @abstractmethod
@@ -193,3 +196,34 @@ class BaseAgent[ConfigType: BaseAgentConfig](ABC):
         raise NotImplementedError(
             f"get_session not implemented for {type(self).__name__}"
         )
+
+    def get_graph_ir(self) -> AgentGraph:
+        """Return a framework-agnostic graph IR.
+
+        Override in subclasses that can introspect their underlying agent.
+        """
+        raise NotImplementedError(
+            f"{self.agent_type} does not support graph introspection"
+        )
+
+    def draw_mermaid(self) -> str:
+        """Render the agent graph as a Mermaid source string.
+
+        Default: render the IR via the engine's framework-agnostic renderer.
+        Adapters with native diagram support (e.g. LangGraph) may override.
+        """
+        ir = self.get_graph_ir()
+        from idun_agent_engine.server.graph.mermaid import render_mermaid
+
+        return render_mermaid(ir)
+
+    def draw_ascii(self) -> str:
+        """Render the agent graph as ASCII art.
+
+        Default: render the IR via the engine's framework-agnostic renderer.
+        Adapters with native ASCII support (e.g. LangGraph + grandalf) may override.
+        """
+        ir = self.get_graph_ir()
+        from idun_agent_engine.server.graph.ascii import render_ascii
+
+        return render_ascii(ir)

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -861,7 +861,6 @@ class LanggraphAgent(agent_base.BaseAgent):
             AgentNode,
             EdgeKind,
         )
-        from langgraph.graph.state import CompiledStateGraph
 
         if not isinstance(self._agent_instance, CompiledStateGraph):
             raise NotImplementedError(
@@ -872,7 +871,7 @@ class LanggraphAgent(agent_base.BaseAgent):
         nodes: list[AgentNode] = []
         edges: list[AgentGraphEdge] = []
 
-        for node_id, _ in lg_graph.nodes.items():
+        for node_id in lg_graph.nodes:
             is_root = node_id == "__start__"
             nodes.append(
                 AgentNode(
@@ -886,21 +885,24 @@ class LanggraphAgent(agent_base.BaseAgent):
         for lg_edge in lg_graph.edges:
             # Public attrs: source, target. `conditional` and `data` are documented;
             # if a future LangGraph version renames them, fall back gracefully.
+            data = getattr(lg_edge, "data", None)
             condition: str | None = None
             try:
-                if getattr(lg_edge, "conditional", False):
-                    data = getattr(lg_edge, "data", None)
-                    condition = str(data) if data is not None else None
+                if getattr(lg_edge, "conditional", False) and data is not None:
+                    condition = str(data)
             except Exception:
+                logger.debug(
+                    "Failed to inspect LangGraph edge condition", exc_info=True
+                )
                 condition = None
-            label = getattr(lg_edge, "data", None)
+            label = str(data) if data is not None and not condition else None
             edges.append(
                 AgentGraphEdge(
                     source=f"node:{lg_edge.source}",
                     target=f"node:{lg_edge.target}",
                     kind=EdgeKind.GRAPH_EDGE,
                     condition=condition,
-                    label=str(label) if label is not None and not condition else None,
+                    label=label,
                 )
             )
 
@@ -916,8 +918,6 @@ class LanggraphAgent(agent_base.BaseAgent):
 
     def draw_mermaid(self) -> str:
         """Delegate to LangGraph's native draw_mermaid for polish/parity."""
-        from langgraph.graph.state import CompiledStateGraph
-
         if not isinstance(self._agent_instance, CompiledStateGraph):
             raise NotImplementedError(
                 "LangGraph mermaid rendering requires a CompiledStateGraph"
@@ -926,8 +926,6 @@ class LanggraphAgent(agent_base.BaseAgent):
 
     def draw_ascii(self) -> str:
         """Delegate to LangGraph's native draw_ascii (grandalf-backed)."""
-        from langgraph.graph.state import CompiledStateGraph
-
         if not isinstance(self._agent_instance, CompiledStateGraph):
             raise NotImplementedError(
                 "LangGraph ascii rendering requires a CompiledStateGraph"

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from ag_ui.core import BaseEvent
     from ag_ui.core.types import RunAgentInput
     from idun_agent_schema.engine.capabilities import AgentCapabilities
+    from idun_agent_schema.engine.graph import AgentGraph
 
 import aiosqlite
 from ag_ui.core import events as ag_events
@@ -848,6 +849,90 @@ class LanggraphAgent(agent_base.BaseAgent):
         )
         self._cached_capabilities = result
         return result
+
+    def get_graph_ir(self) -> AgentGraph:
+        """Return a framework-agnostic graph IR populated from the compiled graph."""
+        from idun_agent_schema.engine.agent_framework import AgentFramework
+        from idun_agent_schema.engine.graph import (
+            AgentGraph,
+            AgentGraphEdge,
+            AgentGraphMetadata,
+            AgentKind,
+            AgentNode,
+            EdgeKind,
+        )
+        from langgraph.graph.state import CompiledStateGraph
+
+        if not isinstance(self._agent_instance, CompiledStateGraph):
+            raise NotImplementedError(
+                "LangGraph graph introspection requires a CompiledStateGraph"
+            )
+
+        lg_graph = self._agent_instance.get_graph()
+        nodes: list[AgentNode] = []
+        edges: list[AgentGraphEdge] = []
+
+        for node_id, _ in lg_graph.nodes.items():
+            is_root = node_id == "__start__"
+            nodes.append(
+                AgentNode(
+                    id=f"node:{node_id}",
+                    name=node_id,
+                    agent_kind=AgentKind.CUSTOM,
+                    is_root=is_root,
+                )
+            )
+
+        for lg_edge in lg_graph.edges:
+            # Public attrs: source, target. `conditional` and `data` are documented;
+            # if a future LangGraph version renames them, fall back gracefully.
+            condition: str | None = None
+            try:
+                if getattr(lg_edge, "conditional", False):
+                    data = getattr(lg_edge, "data", None)
+                    condition = str(data) if data is not None else None
+            except Exception:
+                condition = None
+            label = getattr(lg_edge, "data", None)
+            edges.append(
+                AgentGraphEdge(
+                    source=f"node:{lg_edge.source}",
+                    target=f"node:{lg_edge.target}",
+                    kind=EdgeKind.GRAPH_EDGE,
+                    condition=condition,
+                    label=str(label) if label is not None and not condition else None,
+                )
+            )
+
+        return AgentGraph(
+            metadata=AgentGraphMetadata(
+                framework=AgentFramework.LANGGRAPH,
+                agent_name=self.name,
+                root_id="node:__start__",
+            ),
+            nodes=nodes,
+            edges=edges,
+        )
+
+    def draw_mermaid(self) -> str:
+        """Delegate to LangGraph's native draw_mermaid for polish/parity."""
+        from langgraph.graph.state import CompiledStateGraph
+
+        if not isinstance(self._agent_instance, CompiledStateGraph):
+            raise NotImplementedError(
+                "LangGraph mermaid rendering requires a CompiledStateGraph"
+            )
+        return self._agent_instance.get_graph().draw_mermaid()
+
+    def draw_ascii(self) -> str:
+        """Delegate to LangGraph's native draw_ascii (grandalf-backed)."""
+        from langgraph.graph.state import CompiledStateGraph
+
+        if not isinstance(self._agent_instance, CompiledStateGraph):
+            raise NotImplementedError(
+                "LangGraph ascii rendering requires a CompiledStateGraph"
+            )
+        return self._agent_instance.get_graph().draw_ascii()
 
     def history_capabilities(self) -> HistoryCapabilities:
         """Declare LangGraph session-history support.

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -871,7 +871,14 @@ class LanggraphAgent(agent_base.BaseAgent):
         nodes: list[AgentNode] = []
         edges: list[AgentGraphEdge] = []
 
+        # Skip `__end__` so it doesn't render as a "ghost" Custom agent card.
+        # Keep `__start__` — it marks the entry point (is_root=True).
+        # Edges into `__end__` are also dropped to avoid dangling references.
+        skip_nodes = {"__end__"}
+
         for node_id in lg_graph.nodes:
+            if node_id in skip_nodes:
+                continue
             is_root = node_id == "__start__"
             nodes.append(
                 AgentNode(
@@ -883,6 +890,8 @@ class LanggraphAgent(agent_base.BaseAgent):
             )
 
         for lg_edge in lg_graph.edges:
+            if lg_edge.source in skip_nodes or lg_edge.target in skip_nodes:
+                continue
             # Public attrs: source, target. `conditional` and `data` are documented;
             # if a future LangGraph version renames them, fall back gracefully.
             data = getattr(lg_edge, "data", None)

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -937,6 +937,10 @@ class LanggraphAgent(agent_base.BaseAgent):
         try:
             return self._agent_instance.get_graph().draw_ascii()
         except ImportError:
+            logger.warning(
+                "grandalf not installed; using framework-agnostic ASCII renderer "
+                "for LangGraph agent"
+            )
             from idun_agent_engine.server.graph.ascii import render_ascii
 
             return render_ascii(self.get_graph_ir())

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -925,12 +925,21 @@ class LanggraphAgent(agent_base.BaseAgent):
         return self._agent_instance.get_graph().draw_mermaid()
 
     def draw_ascii(self) -> str:
-        """Delegate to LangGraph's native draw_ascii (grandalf-backed)."""
+        """Render ASCII art.
+
+        Delegates to LangGraph's native grandalf-backed renderer when grandalf
+        is installed; falls back to the framework-agnostic IR renderer otherwise.
+        """
         if not isinstance(self._agent_instance, CompiledStateGraph):
             raise NotImplementedError(
                 "LangGraph ascii rendering requires a CompiledStateGraph"
             )
-        return self._agent_instance.get_graph().draw_ascii()
+        try:
+            return self._agent_instance.get_graph().draw_ascii()
+        except ImportError:
+            from idun_agent_engine.server.graph.ascii import render_ascii
+
+            return render_ascii(self.get_graph_ir())
 
     def history_capabilities(self) -> HistoryCapabilities:
         """Declare LangGraph session-history support.

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/graph/ascii.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/graph/ascii.py
@@ -59,10 +59,18 @@ def render_ascii(graph: AgentGraph) -> str:
     for w in graph.metadata.warnings:
         lines.append(f"⚠ {w}")
 
+    # Cycle guard — LangGraph IRs can have cycles (conditional edges that loop
+    # back). Without this, _walk recurses until the stack blows up.
+    visited: set[str] = set()
+
     def _walk(node_id: str, prefix: str, is_last: bool, is_root: bool) -> None:
         node = nodes_by_id[node_id]
         connector = "" if is_root else ("└─ " if is_last else "├─ ")
         if isinstance(node, AgentNode):
+            if node_id in visited:
+                lines.append(f"{prefix}{connector}{_agent_label(node)} ↺")
+                return
+            visited.add(node_id)
             lines.append(f"{prefix}{connector}{_agent_label(node)}")
         else:
             assert isinstance(node, ToolNode)

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/graph/ascii.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/graph/ascii.py
@@ -1,0 +1,89 @@
+"""Render an AgentGraph IR as ASCII art (tree printer).
+
+Framework-agnostic. LangGraph adapters override draw_ascii() to use
+LangGraph's native draw_ascii() (which uses grandalf).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentNode,
+    EdgeKind,
+    ToolNode,
+)
+
+
+def _agent_label(node: AgentNode) -> str:
+    kind_name = {
+        "llm": "LlmAgent",
+        "sequential": "SequentialAgent",
+        "parallel": "ParallelAgent",
+        "loop": "LoopAgent",
+        "custom": "Custom",
+    }[node.agent_kind.value]
+    suffix = ", root" if node.is_root else ""
+    return f"{node.name} ({kind_name}{suffix})"
+
+
+def _tool_label(node: ToolNode) -> str:
+    if node.tool_kind.value == "mcp":
+        server = f": {node.mcp_server_name}" if node.mcp_server_name else ""
+        return f"{node.name} (mcp{server})"
+    return f"{node.name} ({node.tool_kind.value})"
+
+
+def render_ascii(graph: AgentGraph) -> str:
+    nodes_by_id = {n.id: n for n in graph.nodes}
+
+    sub_agents: dict[str, list[str]] = defaultdict(list)
+    tools: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.edges:
+        if edge.kind == EdgeKind.TOOL_ATTACH:
+            tools[edge.source].append(edge.target)
+        elif edge.kind in {
+            EdgeKind.PARENT_CHILD,
+            EdgeKind.SEQUENTIAL_STEP,
+            EdgeKind.PARALLEL_BRANCH,
+            EdgeKind.LOOP_STEP,
+            # GRAPH_EDGE: LangGraph delegates to native draw_ascii; if a GRAPH_EDGE
+            # ever shows up here, treat it as parent_child for tree-printing purposes.
+            EdgeKind.GRAPH_EDGE,
+        }:
+            sub_agents[edge.source].append(edge.target)
+
+    lines: list[str] = []
+    lines.append(f"{graph.metadata.framework.value} · {graph.metadata.agent_name}")
+    for w in graph.metadata.warnings:
+        lines.append(f"⚠ {w}")
+
+    def _walk(node_id: str, prefix: str, is_last: bool, is_root: bool) -> None:
+        node = nodes_by_id[node_id]
+        connector = "" if is_root else ("└─ " if is_last else "├─ ")
+        if isinstance(node, AgentNode):
+            lines.append(f"{prefix}{connector}{_agent_label(node)}")
+        else:
+            assert isinstance(node, ToolNode)
+            lines.append(f"{prefix}{connector}{_tool_label(node)}")
+            return  # tools are leaves
+
+        child_prefix = prefix + ("" if is_root else ("   " if is_last else "│  "))
+
+        node_tools = tools.get(node_id, [])
+        node_subs = sub_agents.get(node_id, [])
+
+        if node_tools:
+            tools_is_last = not node_subs
+            tools_connector = "└─ " if tools_is_last else "├─ "
+            lines.append(f"{child_prefix}{tools_connector}tools")
+            tool_prefix = child_prefix + ("   " if tools_is_last else "│  ")
+            for i, tid in enumerate(node_tools):
+                _walk(tid, tool_prefix, i == len(node_tools) - 1, is_root=False)
+
+        for i, sid in enumerate(node_subs):
+            _walk(sid, child_prefix, i == len(node_subs) - 1, is_root=False)
+
+    _walk(graph.metadata.root_id, "", True, is_root=True)
+    return "\n".join(lines)

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/graph/mermaid.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/graph/mermaid.py
@@ -1,0 +1,89 @@
+"""Render an AgentGraph IR as a Mermaid source string.
+
+Framework-agnostic — consumes only the IR. LangGraph adapters override
+draw_mermaid() to use LangGraph's native renderer; ADK uses this.
+"""
+
+from __future__ import annotations
+
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphNode,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+
+
+def _node_id(node_id: str) -> str:
+    """Mermaid identifiers can't contain ':' or '@' — convert to underscores."""
+    return node_id.replace(":", "_").replace("@", "_")
+
+
+def _node_class(node: AgentGraphNode) -> str:
+    if isinstance(node, AgentNode):
+        return "agentRoot" if node.is_root else "agent"
+    assert isinstance(node, ToolNode)
+    return {
+        ToolKind.MCP: "toolMcp",
+        ToolKind.NATIVE: "toolNative",
+        ToolKind.BUILT_IN: "toolBuiltIn",
+    }[node.tool_kind]
+
+
+def _node_line(node: AgentGraphNode) -> str:
+    nid = _node_id(node.id)
+    cls = _node_class(node)
+    if isinstance(node, AgentNode):
+        label = f"{node.name}<br/>{node.agent_kind.value}"
+        return f'  {nid}["{label}"]:::{cls}'
+    assert isinstance(node, ToolNode)
+    return f'  {nid}(["{node.name}"]):::{cls}'
+
+
+def _edge_line(
+    edge: AgentGraphEdge,
+    node_lookup: dict[str, AgentGraphNode],
+) -> str:
+    src = _node_id(edge.source)
+    dst = _node_id(edge.target)
+
+    if edge.kind == EdgeKind.PARENT_CHILD:
+        return f"  {src} --> {dst}"
+    if edge.kind == EdgeKind.TOOL_ATTACH:
+        return f"  {src} -.-> {dst}"
+    if edge.kind == EdgeKind.SEQUENTIAL_STEP:
+        order = (edge.order or 0) + 1
+        return f'  {src} == "{order}." ==> {dst}'
+    if edge.kind == EdgeKind.PARALLEL_BRANCH:
+        return f"  {src} ==> {dst}"
+    if edge.kind == EdgeKind.LOOP_STEP:
+        parent = node_lookup.get(edge.source)
+        max_iter = getattr(parent, "loop_max_iterations", None)
+        label = f"↻ ×{max_iter}" if max_iter else "↻"
+        return f'  {src} -. "{label}" .-> {dst}'
+    if edge.kind == EdgeKind.GRAPH_EDGE:
+        if edge.condition:
+            return f'  {src} -- "{edge.condition}" --> {dst}'
+        return f"  {src} --> {dst}"
+    raise ValueError(f"Unknown edge kind: {edge.kind}")
+
+
+_CLASS_DEFS = [
+    "  classDef agentRoot fill:#f3efff,stroke:#7a6cf0,stroke-width:1.5px",
+    "  classDef agent fill:#fff,stroke:#cfcfd6",
+    "  classDef toolMcp fill:#eaf3ff,stroke:#5a8de6",
+    "  classDef toolNative fill:#f4faf2,stroke:#7cae5d",
+    "  classDef toolBuiltIn fill:#fff7e6,stroke:#d99b3a",
+]
+
+
+def render_mermaid(graph: AgentGraph) -> str:
+    lookup: dict[str, AgentGraphNode] = {n.id: n for n in graph.nodes}
+    lines = ["graph TD"]
+    lines.extend(_node_line(n) for n in graph.nodes)
+    lines.extend(_edge_line(e, lookup) for e in graph.edges)
+    lines.extend(_CLASS_DEFS)
+    return "\n".join(lines)

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
@@ -236,13 +236,13 @@ async def get_graph_ir(
     try:
         return agent.get_graph_ir()
     except NotImplementedError as e:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
-    except Exception:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except Exception as e:
         logger.exception("Graph IR extraction failed")
         raise HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Graph introspection failed",
-        )
+        ) from e
 
 
 @agent_router.get("/graph/mermaid")
@@ -254,13 +254,13 @@ async def get_graph_mermaid(
     try:
         return {"mermaid": agent.draw_mermaid()}
     except NotImplementedError as e:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
-    except Exception:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except Exception as e:
         logger.exception("Mermaid rendering failed")
         raise HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Mermaid rendering failed",
-        )
+        ) from e
 
 
 @agent_router.get("/graph/ascii")
@@ -272,13 +272,13 @@ async def get_graph_ascii(
     try:
         return {"ascii": agent.draw_ascii()}
     except NotImplementedError as e:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
-    except Exception:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except Exception as e:
         logger.exception("ASCII rendering failed")
         raise HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="ASCII rendering failed",
-        )
+        ) from e
 
 
 @agent_router.get("/config")

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from idun_agent_schema.engine.api import ChatRequest, ChatResponse
 from idun_agent_schema.engine.capabilities import AgentCapabilities
+from idun_agent_schema.engine.graph import AgentGraph
 from idun_agent_schema.engine.guardrails import Guardrail
 from idun_agent_schema.engine.sessions import SessionDetail, SessionSummary
 from pydantic import BaseModel
@@ -58,9 +59,7 @@ def _guardrail_input_from(input_data: RunAgentInput) -> str | None:
     return None
 
 
-def _run_guardrails(
-    guardrails: list[Guardrail], text: str, position: str
-) -> None:
+def _run_guardrails(guardrails: list[Guardrail], text: str, position: str) -> None:
     """Validate text against guardrails matching the given position."""
     for guard in guardrails:
         if guard.position != position:  # type: ignore[attr-defined]
@@ -223,29 +222,63 @@ async def run(
                 yield 'event: error\ndata: {"error": "Agent execution failed"}\n\n'
         finally:
             current_user_id.reset(token)
-            logger.debug(
-                f"Run — reset user_id token thread_id={input_data.thread_id}"
-            )
+            logger.debug(f"Run — reset user_id token thread_id={input_data.thread_id}")
 
     return StreamingResponse(event_generator(), media_type=encoder.get_content_type())
 
 
-@agent_router.get("/graph")
-async def get_graph(
+@agent_router.get("/graph", response_model=AgentGraph)
+async def get_graph_ir(
     agent: Annotated[BaseAgent, Depends(get_agent)],
     _user: Annotated[dict | None, Depends(get_verified_user)],
-):
-    """Return the Mermaid diagram of the compiled LangGraph agent."""
-    from langgraph.graph.state import CompiledStateGraph
-
-    instance = getattr(agent, "_agent_instance", None)
-    if not isinstance(instance, CompiledStateGraph):
+) -> AgentGraph:
+    """Framework-agnostic JSON IR — primary contract for UI rendering."""
+    try:
+        return agent.get_graph_ir()
+    except NotImplementedError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception:
+        logger.exception("Graph IR extraction failed")
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Graph visualization is only available for LangGraph agents",
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Graph introspection failed",
         )
 
-    return {"graph": instance.get_graph().draw_mermaid()}
+
+@agent_router.get("/graph/mermaid")
+async def get_graph_mermaid(
+    agent: Annotated[BaseAgent, Depends(get_agent)],
+    _user: Annotated[dict | None, Depends(get_verified_user)],
+) -> dict[str, str]:
+    """Mermaid source string."""
+    try:
+        return {"mermaid": agent.draw_mermaid()}
+    except NotImplementedError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception:
+        logger.exception("Mermaid rendering failed")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Mermaid rendering failed",
+        )
+
+
+@agent_router.get("/graph/ascii")
+async def get_graph_ascii(
+    agent: Annotated[BaseAgent, Depends(get_agent)],
+    _user: Annotated[dict | None, Depends(get_verified_user)],
+) -> dict[str, str]:
+    """ASCII art rendering."""
+    try:
+        return {"ascii": agent.draw_ascii()}
+    except NotImplementedError as e:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception:
+        logger.exception("ASCII rendering failed")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ASCII rendering failed",
+        )
 
 
 @agent_router.get("/config")
@@ -435,9 +468,7 @@ def register_invoke_route(app: FastAPI, input_model: type[BaseModel]) -> None:
         """Invoke the agent with a message and get a response."""
         guardrails = getattr(request.app.state, "guardrails", [])
         if guardrails:
-            _run_guardrails(
-                guardrails, text=input_data.query, position="input"
-            )
+            _run_guardrails(guardrails, text=input_data.query, position="input")
 
         try:
             query = input_data.query[:120]

--- a/libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py
@@ -1,4 +1,4 @@
-from google.adk.agents import BaseAgent
+from google.adk.agents import BaseAgent, LlmAgent
 from google.adk.events import Event
 from google.genai.types import Content, Part
 from pydantic import BaseModel
@@ -23,4 +23,30 @@ class MockADKAgent(BaseAgent):
 
 mock_adk_agent_instance = MockADKAgent(
     name="mock_agent", description="A mock ADK agent for testing without LLM calls."
+)
+
+# -----------------------------------------------------------------------------
+# Fixtures for graph IR tests
+# -----------------------------------------------------------------------------
+
+# Simple LlmAgent, no tools, no sub-agents
+mock_llm_simple = LlmAgent(
+    name="simple",
+    model="gemini-2.5-flash",
+    instruction="You are a test agent.",
+    description="A simple test agent.",
+)
+
+
+def _native_func(x: str) -> str:
+    """A plain function tool."""
+    return x
+
+
+# LlmAgent with one native function tool
+mock_llm_with_native_tool = LlmAgent(
+    name="with_native",
+    model="gemini-2.5-flash",
+    instruction="You are a test agent.",
+    tools=[_native_func],
 )

--- a/libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py
@@ -81,3 +81,28 @@ mock_loop_agent = LoopAgent(
     sub_agents=[mock_loop_step],
     max_iterations=5,
 )
+
+# Nested: root LlmAgent with a SequentialAgent sub-agent + native tool
+mock_nested_inner_a = LlmAgent(
+    name="inner_a", model="gemini-2.5-flash", instruction="ia"
+)
+mock_nested_inner_b = LlmAgent(
+    name="inner_b", model="gemini-2.5-flash", instruction="ib"
+)
+mock_nested_seq = SequentialAgent(
+    name="inner_seq",
+    sub_agents=[mock_nested_inner_a, mock_nested_inner_b],
+)
+mock_nested_root = LlmAgent(
+    name="nested_root",
+    model="gemini-2.5-flash",
+    instruction="root",
+    tools=[_native_func],
+    sub_agents=[mock_nested_seq],
+)
+
+# Custom subclass — reuse MockADKAgent already defined above.
+mock_custom_root = MockADKAgent(
+    name="custom_root",
+    description="Custom subclass for graph IR test",
+)

--- a/libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/mock_adk_agent.py
@@ -1,4 +1,10 @@
-from google.adk.agents import BaseAgent, LlmAgent
+from google.adk.agents import (
+    BaseAgent,
+    LlmAgent,
+    LoopAgent,
+    ParallelAgent,
+    SequentialAgent,
+)
 from google.adk.events import Event
 from google.genai.types import Content, Part
 from pydantic import BaseModel
@@ -49,4 +55,29 @@ mock_llm_with_native_tool = LlmAgent(
     model="gemini-2.5-flash",
     instruction="You are a test agent.",
     tools=[_native_func],
+)
+
+# -----------------------------------------------------------------------------
+# Workflow agent fixtures — sequential, parallel, loop
+# -----------------------------------------------------------------------------
+
+mock_seq_step_a = LlmAgent(name="seq_a", model="gemini-2.5-flash", instruction="A")
+mock_seq_step_b = LlmAgent(name="seq_b", model="gemini-2.5-flash", instruction="B")
+mock_seq_step_c = LlmAgent(name="seq_c", model="gemini-2.5-flash", instruction="C")
+mock_sequential_agent = SequentialAgent(
+    name="seq_root",
+    sub_agents=[mock_seq_step_a, mock_seq_step_b, mock_seq_step_c],
+)
+
+mock_par_a = LlmAgent(name="par_a", model="gemini-2.5-flash", instruction="A")
+mock_par_b = LlmAgent(name="par_b", model="gemini-2.5-flash", instruction="B")
+mock_parallel_agent = ParallelAgent(
+    name="par_root", sub_agents=[mock_par_a, mock_par_b]
+)
+
+mock_loop_step = LlmAgent(name="loop_step", model="gemini-2.5-flash", instruction="L")
+mock_loop_agent = LoopAgent(
+    name="loop_root",
+    sub_agents=[mock_loop_step],
+    max_iterations=5,
 )

--- a/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_loop.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_loop.py
@@ -1,0 +1,20 @@
+"""ADK: LoopAgent for iterative refinement — critic/reviser pair."""
+from google.adk.agents import LlmAgent, LoopAgent
+
+critic = LlmAgent(
+    name="critic",
+    model="gemini-2.0-flash",
+    instruction="Critique the current draft and suggest improvements.",
+)
+
+reviser = LlmAgent(
+    name="reviser",
+    model="gemini-2.0-flash",
+    instruction="Apply the critic's feedback to revise the draft.",
+)
+
+root_agent = LoopAgent(
+    name="critic_reviser_loop",
+    sub_agents=[critic, reviser],
+    max_iterations=3,
+)

--- a/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_nested.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_nested.py
@@ -1,0 +1,48 @@
+"""ADK: realistic nested topology — coordinator with sub-agents that have tools.
+
+Mirrors the example from §4 of the spec: a customer support agent with billing
+and tech support sub-agents, each carrying their own tools.
+"""
+from google.adk.agents import LlmAgent
+from google.adk.tools import google_search
+
+
+def search_faq(query: str) -> str:
+    """Search the FAQ knowledge base."""
+    return f"FAQ result for: {query}"
+
+
+def issue_refund(amount: float, reason: str) -> str:
+    """Issue a customer refund."""
+    return f"Refunded ${amount} for: {reason}"
+
+
+def create_ticket(subject: str, priority: str = "normal") -> str:
+    """Create a support ticket."""
+    return f"Ticket created: {subject} (priority: {priority})"
+
+
+billing = LlmAgent(
+    name="billing_agent",
+    model="gemini-2.0-flash",
+    instruction="Handle billing questions and refunds.",
+    description="Billing and refunds specialist.",
+    tools=[issue_refund],
+)
+
+tech_support = LlmAgent(
+    name="tech_support_agent",
+    model="gemini-2.0-flash",
+    instruction="Handle technical issues. Create tickets for unresolved problems.",
+    description="Technical support specialist.",
+    tools=[create_ticket, google_search],
+)
+
+root_agent = LlmAgent(
+    name="support_coordinator",
+    model="gemini-2.0-flash",
+    instruction="Route customer questions to the right specialist.",
+    description="Customer support coordinator.",
+    tools=[search_faq],
+    sub_agents=[billing, tech_support],
+)

--- a/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_parallel.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_parallel.py
@@ -1,0 +1,14 @@
+"""ADK: ParallelAgent fanning out to 3 specialists — multi-perspective analysis."""
+from google.adk.agents import LlmAgent, ParallelAgent
+
+financial = LlmAgent(name="financial_analyst", model="gemini-2.0-flash",
+                     instruction="Analyze financial aspects.")
+legal = LlmAgent(name="legal_analyst", model="gemini-2.0-flash",
+                 instruction="Analyze legal aspects.")
+technical = LlmAgent(name="technical_analyst", model="gemini-2.0-flash",
+                     instruction="Analyze technical aspects.")
+
+root_agent = ParallelAgent(
+    name="multi_perspective",
+    sub_agents=[financial, legal, technical],
+)

--- a/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_sequential.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_sequential.py
@@ -1,0 +1,25 @@
+"""ADK: SequentialAgent orchestrating 3 LlmAgents — content pipeline."""
+from google.adk.agents import LlmAgent, SequentialAgent
+
+researcher = LlmAgent(
+    name="researcher",
+    model="gemini-2.0-flash",
+    instruction="Research the topic and gather facts.",
+)
+
+writer = LlmAgent(
+    name="writer",
+    model="gemini-2.0-flash",
+    instruction="Write an article from the research notes.",
+)
+
+editor = LlmAgent(
+    name="editor",
+    model="gemini-2.0-flash",
+    instruction="Edit the article for clarity and tone.",
+)
+
+root_agent = SequentialAgent(
+    name="content_pipeline",
+    sub_agents=[researcher, writer, editor],
+)

--- a/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_simple.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_simple.py
@@ -1,0 +1,9 @@
+"""ADK: simple LlmAgent, no tools, no sub-agents."""
+from google.adk.agents import LlmAgent
+
+root_agent = LlmAgent(
+    name="chat_agent",
+    model="gemini-2.0-flash",
+    instruction="You are a helpful assistant.",
+    description="A simple chat agent.",
+)

--- a/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_with_tools.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/topology_adk_with_tools.py
@@ -1,0 +1,22 @@
+"""ADK: LlmAgent with native + built-in tools."""
+from google.adk.agents import LlmAgent
+from google.adk.tools import google_search
+
+
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    return f"Weather in {city}: sunny, 72F"
+
+
+def get_time(timezone: str = "UTC") -> str:
+    """Get the current time in a timezone."""
+    return f"Current time ({timezone}): 14:00"
+
+
+root_agent = LlmAgent(
+    name="info_agent",
+    model="gemini-2.0-flash",
+    instruction="Answer questions using your tools.",
+    description="An info-finding agent.",
+    tools=[get_weather, get_time, google_search],
+)

--- a/libs/idun_agent_engine/tests/fixtures/agents/topology_lg_branching.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/topology_lg_branching.py
@@ -1,0 +1,64 @@
+"""LangGraph: realistic Self-RAG-style multi-node graph with conditional edges."""
+from typing import Annotated, TypedDict
+
+from langchain_core.messages import AIMessage
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+    documents: list[str]
+    question: str
+    retry_count: int
+
+
+def retrieve(state: State) -> State:
+    return {"documents": ["doc1", "doc2"]}
+
+
+def grade_documents(state: State) -> State:
+    return {}
+
+
+def generate(state: State) -> State:
+    return {"messages": [AIMessage(content="answer")]}
+
+
+def transform_query(state: State) -> State:
+    return {"retry_count": state.get("retry_count", 0) + 1}
+
+
+def decide_to_generate(state: State) -> str:
+    if state.get("retry_count", 0) > 3:
+        return "generate"
+    return "transform_query"
+
+
+def grade_generation(state: State) -> str:
+    if state.get("retry_count", 0) > 5:
+        return "useful"
+    return "not useful"
+
+
+_b = StateGraph(State)
+_b.add_node("retrieve", retrieve)
+_b.add_node("grade_documents", grade_documents)
+_b.add_node("generate", generate)
+_b.add_node("transform_query", transform_query)
+
+_b.add_edge(START, "retrieve")
+_b.add_edge("retrieve", "grade_documents")
+_b.add_conditional_edges(
+    "grade_documents",
+    decide_to_generate,
+    {"transform_query": "transform_query", "generate": "generate"},
+)
+_b.add_edge("transform_query", "retrieve")
+_b.add_conditional_edges(
+    "generate",
+    grade_generation,
+    {"not useful": "transform_query", "useful": END},
+)
+
+graph = _b.compile()

--- a/libs/idun_agent_engine/tests/fixtures/agents/topology_lg_chat.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/topology_lg_chat.py
@@ -1,0 +1,26 @@
+"""LangGraph: simple linear chat graph (single echo node)."""
+from typing import Annotated, TypedDict
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph import END, StateGraph
+from langgraph.graph.message import add_messages
+
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+def echo(state: State) -> State:
+    last = ""
+    for msg in reversed(state.get("messages", [])):
+        if isinstance(msg, HumanMessage):
+            last = msg.content if isinstance(msg.content, str) else ""
+            break
+    return {"messages": [AIMessage(content=f"echo: {last}")]}
+
+
+_builder = StateGraph(State)
+_builder.add_node("echo", echo)
+_builder.set_entry_point("echo")
+_builder.add_edge("echo", END)
+graph = _builder.compile()

--- a/libs/idun_agent_engine/tests/integration/test_graph_routes.py
+++ b/libs/idun_agent_engine/tests/integration/test_graph_routes.py
@@ -1,0 +1,270 @@
+"""Integration tests for /agent/graph, /agent/graph/mermaid, /agent/graph/ascii.
+
+Boots the engine in-process via FastAPI's TestClient against a set of
+real-world agent topologies (LangGraph + ADK). Validates that all three
+routes return 200 and the IR's structure matches expectations per topology.
+
+Caught two production bugs during development:
+- `lg_branching` triggered a recursion bomb in `render_ascii` for cyclic
+  IRs (LangGraph conditional edges). Fix: visited-set guard.
+- `__end__` rendered as a "ghost" Custom agent card in LangGraph IRs.
+  Fix: skip the sentinel in the LangGraph adapter walker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from idun_agent_engine.core.app_factory import create_app
+from idun_agent_engine.core.config_builder import ConfigBuilder
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "agents"
+
+
+@dataclass(frozen=True)
+class Topology:
+    """Expected shape of a graph IR for a given fixture."""
+
+    name: str
+    framework: str  # "LANGGRAPH" | "ADK"
+    fixture_file: str
+    var_name: str
+    expected_agent_count: int
+    expected_tool_count: int
+    expected_edge_count: int
+    # Subset assertions: edges/agents/tools must include AT LEAST these.
+    expected_edge_kinds: frozenset[str]
+    expected_agent_kinds: frozenset[str]
+    expected_tool_kinds: frozenset[str] = frozenset()
+
+
+TOPOLOGIES: list[Topology] = [
+    Topology(
+        name="lg_chat",
+        framework="LANGGRAPH",
+        fixture_file="topology_lg_chat.py",
+        var_name="graph",
+        # __start__ + echo (no __end__ — it's filtered)
+        expected_agent_count=2,
+        expected_tool_count=0,
+        expected_edge_count=1,
+        expected_edge_kinds=frozenset({"graph_edge"}),
+        expected_agent_kinds=frozenset({"custom"}),
+    ),
+    Topology(
+        name="lg_branching",
+        framework="LANGGRAPH",
+        fixture_file="topology_lg_branching.py",
+        var_name="graph",
+        # __start__ + retrieve + grade_documents + generate + transform_query
+        # (__end__ is filtered)
+        expected_agent_count=5,
+        expected_tool_count=0,
+        # __start__→retrieve, retrieve→grade_documents, 2× from grade_documents
+        # (transform_query, generate), transform_query→retrieve (cycle),
+        # generate→transform_query (cycle). generate→__end__ filtered.
+        expected_edge_count=6,
+        expected_edge_kinds=frozenset({"graph_edge"}),
+        expected_agent_kinds=frozenset({"custom"}),
+    ),
+    Topology(
+        name="adk_simple",
+        framework="ADK",
+        fixture_file="topology_adk_simple.py",
+        var_name="root_agent",
+        expected_agent_count=1,
+        expected_tool_count=0,
+        expected_edge_count=0,
+        expected_edge_kinds=frozenset(),
+        expected_agent_kinds=frozenset({"llm"}),
+    ),
+    Topology(
+        name="adk_with_tools",
+        framework="ADK",
+        fixture_file="topology_adk_with_tools.py",
+        var_name="root_agent",
+        expected_agent_count=1,
+        expected_tool_count=3,  # 2 native + 1 built_in
+        expected_edge_count=3,
+        expected_edge_kinds=frozenset({"tool_attach"}),
+        expected_agent_kinds=frozenset({"llm"}),
+        expected_tool_kinds=frozenset({"native", "built_in"}),
+    ),
+    Topology(
+        name="adk_sequential",
+        framework="ADK",
+        fixture_file="topology_adk_sequential.py",
+        var_name="root_agent",
+        expected_agent_count=4,  # root + 3 steps
+        expected_tool_count=0,
+        expected_edge_count=3,
+        expected_edge_kinds=frozenset({"sequential_step"}),
+        expected_agent_kinds=frozenset({"llm", "sequential"}),
+    ),
+    Topology(
+        name="adk_parallel",
+        framework="ADK",
+        fixture_file="topology_adk_parallel.py",
+        var_name="root_agent",
+        expected_agent_count=4,  # root + 3 branches
+        expected_tool_count=0,
+        expected_edge_count=3,
+        expected_edge_kinds=frozenset({"parallel_branch"}),
+        expected_agent_kinds=frozenset({"llm", "parallel"}),
+    ),
+    Topology(
+        name="adk_loop",
+        framework="ADK",
+        fixture_file="topology_adk_loop.py",
+        var_name="root_agent",
+        expected_agent_count=3,  # root + critic + reviser
+        expected_tool_count=0,
+        expected_edge_count=2,
+        expected_edge_kinds=frozenset({"loop_step"}),
+        expected_agent_kinds=frozenset({"llm", "loop"}),
+    ),
+    Topology(
+        name="adk_nested",
+        framework="ADK",
+        fixture_file="topology_adk_nested.py",
+        var_name="root_agent",
+        expected_agent_count=3,  # coordinator + billing + tech_support
+        expected_tool_count=4,  # search_faq + refund + create_ticket + google_search
+        expected_edge_count=6,  # 2 parent_child + 4 tool_attach
+        expected_edge_kinds=frozenset({"parent_child", "tool_attach"}),
+        expected_agent_kinds=frozenset({"llm"}),
+        expected_tool_kinds=frozenset({"native", "built_in"}),
+    ),
+]
+
+
+def _build_app(topology: Topology):
+    abs_path = FIXTURES / topology.fixture_file
+    if topology.framework == "LANGGRAPH":
+        agent_cfg = {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": topology.name,
+                "graph_definition": f"{abs_path}:{topology.var_name}",
+            },
+        }
+    else:  # ADK
+        agent_cfg = {
+            "type": "ADK",
+            "config": {
+                "name": topology.name,
+                "app_name": topology.name,
+                "agent": f"{abs_path}:{topology.var_name}",
+            },
+        }
+    cfg = ConfigBuilder.from_dict(
+        {"server": {"api": {"port": 0}}, "agent": agent_cfg}
+    ).build()
+    return create_app(engine_config=cfg)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("topology", TOPOLOGIES, ids=lambda t: t.name)
+class TestGraphRoutesAcrossTopologies:
+    """Smoke-test the three graph routes against each topology."""
+
+    def test_ir_route_returns_expected_structure(self, topology: Topology):
+        app = _build_app(topology)
+        with TestClient(app) as client:
+            r = client.get("/agent/graph")
+        assert r.status_code == 200, r.text
+
+        ir = r.json()
+        assert ir["format_version"] == "1"
+        assert ir["metadata"]["framework"] == topology.framework
+
+        agents = [n for n in ir["nodes"] if n["kind"] == "agent"]
+        tools = [n for n in ir["nodes"] if n["kind"] == "tool"]
+        assert len(agents) == topology.expected_agent_count, (
+            f"agents: got {len(agents)}, want {topology.expected_agent_count}"
+        )
+        assert len(tools) == topology.expected_tool_count, (
+            f"tools: got {len(tools)}, want {topology.expected_tool_count}"
+        )
+        assert len(ir["edges"]) == topology.expected_edge_count, (
+            f"edges: got {len(ir['edges'])}, want {topology.expected_edge_count}"
+        )
+
+        # Subset checks — IR may have edge/agent/tool kinds beyond the expected
+        # set, but it must include all expected kinds.
+        edge_kinds = {e["kind"] for e in ir["edges"]}
+        assert topology.expected_edge_kinds <= edge_kinds, (
+            f"edge_kinds missing: {topology.expected_edge_kinds - edge_kinds}"
+        )
+        agent_kinds = {a["agent_kind"] for a in agents}
+        assert topology.expected_agent_kinds <= agent_kinds, (
+            f"agent_kinds missing: {topology.expected_agent_kinds - agent_kinds}"
+        )
+        if topology.expected_tool_kinds:
+            tool_kinds = {t["tool_kind"] for t in tools}
+            assert topology.expected_tool_kinds <= tool_kinds, (
+                f"tool_kinds missing: "
+                f"{topology.expected_tool_kinds - tool_kinds}"
+            )
+
+    def test_mermaid_route_returns_non_empty_string(self, topology: Topology):
+        app = _build_app(topology)
+        with TestClient(app) as client:
+            r = client.get("/agent/graph/mermaid")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "mermaid" in body
+        assert isinstance(body["mermaid"], str) and body["mermaid"].strip()
+        # Either our framework-agnostic header or LangGraph's native init marker
+        assert "graph TD" in body["mermaid"] or "%%{init" in body["mermaid"]
+
+    def test_ascii_route_returns_non_empty_string(self, topology: Topology):
+        """Also exercises the cycle guard for LangGraph's branching graph."""
+        app = _build_app(topology)
+        with TestClient(app) as client:
+            r = client.get("/agent/graph/ascii")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "ascii" in body
+        assert isinstance(body["ascii"], str) and body["ascii"].strip()
+
+
+@pytest.mark.integration
+class TestGraphRoutesRegression:
+    """Targeted tests for bugs found during heavy E2E smoke testing."""
+
+    def test_ascii_handles_cyclic_langgraph_without_recursion(self):
+        """Regression: render_ascii recursed forever on graphs with cycles.
+
+        The Self-RAG-style fixture creates a cycle (transform_query → retrieve
+        and generate → transform_query). Before the visited-set guard, this
+        crashed with RecursionError → 500.
+        """
+        topology = next(t for t in TOPOLOGIES if t.name == "lg_branching")
+        app = _build_app(topology)
+        with TestClient(app) as client:
+            r = client.get("/agent/graph/ascii")
+        assert r.status_code == 200
+        # The ↺ marker is emitted on revisit — proves the guard fired.
+        assert "↺" in r.json()["ascii"]
+
+    def test_langgraph_ir_filters_end_sentinel(self):
+        """Regression: __end__ rendered as a Custom agent card on the canvas.
+
+        The LangGraph adapter walks `lg_graph.nodes` directly; without
+        filtering, __end__ shows up as a non-root Custom agent.
+        """
+        topology = next(t for t in TOPOLOGIES if t.name == "lg_chat")
+        app = _build_app(topology)
+        with TestClient(app) as client:
+            r = client.get("/agent/graph")
+        assert r.status_code == 200
+        ir = r.json()
+        node_names = {n["name"] for n in ir["nodes"]}
+        assert "__end__" not in node_names
+        # __start__ is kept as the entry-point marker (is_root=True).
+        assert "__start__" in node_names

--- a/libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py
@@ -1,0 +1,67 @@
+"""Tests for AdkAgent graph introspection — single agent + tools cases."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+
+from idun_agent_engine.core.config_builder import ConfigBuilder
+
+
+def _adk_config(agent_var: str) -> dict:
+    fixture_path = (
+        Path(__file__).parent.parent.parent
+        / "fixtures"
+        / "agents"
+        / "mock_adk_agent.py"
+    )
+    return {
+        "agent": {
+            "type": "ADK",
+            "config": {
+                "name": f"adk_{agent_var}",
+                "app_name": f"adk_{agent_var}",
+                "agent": f"{fixture_path}:{agent_var}",
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_adk_simple_llm_agent() -> None:
+    config = ConfigBuilder.from_dict(_adk_config("mock_llm_simple")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+
+    assert isinstance(ir, AgentGraph)
+    assert ir.metadata.framework == AgentFramework.ADK
+    agent_nodes = [n for n in ir.nodes if isinstance(n, AgentNode)]
+    tool_nodes = [n for n in ir.nodes if isinstance(n, ToolNode)]
+    assert len(agent_nodes) == 1
+    assert len(tool_nodes) == 0
+    assert agent_nodes[0].is_root is True
+    assert agent_nodes[0].name == "simple"
+    assert agent_nodes[0].model == "gemini-2.5-flash"
+
+
+@pytest.mark.asyncio
+async def test_adk_llm_with_native_tool() -> None:
+    config = ConfigBuilder.from_dict(_adk_config("mock_llm_with_native_tool")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+
+    tool_nodes = [n for n in ir.nodes if isinstance(n, ToolNode)]
+    assert len(tool_nodes) == 1
+    assert tool_nodes[0].tool_kind == ToolKind.NATIVE
+    # one tool_attach edge exists
+    attach_edges = [e for e in ir.edges if e.kind == EdgeKind.TOOL_ATTACH]
+    assert len(attach_edges) == 1

--- a/libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py
@@ -96,3 +96,33 @@ async def test_adk_loop_agent_max_iterations() -> None:
     root = next(n for n in ir.nodes if isinstance(n, AgentNode) and n.is_root)
     assert root.loop_max_iterations == 5
     assert any(e.kind == EdgeKind.LOOP_STEP for e in ir.edges)
+
+
+@pytest.mark.asyncio
+async def test_adk_nested_root_with_sequential_subagent() -> None:
+    config = ConfigBuilder.from_dict(_adk_config("mock_nested_root")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+
+    agent_nodes = [n for n in ir.nodes if isinstance(n, AgentNode)]
+    # nested_root + inner_seq + inner_a + inner_b
+    assert len(agent_nodes) == 4
+    # Root → SequentialAgent uses PARENT_CHILD (root is LLM, not workflow)
+    parent_edges = [e for e in ir.edges if e.kind == EdgeKind.PARENT_CHILD]
+    assert len(parent_edges) == 1
+    # Inner_seq → its 2 children use SEQUENTIAL_STEP
+    seq_edges = [e for e in ir.edges if e.kind == EdgeKind.SEQUENTIAL_STEP]
+    assert len(seq_edges) == 2
+
+
+@pytest.mark.asyncio
+async def test_adk_custom_baseagent_subclass_emits_warning() -> None:
+    config = ConfigBuilder.from_dict(_adk_config("mock_custom_root")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+
+    root = next(n for n in ir.nodes if isinstance(n, AgentNode) and n.is_root)
+    from idun_agent_schema.engine.graph import AgentKind
+
+    assert root.agent_kind == AgentKind.CUSTOM
+    assert any("custom_root" in w for w in ir.metadata.warnings)

--- a/libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_adk_graph_ir.py
@@ -65,3 +65,34 @@ async def test_adk_llm_with_native_tool() -> None:
     # one tool_attach edge exists
     attach_edges = [e for e in ir.edges if e.kind == EdgeKind.TOOL_ATTACH]
     assert len(attach_edges) == 1
+
+
+@pytest.mark.asyncio
+async def test_adk_sequential_agent() -> None:
+    config = ConfigBuilder.from_dict(_adk_config("mock_sequential_agent")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+    seq_edges = sorted(
+        [e for e in ir.edges if e.kind == EdgeKind.SEQUENTIAL_STEP],
+        key=lambda e: e.order or 0,
+    )
+    assert [e.order for e in seq_edges] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_adk_parallel_agent() -> None:
+    config = ConfigBuilder.from_dict(_adk_config("mock_parallel_agent")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+    par_edges = [e for e in ir.edges if e.kind == EdgeKind.PARALLEL_BRANCH]
+    assert len(par_edges) == 2
+
+
+@pytest.mark.asyncio
+async def test_adk_loop_agent_max_iterations() -> None:
+    config = ConfigBuilder.from_dict(_adk_config("mock_loop_agent")).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(config)
+    ir = agent.get_graph_ir()
+    root = next(n for n in ir.nodes if isinstance(n, AgentNode) and n.is_root)
+    assert root.loop_max_iterations == 5
+    assert any(e.kind == EdgeKind.LOOP_STEP for e in ir.edges)

--- a/libs/idun_agent_engine/tests/unit/agent/test_base_graph.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_base_graph.py
@@ -1,0 +1,88 @@
+"""Tests for BaseAgent default graph methods (NotImplementedError fallback)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from ag_ui.core import BaseEvent
+from ag_ui.core.types import RunAgentInput
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.capabilities import (
+    AgentCapabilities,
+    CapabilityFlags,
+    InputDescriptor,
+    OutputDescriptor,
+)
+from idun_agent_schema.engine.observability_v2 import ObservabilityConfig
+
+from idun_agent_engine.agent.base import BaseAgent
+
+
+class _StubAgent(BaseAgent):
+    """Bare BaseAgent subclass that doesn't override graph methods."""
+
+    @property
+    def id(self) -> str:
+        return "stub"
+
+    @property
+    def agent_type(self) -> str:
+        return "STUB"
+
+    @property
+    def agent_instance(self) -> Any:
+        return None
+
+    @property
+    def copilotkit_agent_instance(self) -> Any:
+        return None
+
+    @property
+    def infos(self) -> dict[str, Any]:
+        return {}
+
+    async def initialize(
+        self,
+        config: dict[str, Any],
+        observability: list[ObservabilityConfig] | None = None,
+    ) -> None:
+        return None
+
+    async def invoke(self, message: Any) -> Any:
+        return None
+
+    async def stream(self, message: Any) -> AsyncGenerator[Any]:
+        if False:  # pragma: no cover
+            yield  # type: ignore[unreachable]
+
+    def discover_capabilities(self) -> AgentCapabilities:
+        return AgentCapabilities(
+            version="1",
+            framework=AgentFramework.CUSTOM,
+            capabilities=CapabilityFlags(
+                streaming=False, history=False, thread_id=False
+            ),
+            input=InputDescriptor(mode="chat", schema_=None),
+            output=OutputDescriptor(mode="text", schema_=None),
+        )
+
+    async def run(self, input_data: RunAgentInput) -> AsyncGenerator[BaseEvent]:
+        if False:  # pragma: no cover
+            yield  # type: ignore[unreachable]
+
+
+def test_get_graph_ir_default_raises_not_implemented() -> None:
+    with pytest.raises(NotImplementedError):
+        _StubAgent().get_graph_ir()
+
+
+def test_draw_mermaid_default_raises_not_implemented() -> None:
+    with pytest.raises(NotImplementedError):
+        _StubAgent().draw_mermaid()
+
+
+def test_draw_ascii_default_raises_not_implemented() -> None:
+    with pytest.raises(NotImplementedError):
+        _StubAgent().draw_ascii()

--- a/libs/idun_agent_engine/tests/unit/agent/test_langgraph_graph_ir.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_langgraph_graph_ir.py
@@ -1,0 +1,63 @@
+"""Tests for LanggraphAgent graph introspection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import AgentGraph, AgentNode, EdgeKind
+
+from idun_agent_engine.core.config_builder import ConfigBuilder
+
+
+@pytest.mark.asyncio
+async def test_langgraph_get_graph_ir_simple() -> None:
+    mock_graph_path = (
+        Path(__file__).parent.parent.parent / "fixtures" / "agents" / "mock_graph.py"
+    )
+    config = {
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "test_agent",
+                "graph_definition": f"{mock_graph_path}:graph",
+            },
+        },
+    }
+    engine_config = ConfigBuilder.from_dict(config).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
+
+    ir = agent.get_graph_ir()
+
+    assert isinstance(ir, AgentGraph)
+    assert ir.metadata.framework == AgentFramework.LANGGRAPH
+    assert ir.format_version == "1"
+    assert any(isinstance(n, AgentNode) and n.is_root for n in ir.nodes)
+    # Every edge has GRAPH_EDGE kind for LangGraph
+    assert all(e.kind == EdgeKind.GRAPH_EDGE for e in ir.edges)
+
+
+@pytest.mark.asyncio
+async def test_langgraph_draw_mermaid_uses_native_output() -> None:
+    """LangGraph delegates to native draw_mermaid; output should not contain
+    our renderer's classDef definitions."""
+    mock_graph_path = (
+        Path(__file__).parent.parent.parent / "fixtures" / "agents" / "mock_graph.py"
+    )
+    config = {
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "test_agent",
+                "graph_definition": f"{mock_graph_path}:graph",
+            },
+        },
+    }
+    engine_config = ConfigBuilder.from_dict(config).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
+
+    output = agent.draw_mermaid()
+    assert "graph TD" in output or "%%{init" in output  # LangGraph native marker
+    # Our renderer's classDef sentinels are NOT present
+    assert "classDef agentRoot" not in output

--- a/libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.ascii
+++ b/libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.ascii
@@ -1,0 +1,7 @@
+ADK · root
+root (LlmAgent, root)
+├─ tools
+│  └─ search (mcp: stdio: npx server-filesystem)
+└─ child (LlmAgent)
+   └─ tools
+      └─ fetch (native)

--- a/libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.mermaid
+++ b/libs/idun_agent_engine/tests/unit/server/graph/fixtures/simple.mermaid
@@ -1,0 +1,11 @@
+graph TD
+  agent_root["root<br/>llm"]:::agentRoot
+  tool_search_root(["search"]):::toolMcp
+  tool_lookup_root(["lookup"]):::toolNative
+  agent_root -.-> tool_search_root
+  agent_root -.-> tool_lookup_root
+  classDef agentRoot fill:#f3efff,stroke:#7a6cf0,stroke-width:1.5px
+  classDef agent fill:#fff,stroke:#cfcfd6
+  classDef toolMcp fill:#eaf3ff,stroke:#5a8de6
+  classDef toolNative fill:#f4faf2,stroke:#7cae5d
+  classDef toolBuiltIn fill:#fff7e6,stroke:#d99b3a

--- a/libs/idun_agent_engine/tests/unit/server/graph/test_ascii.py
+++ b/libs/idun_agent_engine/tests/unit/server/graph/test_ascii.py
@@ -1,0 +1,64 @@
+"""Golden tests for render_ascii (framework-agnostic)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphMetadata,
+    AgentKind,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+
+from idun_agent_engine.server.graph.ascii import render_ascii
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.mark.unit
+def test_render_ascii_matches_golden() -> None:
+    graph = AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK,
+            agent_name="root",
+            root_id="agent:root",
+        ),
+        nodes=[
+            AgentNode(
+                id="agent:root", name="root", agent_kind=AgentKind.LLM, is_root=True
+            ),
+            ToolNode(
+                id="tool:search@root",
+                name="search",
+                tool_kind=ToolKind.MCP,
+                mcp_server_name="stdio: npx server-filesystem",
+            ),
+            AgentNode(id="agent:child", name="child", agent_kind=AgentKind.LLM),
+            ToolNode(id="tool:fetch@child", name="fetch", tool_kind=ToolKind.NATIVE),
+        ],
+        edges=[
+            AgentGraphEdge(
+                source="agent:root",
+                target="tool:search@root",
+                kind=EdgeKind.TOOL_ATTACH,
+            ),
+            AgentGraphEdge(
+                source="agent:root", target="agent:child", kind=EdgeKind.PARENT_CHILD
+            ),
+            AgentGraphEdge(
+                source="agent:child",
+                target="tool:fetch@child",
+                kind=EdgeKind.TOOL_ATTACH,
+            ),
+        ],
+    )
+    output = render_ascii(graph)
+    expected = (FIXTURES / "simple.ascii").read_text()
+    assert output.rstrip() == expected.rstrip()

--- a/libs/idun_agent_engine/tests/unit/server/graph/test_mermaid.py
+++ b/libs/idun_agent_engine/tests/unit/server/graph/test_mermaid.py
@@ -1,0 +1,98 @@
+"""Golden tests for render_mermaid (framework-agnostic)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphMetadata,
+    AgentKind,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+
+from idun_agent_engine.server.graph.mermaid import render_mermaid
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _build_simple_graph() -> AgentGraph:
+    """root LlmAgent with one MCP tool and one native tool, no sub-agents."""
+    return AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK,
+            agent_name="root",
+            root_id="agent:root",
+        ),
+        nodes=[
+            AgentNode(
+                id="agent:root", name="root", agent_kind=AgentKind.LLM, is_root=True
+            ),
+            ToolNode(id="tool:search@root", name="search", tool_kind=ToolKind.MCP),
+            ToolNode(id="tool:lookup@root", name="lookup", tool_kind=ToolKind.NATIVE),
+        ],
+        edges=[
+            AgentGraphEdge(
+                source="agent:root",
+                target="tool:search@root",
+                kind=EdgeKind.TOOL_ATTACH,
+            ),
+            AgentGraphEdge(
+                source="agent:root",
+                target="tool:lookup@root",
+                kind=EdgeKind.TOOL_ATTACH,
+            ),
+        ],
+    )
+
+
+@pytest.mark.unit
+def test_render_mermaid_matches_golden() -> None:
+    output = render_mermaid(_build_simple_graph())
+    expected = (FIXTURES / "simple.mermaid").read_text()
+    assert output.strip() == expected.strip()
+
+
+@pytest.mark.unit
+def test_render_mermaid_handles_workflow_edges() -> None:
+    graph = AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK,
+            agent_name="root",
+            root_id="agent:root",
+        ),
+        nodes=[
+            AgentNode(
+                id="agent:root",
+                name="root",
+                agent_kind=AgentKind.SEQUENTIAL,
+                is_root=True,
+            ),
+            AgentNode(id="agent:a", name="a", agent_kind=AgentKind.LLM),
+            AgentNode(id="agent:b", name="b", agent_kind=AgentKind.LLM),
+        ],
+        edges=[
+            AgentGraphEdge(
+                source="agent:root",
+                target="agent:a",
+                kind=EdgeKind.SEQUENTIAL_STEP,
+                order=0,
+            ),
+            AgentGraphEdge(
+                source="agent:root",
+                target="agent:b",
+                kind=EdgeKind.SEQUENTIAL_STEP,
+                order=1,
+            ),
+        ],
+    )
+    out = render_mermaid(graph)
+    assert "graph TD" in out
+    # Order labels should appear (1-indexed in display)
+    assert "1." in out and "2." in out

--- a/libs/idun_agent_engine/tests/unit/server/routers/agent/test_graph_route.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/agent/test_graph_route.py
@@ -1,4 +1,6 @@
-"""Tests for the /agent/graph endpoint."""
+"""Tests for the /agent/graph, /agent/graph/mermaid, /agent/graph/ascii endpoints."""
+
+from __future__ import annotations
 
 from pathlib import Path
 
@@ -9,52 +11,89 @@ from idun_agent_engine.core.app_factory import create_app
 from idun_agent_engine.core.config_builder import ConfigBuilder
 
 
+def _langgraph_app():
+    config = ConfigBuilder.from_dict(
+        {
+            "server": {"api": {"port": 8000}},
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "Test Agent",
+                    "graph_definition": "tests.fixtures.agents.mock_graph:graph",
+                },
+            },
+        }
+    ).build()
+    return create_app(engine_config=config)
+
+
+def _haystack_app():
+    mock_path = (
+        Path(__file__).resolve().parent.parent.parent.parent.parent
+        / "fixtures"
+        / "agents"
+        / "mock_haystack_pipeline.py"
+    )
+    config = ConfigBuilder.from_dict(
+        {
+            "server": {"api": {"port": 8000}},
+            "agent": {
+                "type": "HAYSTACK",
+                "config": {
+                    "name": "Haystack Agent",
+                    "component_type": "pipeline",
+                    "component_definition": f"{mock_path}:mock_haystack_pipeline",
+                },
+            },
+        }
+    ).build()
+    return create_app(engine_config=config)
+
+
 @pytest.mark.unit
-class TestAgentGraphRoute:
-    def test_returns_200_with_graph_key(self):
-        config = ConfigBuilder.from_dict(
-            {
-                "server": {"api": {"port": 8000}},
-                "agent": {
-                    "type": "LANGGRAPH",
-                    "config": {
-                        "name": "Test Agent",
-                        "graph_definition": "tests.fixtures.agents.mock_graph:graph",
-                    },
-                },
-            }
-        ).build()
-        app = create_app(engine_config=config)
-
+class TestAgentGraphRoutes:
+    def test_ir_route_returns_agent_graph(self) -> None:
+        app = _langgraph_app()
         with TestClient(app) as client:
             response = client.get("/agent/graph")
-
         assert response.status_code == 200
-        assert "graph" in response.json()
+        body = response.json()
+        assert body["format_version"] == "1"
+        assert "metadata" in body and "nodes" in body and "edges" in body
+        assert body["metadata"]["framework"] == "LANGGRAPH"
 
-    def test_returns_404_for_non_langgraph(self):
-        mock_path = (
-            Path(__file__).resolve().parent.parent.parent.parent.parent
-            / "fixtures"
-            / "agents"
-            / "mock_haystack_pipeline.py"
-        )
-        config = ConfigBuilder.from_dict(
-            {
-                "server": {"api": {"port": 8000}},
-                "agent": {
-                    "type": "HAYSTACK",
-                    "config": {
-                        "name": "Haystack Agent",
-                        "component_type": "pipeline",
-                        "component_definition": f"{mock_path}:mock_haystack_pipeline",
-                    },
-                },
-            }
-        ).build()
-        app = create_app(engine_config=config)
+    def test_mermaid_route_returns_string(self) -> None:
+        app = _langgraph_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph/mermaid")
+        assert response.status_code == 200
+        body = response.json()
+        assert "mermaid" in body
+        assert isinstance(body["mermaid"], str) and body["mermaid"]
 
+    def test_ascii_route_returns_string(self) -> None:
+        app = _langgraph_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph/ascii")
+        assert response.status_code == 200
+        body = response.json()
+        assert "ascii" in body
+        assert isinstance(body["ascii"], str) and body["ascii"]
+
+    def test_ir_route_404_for_haystack(self) -> None:
+        app = _haystack_app()
         with TestClient(app) as client:
             response = client.get("/agent/graph")
+        assert response.status_code == 404
 
+    def test_mermaid_route_404_for_haystack(self) -> None:
+        app = _haystack_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph/mermaid")
+        assert response.status_code == 404
+
+    def test_ascii_route_404_for_haystack(self) -> None:
+        app = _haystack_app()
+        with TestClient(app) as client:
+            response = client.get("/agent/graph/ascii")
         assert response.status_code == 404

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/__init__.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/__init__.py
@@ -10,6 +10,17 @@ from .capabilities import (  # noqa: F401
     OutputDescriptor,
 )
 from .engine import EngineConfig  # noqa: F401
+from .graph import (  # noqa: F401
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphMetadata,
+    AgentGraphNode,
+    AgentKind,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
 from .integrations import (  # noqa: F401
     DiscordIntegrationConfig,
     IntegrationConfig,

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/graph.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/graph.py
@@ -1,0 +1,85 @@
+"""Framework-agnostic graph IR shared by engine and UI consumers.
+
+Versioned via `format_version`. New variants ship alongside, never as a
+breaking change.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+from idun_agent_schema.engine.agent_framework import AgentFramework
+
+
+class AgentKind(str, Enum):
+    LLM = "llm"
+    SEQUENTIAL = "sequential"
+    PARALLEL = "parallel"
+    LOOP = "loop"
+    CUSTOM = "custom"
+
+
+class ToolKind(str, Enum):
+    NATIVE = "native"
+    MCP = "mcp"
+    BUILT_IN = "built_in"
+
+
+class EdgeKind(str, Enum):
+    PARENT_CHILD = "parent_child"
+    SEQUENTIAL_STEP = "sequential_step"
+    PARALLEL_BRANCH = "parallel_branch"
+    LOOP_STEP = "loop_step"
+    TOOL_ATTACH = "tool_attach"
+    GRAPH_EDGE = "graph_edge"
+
+
+class AgentNode(BaseModel):
+    kind: Literal["agent"] = "agent"
+    id: str
+    name: str
+    agent_kind: AgentKind
+    is_root: bool = False
+    description: str | None = None
+    model: str | None = None
+    loop_max_iterations: int | None = None
+
+
+class ToolNode(BaseModel):
+    kind: Literal["tool"] = "tool"
+    id: str
+    name: str
+    tool_kind: ToolKind
+    description: str | None = None
+    mcp_server_name: str | None = None
+
+
+AgentGraphNode = Annotated[
+    AgentNode | ToolNode, Field(discriminator="kind")
+]
+
+
+class AgentGraphEdge(BaseModel):
+    source: str
+    target: str
+    kind: EdgeKind
+    order: int | None = None
+    condition: str | None = None
+    label: str | None = None
+
+
+class AgentGraphMetadata(BaseModel):
+    framework: AgentFramework
+    agent_name: str
+    root_id: str
+    warnings: list[str] = Field(default_factory=list)
+
+
+class AgentGraph(BaseModel):
+    format_version: Literal["1"] = "1"
+    metadata: AgentGraphMetadata
+    nodes: list[AgentGraphNode]
+    edges: list[AgentGraphEdge]

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/graph.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/graph.py
@@ -57,9 +57,7 @@ class ToolNode(BaseModel):
     mcp_server_name: str | None = None
 
 
-AgentGraphNode = Annotated[
-    AgentNode | ToolNode, Field(discriminator="kind")
-]
+AgentGraphNode = Annotated[AgentNode | ToolNode, Field(discriminator="kind")]
 
 
 class AgentGraphEdge(BaseModel):

--- a/libs/idun_agent_schema/tests/standalone/test_graph.py
+++ b/libs/idun_agent_schema/tests/standalone/test_graph.py
@@ -1,5 +1,7 @@
 """Tests for the graph IR Pydantic models."""
 
+from __future__ import annotations
+
 import pytest
 from pydantic import ValidationError
 
@@ -40,19 +42,23 @@ def _sample_graph() -> AgentGraph:
             ),
         ],
         edges=[
-            AgentGraphEdge(source="agent:root", target="tool:search@root", kind=EdgeKind.TOOL_ATTACH),
+            AgentGraphEdge(
+                source="agent:root",
+                target="tool:search@root",
+                kind=EdgeKind.TOOL_ATTACH,
+            ),
         ],
     )
 
 
-def test_agent_graph_round_trips_through_json():
+def test_agent_graph_round_trips_through_json() -> None:
     graph = _sample_graph()
     raw = graph.model_dump_json()
     parsed = AgentGraph.model_validate_json(raw)
     assert parsed == graph
 
 
-def test_node_discriminator_parses_both_variants():
+def test_node_discriminator_parses_both_variants() -> None:
     payload = {
         "format_version": "1",
         "metadata": {
@@ -62,7 +68,13 @@ def test_node_discriminator_parses_both_variants():
             "warnings": [],
         },
         "nodes": [
-            {"kind": "agent", "id": "agent:root", "name": "root", "agent_kind": "llm", "is_root": True},
+            {
+                "kind": "agent",
+                "id": "agent:root",
+                "name": "root",
+                "agent_kind": "llm",
+                "is_root": True,
+            },
             {"kind": "tool", "id": "tool:t@root", "name": "t", "tool_kind": "native"},
         ],
         "edges": [
@@ -74,23 +86,30 @@ def test_node_discriminator_parses_both_variants():
     assert isinstance(parsed.nodes[1], ToolNode)
 
 
-def test_format_version_rejects_unknown():
+def test_format_version_rejects_unknown() -> None:
     payload = {
         "format_version": "2",
         "metadata": {
-            "framework": "ADK", "agent_name": "n", "root_id": "agent:r", "warnings": [],
+            "framework": "ADK",
+            "agent_name": "n",
+            "root_id": "agent:r",
+            "warnings": [],
         },
-        "nodes": [], "edges": [],
+        "nodes": [],
+        "edges": [],
     }
     with pytest.raises(ValidationError):
         AgentGraph.model_validate(payload)
 
 
-def test_format_version_defaults_to_1():
+def test_format_version_defaults_to_1() -> None:
     g = AgentGraph(
         metadata=AgentGraphMetadata(
-            framework=AgentFramework.LANGGRAPH, agent_name="n", root_id="r",
+            framework=AgentFramework.LANGGRAPH,
+            agent_name="n",
+            root_id="r",
         ),
-        nodes=[], edges=[],
+        nodes=[],
+        edges=[],
     )
     assert g.format_version == "1"

--- a/libs/idun_agent_schema/tests/standalone/test_graph.py
+++ b/libs/idun_agent_schema/tests/standalone/test_graph.py
@@ -1,0 +1,96 @@
+"""Tests for the graph IR Pydantic models."""
+
+import pytest
+from pydantic import ValidationError
+
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.graph import (
+    AgentGraph,
+    AgentGraphEdge,
+    AgentGraphMetadata,
+    AgentKind,
+    AgentNode,
+    EdgeKind,
+    ToolKind,
+    ToolNode,
+)
+
+
+def _sample_graph() -> AgentGraph:
+    return AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.ADK,
+            agent_name="root",
+            root_id="agent:root",
+            warnings=[],
+        ),
+        nodes=[
+            AgentNode(
+                id="agent:root",
+                name="root",
+                agent_kind=AgentKind.LLM,
+                is_root=True,
+                model="gemini-2.5-flash",
+            ),
+            ToolNode(
+                id="tool:search@root",
+                name="search",
+                tool_kind=ToolKind.MCP,
+                mcp_server_name="stdio: npx server-filesystem",
+            ),
+        ],
+        edges=[
+            AgentGraphEdge(source="agent:root", target="tool:search@root", kind=EdgeKind.TOOL_ATTACH),
+        ],
+    )
+
+
+def test_agent_graph_round_trips_through_json():
+    graph = _sample_graph()
+    raw = graph.model_dump_json()
+    parsed = AgentGraph.model_validate_json(raw)
+    assert parsed == graph
+
+
+def test_node_discriminator_parses_both_variants():
+    payload = {
+        "format_version": "1",
+        "metadata": {
+            "framework": "ADK",
+            "agent_name": "root",
+            "root_id": "agent:root",
+            "warnings": [],
+        },
+        "nodes": [
+            {"kind": "agent", "id": "agent:root", "name": "root", "agent_kind": "llm", "is_root": True},
+            {"kind": "tool", "id": "tool:t@root", "name": "t", "tool_kind": "native"},
+        ],
+        "edges": [
+            {"source": "agent:root", "target": "tool:t@root", "kind": "tool_attach"},
+        ],
+    }
+    parsed = AgentGraph.model_validate(payload)
+    assert isinstance(parsed.nodes[0], AgentNode)
+    assert isinstance(parsed.nodes[1], ToolNode)
+
+
+def test_format_version_rejects_unknown():
+    payload = {
+        "format_version": "2",
+        "metadata": {
+            "framework": "ADK", "agent_name": "n", "root_id": "agent:r", "warnings": [],
+        },
+        "nodes": [], "edges": [],
+    }
+    with pytest.raises(ValidationError):
+        AgentGraph.model_validate(payload)
+
+
+def test_format_version_defaults_to_1():
+    g = AgentGraph(
+        metadata=AgentGraphMetadata(
+            framework=AgentFramework.LANGGRAPH, agent_name="n", root_id="r",
+        ),
+        nodes=[], edges=[],
+    )
+    assert g.format_version == "1"

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardDone.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardDone.test.tsx
@@ -1,7 +1,31 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { WizardDone } from "@/components/onboarding/WizardDone";
 import type { AgentRead } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getAgentGraph: vi.fn(),
+    },
+  };
+});
+
+// next/dynamic is not supported in vitest jsdom; stub it so AgentGraph
+// resolves to a simple div without triggering ReactFlow canvas errors.
+vi.mock("next/dynamic", () => ({
+  default: (_loader: unknown, _opts: unknown) => {
+    const Stub = () => <div data-testid="agent-graph-stub" />;
+    Stub.displayName = "AgentGraphStub";
+    return Stub;
+  },
+}));
+
+import { api, ApiError } from "@/lib/api";
 
 const AGENT: AgentRead = {
   id: "x",
@@ -16,9 +40,25 @@ const AGENT: AgentRead = {
   updatedAt: "2026-04-29T00:00:00Z",
 };
 
+function renderWithQueryClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
 describe("WizardDone", () => {
+  beforeEach(() => {
+    (api.getAgentGraph as ReturnType<typeof vi.fn>).mockResolvedValue({
+      nodes: [],
+      edges: [],
+    });
+  });
+
   it("renders the agent name", () => {
-    render(
+    renderWithQueryClient(
       <WizardDone
         agent={AGENT}
         framework="LANGGRAPH"
@@ -30,7 +70,7 @@ describe("WizardDone", () => {
   });
 
   it("starter + LANGGRAPH shows OPENAI_API_KEY reminder", () => {
-    render(
+    renderWithQueryClient(
       <WizardDone
         agent={AGENT}
         framework="LANGGRAPH"
@@ -42,7 +82,7 @@ describe("WizardDone", () => {
   });
 
   it("starter + ADK shows GOOGLE_API_KEY reminder", () => {
-    render(
+    renderWithQueryClient(
       <WizardDone
         agent={AGENT}
         framework="ADK"
@@ -54,7 +94,7 @@ describe("WizardDone", () => {
   });
 
   it("detection mode shows the generic env reminder", () => {
-    render(
+    renderWithQueryClient(
       <WizardDone
         agent={AGENT}
         framework="LANGGRAPH"
@@ -70,7 +110,7 @@ describe("WizardDone", () => {
 
   it("calls onGoToChat when CTA clicked", () => {
     const onGoToChat = vi.fn();
-    render(
+    renderWithQueryClient(
       <WizardDone
         agent={AGENT}
         framework="LANGGRAPH"
@@ -80,5 +120,41 @@ describe("WizardDone", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: /go to chat/i }));
     expect(onGoToChat).toHaveBeenCalled();
+  });
+
+  it("shows graph stub when query resolves", async () => {
+    renderWithQueryClient(
+      <WizardDone
+        agent={AGENT}
+        framework="LANGGRAPH"
+        mode="starter"
+        onGoToChat={vi.fn()}
+      />,
+    );
+    // The dynamic stub renders immediately in tests; verify the card title
+    expect(screen.getByText(/your agent/i)).toBeInTheDocument();
+  });
+
+  it("shows 404 message when graph endpoint returns 404", async () => {
+    (api.getAgentGraph as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiError(404, "not found"),
+    );
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={client}>
+        <WizardDone
+          agent={AGENT}
+          framework="LANGGRAPH"
+          mode="starter"
+          onGoToChat={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+    const msg = await screen.findByText(
+      /graph view isn't available for this agent type yet/i,
+    );
+    expect(msg).toBeInTheDocument();
   });
 });

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardDone.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardDone.test.tsx
@@ -15,14 +15,10 @@ vi.mock("@/lib/api", async () => {
   };
 });
 
-// next/dynamic is not supported in vitest jsdom; stub it so AgentGraph
-// resolves to a simple div without triggering ReactFlow canvas errors.
-vi.mock("next/dynamic", () => ({
-  default: (_loader: unknown, _opts: unknown) => {
-    const Stub = () => <div data-testid="agent-graph-stub" />;
-    Stub.displayName = "AgentGraphStub";
-    return Stub;
-  },
+// Stub the lazy graph wrapper — keeps ReactFlow + html-to-image out of jsdom
+// without affecting the suspense/lazy plumbing we want WizardDone to use.
+vi.mock("@/components/graph/AgentGraphLazy", () => ({
+  AgentGraphLazy: () => <div data-testid="agent-graph-stub" />,
 }));
 
 import { api, ApiError } from "@/lib/api";

--- a/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
@@ -3,6 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { RotateCcw } from "lucide-react";
+import dynamic from "next/dynamic";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -32,6 +33,16 @@ import {
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ApiError, type AgentRead, api } from "@/lib/api";
+
+const AgentGraph = dynamic(
+  () => import("@/components/graph/AgentGraph").then((m) => m.AgentGraph),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[480px] animate-pulse rounded-md bg-muted" />
+    ),
+  },
+);
 
 type Framework = "langgraph" | "adk";
 const FRAMEWORKS: Framework[] = ["langgraph", "adk"];
@@ -108,6 +119,15 @@ export default function AgentPage() {
   const { data, isLoading } = useQuery({
     queryKey: ["agent"],
     queryFn: api.getAgent,
+  });
+
+  const graphQuery = useQuery({
+    queryKey: ["admin-agent-graph"],
+    queryFn: () => api.getAgentGraph(),
+    retry: (failureCount, err) => {
+      if (err instanceof ApiError && err.status === 404) return false;
+      return failureCount < 2;
+    },
   });
 
   const initialFramework = useMemo(() => readFramework(data), [data]);
@@ -337,6 +357,38 @@ export default function AgentPage() {
             {save.isPending ? "Saving…" : "Save"}
           </Button>
         </CardFooter>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Agent graph</CardTitle>
+          <CardDescription>
+            A visual map of this agent&apos;s sub-agents and tools.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {graphQuery.isLoading && (
+            <div className="h-[480px] animate-pulse rounded-md bg-muted" />
+          )}
+          {graphQuery.isError &&
+            graphQuery.error instanceof ApiError &&
+            graphQuery.error.status === 404 && (
+              <p className="text-sm text-muted-foreground">
+                Graph view isn&apos;t available for this agent type yet.
+              </p>
+            )}
+          {graphQuery.isError &&
+            !(
+              graphQuery.error instanceof ApiError &&
+              graphQuery.error.status === 404
+            ) && (
+              <Alert>
+                <AlertTitle>Graph unavailable</AlertTitle>
+                <AlertDescription>Try reloading the page.</AlertDescription>
+              </Alert>
+            )}
+          {graphQuery.data && <AgentGraph graph={graphQuery.data} height={480} />}
+        </CardContent>
       </Card>
 
       <EditYamlSheet

--- a/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
@@ -3,14 +3,18 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { RotateCcw } from "lucide-react";
-import dynamic from "next/dynamic";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 
 import { EditYamlSheet } from "@/components/admin/EditYamlSheet";
+import {
+  AgentGraphLazy,
+  type AgentGraphHandle,
+} from "@/components/graph/AgentGraphLazy";
+import { ExportMenu } from "@/components/graph/ExportMenu";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -33,16 +37,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ApiError, type AgentRead, api } from "@/lib/api";
-
-const AgentGraph = dynamic(
-  () => import("@/components/graph/AgentGraph").then((m) => m.AgentGraph),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="h-[480px] animate-pulse rounded-md bg-muted" />
-    ),
-  },
-);
 
 type Framework = "langgraph" | "adk";
 const FRAMEWORKS: Framework[] = ["langgraph", "adk"];
@@ -129,6 +123,8 @@ export default function AgentPage() {
       return failureCount < 2;
     },
   });
+
+  const graphRef = useRef<AgentGraphHandle | null>(null);
 
   const initialFramework = useMemo(() => readFramework(data), [data]);
   const [activeTab, setActiveTab] = useState<Framework>(initialFramework);
@@ -360,11 +356,20 @@ export default function AgentPage() {
       </Card>
 
       <Card>
-        <CardHeader>
-          <CardTitle>Agent graph</CardTitle>
-          <CardDescription>
-            A visual map of this agent&apos;s sub-agents and tools.
-          </CardDescription>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+          <div className="space-y-1.5">
+            <CardTitle>Agent graph</CardTitle>
+            <CardDescription>
+              A visual map of this agent&apos;s sub-agents and tools.
+            </CardDescription>
+          </div>
+          <ExportMenu
+            graphRef={graphRef}
+            agentName={data?.name ?? "agent"}
+            disabled={
+              graphQuery.isLoading || graphQuery.isError || !graphQuery.data
+            }
+          />
         </CardHeader>
         <CardContent>
           {graphQuery.isLoading && (
@@ -387,7 +392,9 @@ export default function AgentPage() {
                 <AlertDescription>Try reloading the page.</AlertDescription>
               </Alert>
             )}
-          {graphQuery.data && <AgentGraph graph={graphQuery.data} height={480} />}
+          {graphQuery.data && (
+            <AgentGraphLazy ref={graphRef} graph={graphQuery.data} height={480} />
+          )}
         </CardContent>
       </Card>
 

--- a/services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx
@@ -5,11 +5,12 @@ import "@xyflow/react/dist/style.css";
 import {
   Background,
   Controls,
+  getNodesBounds,
   MiniMap,
   ReactFlow,
   ReactFlowProvider,
 } from "@xyflow/react";
-import { useMemo } from "react";
+import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 
 import type { AgentGraph as AgentGraphIR } from "@/lib/api/types/graph";
 
@@ -25,44 +26,73 @@ interface AgentGraphProps {
   height?: number;
 }
 
+export interface AgentGraphHandle {
+  /** The .react-flow root DOM element (for html-to-image), or null pre-mount. */
+  getCanvasElement(): HTMLElement | null;
+  /** World-coordinate bounding box of all nodes; null if no nodes. */
+  getNodesBounds(): { x: number; y: number; width: number; height: number } | null;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const NODE_TYPES = { agent: AgentNode, tool: ToolNode } as Record<string, React.ComponentType<any>>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const EDGE_TYPES = { pretty: PrettyEdge } as Record<string, React.ComponentType<any>>;
 
-export function AgentGraph({ graph, height = 420 }: AgentGraphProps) {
-  const { nodes, edges } = useMemo(() => {
-    const mapped = irToReactFlow(graph);
-    return {
-      nodes: applyDagreLayout(mapped.nodes, mapped.edges),
-      edges: mapped.edges,
-    };
-  }, [graph]);
+export const AgentGraph = forwardRef<AgentGraphHandle, AgentGraphProps>(
+  function AgentGraph({ graph, height = 420 }, ref) {
+    const containerRef = useRef<HTMLDivElement | null>(null);
 
-  return (
-    <div
-      style={{ height }}
-      className="w-full overflow-hidden rounded-md border bg-background"
-    >
-      <ReactFlowProvider>
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          nodeTypes={NODE_TYPES}
-          edgeTypes={EDGE_TYPES}
-          fitView
-          minZoom={0.4}
-          maxZoom={1.5}
-          proOptions={{ hideAttribution: true }}
-          nodesDraggable={false}
-          nodesConnectable={false}
-          elementsSelectable={false}
-        >
-          <Background />
-          <Controls showInteractive={false} />
-          <MiniMap pannable zoomable />
-        </ReactFlow>
-      </ReactFlowProvider>
-    </div>
-  );
-}
+    const { nodes, edges } = useMemo(() => {
+      const mapped = irToReactFlow(graph);
+      return {
+        nodes: applyDagreLayout(mapped.nodes, mapped.edges),
+        edges: mapped.edges,
+      };
+    }, [graph]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        getCanvasElement(): HTMLElement | null {
+          // The .react-flow div is the deepest stable DOM ancestor of all
+          // rendered nodes/edges. html-to-image walks down from here.
+          return containerRef.current?.querySelector<HTMLElement>(".react-flow") ?? null;
+        },
+        getNodesBounds() {
+          if (nodes.length === 0) return null;
+          const b = getNodesBounds(nodes);
+          return { x: b.x, y: b.y, width: b.width, height: b.height };
+        },
+      }),
+      [nodes],
+    );
+
+    return (
+      <div
+        ref={containerRef}
+        style={{ height }}
+        className="w-full overflow-hidden rounded-md border bg-background"
+      >
+        <ReactFlowProvider>
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={NODE_TYPES}
+            edgeTypes={EDGE_TYPES}
+            fitView
+            minZoom={0.4}
+            maxZoom={1.5}
+            proOptions={{ hideAttribution: true }}
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable={false}
+          >
+            <Background />
+            <Controls showInteractive={false} />
+            <MiniMap pannable zoomable />
+          </ReactFlow>
+        </ReactFlowProvider>
+      </div>
+    );
+  },
+);

--- a/services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import "@xyflow/react/dist/style.css";
+
+import {
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+} from "@xyflow/react";
+import { useMemo } from "react";
+
+import type { AgentGraph as AgentGraphIR } from "@/lib/api/types/graph";
+
+import { PrettyEdge } from "./edges/PrettyEdge";
+import { irToReactFlow } from "./irToReactFlow";
+import { applyDagreLayout } from "./layout";
+import { AgentNode } from "./nodes/AgentNode";
+import { ToolNode } from "./nodes/ToolNode";
+
+interface AgentGraphProps {
+  graph: AgentGraphIR;
+  /** Height of the canvas. Defaults to a sensible value for a card embed. */
+  height?: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const NODE_TYPES = { agent: AgentNode, tool: ToolNode } as Record<string, React.ComponentType<any>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const EDGE_TYPES = { pretty: PrettyEdge } as Record<string, React.ComponentType<any>>;
+
+export function AgentGraph({ graph, height = 420 }: AgentGraphProps) {
+  const { nodes, edges } = useMemo(() => {
+    const mapped = irToReactFlow(graph);
+    return {
+      nodes: applyDagreLayout(mapped.nodes, mapped.edges),
+      edges: mapped.edges,
+    };
+  }, [graph]);
+
+  return (
+    <div
+      style={{ height }}
+      className="w-full overflow-hidden rounded-md border bg-background"
+    >
+      <ReactFlowProvider>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={NODE_TYPES}
+          edgeTypes={EDGE_TYPES}
+          fitView
+          minZoom={0.4}
+          maxZoom={1.5}
+          proOptions={{ hideAttribution: true }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+        >
+          <Background />
+          <Controls showInteractive={false} />
+          <MiniMap pannable zoomable />
+        </ReactFlow>
+      </ReactFlowProvider>
+    </div>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/AgentGraph.tsx
@@ -54,9 +54,11 @@ export const AgentGraph = forwardRef<AgentGraphHandle, AgentGraphProps>(
       ref,
       () => ({
         getCanvasElement(): HTMLElement | null {
-          // The .react-flow div is the deepest stable DOM ancestor of all
-          // rendered nodes/edges. html-to-image walks down from here.
-          return containerRef.current?.querySelector<HTMLElement>(".react-flow") ?? null;
+          // Capture the viewport (not the outer .react-flow wrapper) so html-to-image
+          // gets the nodes/edges layer; our transform override will reset its own
+          // pan/zoom transform (otherwise it composes with the user's current viewport
+          // and the export reflects whatever pan/zoom they have).
+          return containerRef.current?.querySelector<HTMLElement>(".react-flow__viewport") ?? null;
         },
         getNodesBounds() {
           if (nodes.length === 0) return null;

--- a/services/idun_agent_standalone_ui/components/graph/AgentGraphLazy.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/AgentGraphLazy.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/**
+ * Lazy-loading client wrapper for `<AgentGraph>` that PRESERVES ref forwarding.
+ *
+ * `next/dynamic` cannot be used here: its loadable wrapper hijacks the ref
+ * via `useImperativeHandle(ref, () => ({ retry }))` (see
+ * `node_modules/next/dist/shared/lib/loadable.shared-runtime.js`), so
+ * `ref.current` would be `{ retry: <fn> }` instead of `AgentGraphHandle` —
+ * breaking the ExportMenu's ability to grab the canvas DOM and node bounds.
+ *
+ * `React.lazy` + `<Suspense>` forwards refs natively (refs are regular props
+ * in React 19 and `lazy()` doesn't interpose). This file is `"use client"`,
+ * so during static export the Suspense fallback (skeleton) is rendered on the
+ * server and the real component loads after hydration — same UX as
+ * `next/dynamic({ ssr: false })` without the ref-hijack.
+ */
+
+import { forwardRef, lazy, Suspense } from "react";
+
+import type {
+  AgentGraph as AgentGraphIR,
+} from "@/lib/api/types/graph";
+
+import type { AgentGraphHandle } from "./AgentGraph";
+
+const AgentGraphInner = lazy(() =>
+  import("./AgentGraph").then((m) => ({ default: m.AgentGraph })),
+);
+
+interface AgentGraphLazyProps {
+  graph: AgentGraphIR;
+  height?: number;
+}
+
+export const AgentGraphLazy = forwardRef<AgentGraphHandle, AgentGraphLazyProps>(
+  function AgentGraphLazy(props, ref) {
+    const height = props.height ?? 420;
+    return (
+      <Suspense
+        fallback={
+          <div
+            style={{ height }}
+            className="w-full animate-pulse rounded-md bg-muted"
+          />
+        }
+      >
+        <AgentGraphInner {...props} ref={ref} />
+      </Suspense>
+    );
+  },
+);
+
+// Re-export the handle type so callers don't need a second import path.
+export type { AgentGraphHandle } from "./AgentGraph";

--- a/services/idun_agent_standalone_ui/components/graph/ExportMenu.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/ExportMenu.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  ChevronDown,
+  Download,
+  FileImage,
+  FileText,
+  Image as ImageIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  copyMermaidToClipboard,
+  copyPngToClipboard,
+  exportToPng,
+  exportToSvg,
+} from "@/lib/graph-export";
+
+import type { AgentGraphHandle } from "./AgentGraph";
+
+interface ExportMenuProps {
+  graphRef: { current: AgentGraphHandle | null };
+  agentName: string;
+  /** Hide the menu while the graph query is loading or errored. */
+  disabled?: boolean;
+}
+
+export function ExportMenu({ graphRef, agentName, disabled }: ExportMenuProps) {
+  const guarded = (
+    action: () => Promise<void>,
+    success: string,
+    failure: string,
+  ) =>
+    async () => {
+      try {
+        await action();
+        toast.success(success);
+      } catch (err) {
+        console.error(err);
+        toast.error(failure);
+      }
+    };
+
+  // Resolve canvas + bounds at click time. The menu trigger's `disabled`
+  // prop is the primary guard; this branch is defense in depth in case
+  // the user clicks before the graph mounts (or html-to-image's bounds
+  // helper fails for an empty IR).
+  const withCanvas = (kind: "png-clip" | "png-dl" | "svg-dl") => async () => {
+    const canvas = graphRef.current?.getCanvasElement();
+    const bounds = graphRef.current?.getNodesBounds();
+    if (!canvas || !bounds) {
+      toast.error("Graph not ready");
+      return;
+    }
+    const cfg = { bounds };
+    if (kind === "png-clip")
+      await guarded(
+        () => copyPngToClipboard(canvas, cfg),
+        "Copied graph image to clipboard",
+        "Clipboard not available — try downloading instead",
+      )();
+    if (kind === "png-dl")
+      await guarded(
+        () => exportToPng(canvas, agentName, cfg),
+        "Downloaded PNG",
+        "Couldn't export PNG",
+      )();
+    if (kind === "svg-dl")
+      await guarded(
+        () => exportToSvg(canvas, agentName, cfg),
+        "Downloaded SVG",
+        "Couldn't export SVG",
+      )();
+  };
+
+  const onCopyMermaid = guarded(
+    copyMermaidToClipboard,
+    "Copied Mermaid source",
+    "Couldn't copy Mermaid source",
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" disabled={disabled}>
+          <Download className="mr-1 h-3.5 w-3.5" />
+          Export
+          <ChevronDown className="ml-1 h-3.5 w-3.5 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={withCanvas("png-clip")}>
+          <ImageIcon className="mr-2 h-4 w-4" /> Copy as image
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={withCanvas("png-dl")}>
+          <FileImage className="mr-2 h-4 w-4" /> Download PNG
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={withCanvas("svg-dl")}>
+          <FileImage className="mr-2 h-4 w-4" /> Download SVG
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onCopyMermaid}>
+          <FileText className="mr-2 h-4 w-4" /> Copy Mermaid source
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { useRef } from "react";
 import { describe, expect, it } from "vitest";
 
 import type { AgentGraph as AgentGraphIR } from "@/lib/api/types/graph";
@@ -37,5 +38,37 @@ describe("AgentGraph", () => {
     );
     // The node name appears in the graph; there may also be a "root" badge chip
     expect(screen.getAllByText("root").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("exposes a handle with getCanvasElement and getNodesBounds via ref", () => {
+    function Probe() {
+      const ref = useRef<import("../AgentGraph").AgentGraphHandle>(null);
+      return (
+        <div style={{ width: 800, height: 400 }}>
+          <AgentGraph ref={ref} graph={FIXTURE} />
+          <button
+            data-testid="probe"
+            onClick={() => {
+              const el = ref.current?.getCanvasElement();
+              const bounds = ref.current?.getNodesBounds();
+              (window as unknown as { _probe: unknown })._probe = {
+                hasEl: el instanceof HTMLElement,
+                bounds,
+              };
+            }}
+          />
+        </div>
+      );
+    }
+    render(<Probe />);
+    screen.getByTestId("probe").click();
+    const probe = (window as unknown as { _probe: { hasEl: boolean; bounds: unknown } })._probe;
+    expect(probe.hasEl).toBe(true);
+    expect(probe.bounds).toMatchObject({
+      x: expect.any(Number),
+      y: expect.any(Number),
+      width: expect.any(Number),
+      height: expect.any(Number),
+    });
   });
 });

--- a/services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/__tests__/AgentGraph.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { AgentGraph as AgentGraphIR } from "@/lib/api/types/graph";
+
+import { AgentGraph } from "../AgentGraph";
+
+const FIXTURE: AgentGraphIR = {
+  format_version: "1",
+  metadata: {
+    framework: "ADK",
+    agent_name: "root",
+    root_id: "agent:root",
+    warnings: [],
+  },
+  nodes: [
+    {
+      kind: "agent",
+      id: "agent:root",
+      name: "root",
+      agent_kind: "llm",
+      is_root: true,
+      description: null,
+      model: null,
+      loop_max_iterations: null,
+    },
+  ],
+  edges: [],
+};
+
+describe("AgentGraph", () => {
+  it("renders a single-node graph without crashing", () => {
+    render(
+      <div style={{ width: 800, height: 400 }}>
+        <AgentGraph graph={FIXTURE} />
+      </div>,
+    );
+    // The node name appears in the graph; there may also be a "root" badge chip
+    expect(screen.getAllByText("root").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/services/idun_agent_standalone_ui/components/graph/__tests__/ExportMenu.test.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/__tests__/ExportMenu.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/graph-export", () => ({
+  copyMermaidToClipboard: vi.fn().mockResolvedValue(undefined),
+  copyPngToClipboard: vi.fn().mockResolvedValue(undefined),
+  exportToPng: vi.fn().mockResolvedValue(undefined),
+  exportToSvg: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import * as exporters from "@/lib/graph-export";
+import { toast } from "sonner";
+import type { AgentGraphHandle } from "../AgentGraph";
+import { ExportMenu } from "../ExportMenu";
+
+const mkRef = (): { current: AgentGraphHandle | null } => ({
+  current: {
+    getCanvasElement: () => document.createElement("div"),
+    getNodesBounds: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+  },
+});
+
+describe("ExportMenu", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders 4 menu items when opened", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    expect(screen.getByText("Copy as image")).toBeInTheDocument();
+    expect(screen.getByText("Download PNG")).toBeInTheDocument();
+    expect(screen.getByText("Download SVG")).toBeInTheDocument();
+    expect(screen.getByText("Copy Mermaid source")).toBeInTheDocument();
+  });
+
+  it("calls exportToPng on Download PNG and toasts on success", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="my agent" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Download PNG"));
+    expect(exporters.exportToPng).toHaveBeenCalledOnce();
+    expect(toast.success).toHaveBeenCalledWith("Downloaded PNG");
+  });
+
+  it("calls exportToSvg on Download SVG", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Download SVG"));
+    expect(exporters.exportToSvg).toHaveBeenCalledOnce();
+  });
+
+  it("calls copyPngToClipboard on Copy as image", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Copy as image"));
+    expect(exporters.copyPngToClipboard).toHaveBeenCalledOnce();
+    expect(toast.success).toHaveBeenCalledWith("Copied graph image to clipboard");
+  });
+
+  it("calls copyMermaidToClipboard on Copy Mermaid source", async () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Copy Mermaid source"));
+    expect(exporters.copyMermaidToClipboard).toHaveBeenCalledOnce();
+    expect(toast.success).toHaveBeenCalledWith("Copied Mermaid source");
+  });
+
+  it("surfaces an error toast when an exporter rejects", async () => {
+    vi.mocked(exporters.exportToPng).mockRejectedValueOnce(new Error("boom"));
+    render(<ExportMenu graphRef={mkRef()} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Download PNG"));
+    expect(toast.error).toHaveBeenCalledWith("Couldn't export PNG");
+  });
+
+  it("disables the trigger button when disabled prop is true", () => {
+    render(<ExportMenu graphRef={mkRef()} agentName="x" disabled />);
+    expect(screen.getByRole("button", { name: /export/i })).toBeDisabled();
+  });
+
+  it("toasts an error when the canvas/bounds aren't ready", async () => {
+    const ref: { current: AgentGraphHandle | null } = {
+      current: {
+        getCanvasElement: () => null,
+        getNodesBounds: () => null,
+      },
+    };
+    render(<ExportMenu graphRef={ref} agentName="x" />);
+    await userEvent.click(screen.getByRole("button", { name: /export/i }));
+    await userEvent.click(screen.getByText("Download PNG"));
+    expect(exporters.exportToPng).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("Graph not ready");
+  });
+});

--- a/services/idun_agent_standalone_ui/components/graph/__tests__/irToReactFlow.test.ts
+++ b/services/idun_agent_standalone_ui/components/graph/__tests__/irToReactFlow.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentGraph } from "@/lib/api/types/graph";
+import { irToReactFlow } from "../irToReactFlow";
+
+const SAMPLE: AgentGraph = {
+  format_version: "1",
+  metadata: {
+    framework: "ADK",
+    agent_name: "root",
+    root_id: "agent:root",
+    warnings: [],
+  },
+  nodes: [
+    {
+      kind: "agent",
+      id: "agent:root",
+      name: "root",
+      agent_kind: "llm",
+      is_root: true,
+      description: null,
+      model: "gemini-2.5-flash",
+      loop_max_iterations: null,
+    },
+    {
+      kind: "tool",
+      id: "tool:search@root",
+      name: "search",
+      tool_kind: "mcp",
+      description: null,
+      mcp_server_name: "stdio: x",
+    },
+  ],
+  edges: [
+    {
+      source: "agent:root",
+      target: "tool:search@root",
+      kind: "tool_attach",
+      order: null,
+      condition: null,
+      label: null,
+    },
+  ],
+};
+
+describe("irToReactFlow", () => {
+  it("maps every IR node to one ReactFlow node with the IR id", () => {
+    const { nodes } = irToReactFlow(SAMPLE);
+    expect(nodes).toHaveLength(2);
+    expect(nodes.map((n) => n.id).sort()).toEqual(
+      ["agent:root", "tool:search@root"].sort(),
+    );
+  });
+
+  it("uses 'agent' / 'tool' for ReactFlow node types", () => {
+    const { nodes } = irToReactFlow(SAMPLE);
+    expect(nodes.find((n) => n.id === "agent:root")?.type).toBe("agent");
+    expect(nodes.find((n) => n.id === "tool:search@root")?.type).toBe("tool");
+  });
+
+  it("maps every IR edge to one ReactFlow edge", () => {
+    const { edges } = irToReactFlow(SAMPLE);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      source: "agent:root",
+      target: "tool:search@root",
+      type: "pretty",
+    });
+  });
+});

--- a/services/idun_agent_standalone_ui/components/graph/__tests__/nodes.test.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/__tests__/nodes.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  AgentNode as AgentNodeData,
+  ToolNode as ToolNodeData,
+} from "@/lib/api/types/graph";
+
+import { AgentNode } from "../nodes/AgentNode";
+import { ToolNode } from "../nodes/ToolNode";
+
+const wrap = (ui: React.ReactNode) =>
+  render(<ReactFlowProvider>{ui}</ReactFlowProvider>);
+
+describe("AgentNode", () => {
+  it("renders name, kind chip, and root indicator", () => {
+    const data: AgentNodeData = {
+      kind: "agent",
+      id: "agent:root",
+      name: "support_agent",
+      agent_kind: "llm",
+      is_root: true,
+      description: null,
+      model: "gemini-2.5-flash",
+      loop_max_iterations: null,
+    };
+    wrap(<AgentNode data={data} id={data.id} selected={false} />);
+    expect(screen.getByText("support_agent")).toBeInTheDocument();
+    expect(screen.getByText(/LlmAgent/i)).toBeInTheDocument();
+    expect(screen.getByText(/root/i)).toBeInTheDocument();
+  });
+});
+
+describe("ToolNode", () => {
+  it("renders MCP server name when tool_kind=mcp", () => {
+    const data: ToolNodeData = {
+      kind: "tool",
+      id: "tool:search@root",
+      name: "search_faq",
+      tool_kind: "mcp",
+      description: null,
+      mcp_server_name: "stdio: npx server-filesystem",
+    };
+    wrap(<ToolNode data={data} id={data.id} selected={false} />);
+    expect(screen.getByText("search_faq")).toBeInTheDocument();
+    expect(screen.getByText(/stdio: npx server-filesystem/)).toBeInTheDocument();
+  });
+});

--- a/services/idun_agent_standalone_ui/components/graph/edges/PrettyEdge.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/edges/PrettyEdge.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getBezierPath,
+  type EdgeProps,
+} from "@xyflow/react";
+
+import type { AgentGraphEdge, EdgeKind } from "@/lib/api/types/graph";
+
+interface StylePreset {
+  stroke: string;
+  strokeWidth: number;
+  strokeDasharray?: string;
+}
+
+const STYLES: Record<EdgeKind, StylePreset> = {
+  parent_child: { stroke: "var(--accent, #7a6cf0)", strokeWidth: 1.5 },
+  sequential_step: { stroke: "var(--accent, #7a6cf0)", strokeWidth: 1.5 },
+  parallel_branch: { stroke: "var(--accent, #7a6cf0)", strokeWidth: 2 },
+  loop_step: {
+    stroke: "var(--accent, #7a6cf0)",
+    strokeWidth: 1.5,
+    strokeDasharray: "5 4",
+  },
+  tool_attach: {
+    stroke: "currentColor",
+    strokeWidth: 1.2,
+    strokeDasharray: "4 3",
+  },
+  graph_edge: { stroke: "var(--accent, #7a6cf0)", strokeWidth: 1.2 },
+};
+
+function edgeLabel(data: AgentGraphEdge | undefined): string | null {
+  if (!data) return null;
+  if (data.kind === "sequential_step" && data.order != null) {
+    return `${data.order + 1}.`;
+  }
+  if (data.kind === "loop_step") {
+    return data.label ?? "↻";
+  }
+  if (data.kind === "graph_edge" && data.condition) {
+    return data.condition;
+  }
+  return data.label ?? null;
+}
+
+// Define props via plain interface — @xyflow/react's EdgeProps generic
+// constrains payload types in ways our union doesn't satisfy.
+interface PrettyEdgeProps {
+  id: string;
+  sourceX: number;
+  sourceY: number;
+  targetX: number;
+  targetY: number;
+  sourcePosition: import("@xyflow/react").Position;
+  targetPosition: import("@xyflow/react").Position;
+  data?: AgentGraphEdge;
+}
+
+export function PrettyEdge(props: PrettyEdgeProps) {
+  const {
+    id,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    data,
+  } = props;
+  const [path, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+  const style = data ? STYLES[data.kind] : STYLES.parent_child;
+  const label = edgeLabel(data);
+
+  return (
+    <>
+      <BaseEdge id={id} path={path} style={style} />
+      {label && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+            className="pointer-events-none rounded bg-card px-1.5 py-0.5 text-[10px] font-medium text-foreground shadow-sm"
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/graph/irToReactFlow.ts
+++ b/services/idun_agent_standalone_ui/components/graph/irToReactFlow.ts
@@ -1,0 +1,31 @@
+import type { Edge, Node } from "@xyflow/react";
+
+import type {
+  AgentGraph,
+  AgentGraphEdge,
+  AgentGraphNode,
+} from "@/lib/api/types/graph";
+
+export interface ReactFlowGraph {
+  nodes: Node<AgentGraphNode>[];
+  edges: Edge<AgentGraphEdge>[];
+}
+
+export function irToReactFlow(graph: AgentGraph): ReactFlowGraph {
+  const nodes: Node<AgentGraphNode>[] = graph.nodes.map((n) => ({
+    id: n.id,
+    type: n.kind, // "agent" | "tool"
+    position: { x: 0, y: 0 }, // dagre layout fills these later
+    data: n,
+  }));
+
+  const edges: Edge<AgentGraphEdge>[] = graph.edges.map((e) => ({
+    id: `${e.source}->${e.target}`,
+    source: e.source,
+    target: e.target,
+    type: "pretty", // single custom edge component dispatches on data.kind
+    data: e,
+  }));
+
+  return { nodes, edges };
+}

--- a/services/idun_agent_standalone_ui/components/graph/layout.ts
+++ b/services/idun_agent_standalone_ui/components/graph/layout.ts
@@ -29,6 +29,8 @@ export function applyDagreLayout(
         x: pos.x - NODE_WIDTH / 2,
         y: pos.y - NODE_HEIGHT / 2,
       },
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
     };
   });
 }

--- a/services/idun_agent_standalone_ui/components/graph/layout.ts
+++ b/services/idun_agent_standalone_ui/components/graph/layout.ts
@@ -1,0 +1,34 @@
+import dagre from "@dagrejs/dagre";
+import type { Edge, Node } from "@xyflow/react";
+
+const NODE_WIDTH = 220;
+const NODE_HEIGHT = 60;
+
+export function applyDagreLayout(
+  nodes: Node[],
+  edges: Edge[],
+): Node[] {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({ rankdir: "TB", nodesep: 40, ranksep: 60 });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const n of nodes) {
+    g.setNode(n.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  }
+  for (const e of edges) {
+    g.setEdge(e.source, e.target);
+  }
+
+  dagre.layout(g);
+
+  return nodes.map((n) => {
+    const pos = g.node(n.id);
+    return {
+      ...n,
+      position: {
+        x: pos.x - NODE_WIDTH / 2,
+        y: pos.y - NODE_HEIGHT / 2,
+      },
+    };
+  });
+}

--- a/services/idun_agent_standalone_ui/components/graph/nodes/AgentNode.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/nodes/AgentNode.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Handle, Position } from "@xyflow/react";
+import { Bot, Crown } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import type { AgentKind, AgentNode as AgentNodeData } from "@/lib/api/types/graph";
+import { cn } from "@/lib/utils";
+
+const KIND_LABEL: Record<AgentKind, string> = {
+  llm: "LlmAgent",
+  sequential: "SequentialAgent",
+  parallel: "ParallelAgent",
+  loop: "LoopAgent",
+  custom: "Custom",
+};
+
+interface AgentNodeProps {
+  data: AgentNodeData;
+  selected?: boolean;
+  id: string;
+}
+
+export function AgentNode({ data, selected }: AgentNodeProps) {
+  return (
+    <div
+      className={cn(
+        "min-w-[200px] rounded-lg border bg-card px-3 py-2 shadow-sm",
+        data.is_root
+          ? "border-accent/60 bg-accent/5"
+          : "border-border",
+        selected && "ring-2 ring-accent",
+      )}
+    >
+      <Handle type="target" position={Position.Top} className="!bg-accent/40" />
+      <div className="flex items-start gap-2">
+        <div className="mt-0.5 text-accent">
+          {data.is_root ? <Crown size={16} /> : <Bot size={16} />}
+        </div>
+        <div className="flex-1">
+          <div className="text-sm font-semibold leading-tight text-foreground">
+            {data.name}
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-1">
+            <Badge variant="secondary" className="text-[10px]">
+              {KIND_LABEL[data.agent_kind]}
+            </Badge>
+            {data.is_root && (
+              <Badge variant="outline" className="text-[10px]">
+                root
+              </Badge>
+            )}
+            {data.model && (
+              <Badge variant="outline" className="text-[10px] font-mono">
+                {data.model}
+              </Badge>
+            )}
+            {data.loop_max_iterations != null && (
+              <Badge variant="outline" className="text-[10px]">
+                ×{data.loop_max_iterations}
+              </Badge>
+            )}
+          </div>
+        </div>
+      </div>
+      <Handle type="source" position={Position.Bottom} className="!bg-accent/40" />
+    </div>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/graph/nodes/ToolNode.tsx
+++ b/services/idun_agent_standalone_ui/components/graph/nodes/ToolNode.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Handle, Position } from "@xyflow/react";
+import { Plug, Sparkles, Wrench } from "lucide-react";
+
+import type { ToolKind, ToolNode as ToolNodeData } from "@/lib/api/types/graph";
+import { cn } from "@/lib/utils";
+
+const ICON: Record<ToolKind, React.ReactNode> = {
+  native: <Wrench size={12} />,
+  mcp: <Plug size={12} />,
+  built_in: <Sparkles size={12} />,
+};
+
+const ACCENT: Record<ToolKind, string> = {
+  native: "border-emerald-500/50 bg-emerald-500/5 text-emerald-700 dark:text-emerald-300",
+  mcp: "border-sky-500/50 bg-sky-500/5 text-sky-700 dark:text-sky-300",
+  built_in: "border-amber-500/50 bg-amber-500/5 text-amber-700 dark:text-amber-300",
+};
+
+interface ToolNodeProps {
+  data: ToolNodeData;
+  selected?: boolean;
+  id: string;
+}
+
+export function ToolNode({ data, selected }: ToolNodeProps) {
+  return (
+    <div
+      className={cn(
+        "min-w-[140px] rounded-full border px-2.5 py-1 text-xs shadow-sm",
+        ACCENT[data.tool_kind],
+        selected && "ring-2 ring-accent",
+      )}
+    >
+      <Handle type="target" position={Position.Top} className="!bg-current opacity-40" />
+      <div className="flex items-center gap-1.5">
+        {ICON[data.tool_kind]}
+        <span className="font-medium">{data.name}</span>
+      </div>
+      {data.mcp_server_name && (
+        <div className="mt-0.5 truncate text-[10px] opacity-70">
+          {data.mcp_server_name}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
@@ -2,8 +2,11 @@
 
 import dynamic from "next/dynamic";
 import { useQuery } from "@tanstack/react-query";
+import { useRef } from "react";
 import type { ReactNode } from "react";
 
+import type { AgentGraphHandle } from "@/components/graph/AgentGraph";
+import { ExportMenu } from "@/components/graph/ExportMenu";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -55,6 +58,7 @@ export function WizardDone({
   mode,
   onGoToChat,
 }: WizardDoneProps) {
+  const graphRef = useRef<AgentGraphHandle | null>(null);
   const graphQuery = useQuery({
     queryKey: ["agent-graph"],
     queryFn: () => api.getAgentGraph(),
@@ -88,8 +92,15 @@ export function WizardDone({
       </Card>
 
       <Card className="w-full">
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-base">Your agent</CardTitle>
+          <ExportMenu
+            graphRef={graphRef}
+            agentName={agent.name}
+            disabled={
+              graphQuery.isLoading || graphQuery.isError || !graphQuery.data
+            }
+          />
         </CardHeader>
         <CardContent>
           {graphQuery.isLoading && (
@@ -112,7 +123,9 @@ export function WizardDone({
                 <AlertDescription>Try reloading the page.</AlertDescription>
               </Alert>
             )}
-          {graphQuery.data && <AgentGraph graph={graphQuery.data} />}
+          {graphQuery.data && (
+            <AgentGraph ref={graphRef} graph={graphQuery.data} />
+          )}
         </CardContent>
       </Card>
     </div>

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import { useQuery } from "@tanstack/react-query";
 import { useRef } from "react";
 import type { ReactNode } from "react";
 
-import type { AgentGraphHandle } from "@/components/graph/AgentGraph";
+import {
+  AgentGraphLazy,
+  type AgentGraphHandle,
+} from "@/components/graph/AgentGraphLazy";
 import { ExportMenu } from "@/components/graph/ExportMenu";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -18,16 +20,6 @@ import {
 } from "@/components/ui/card";
 import { api, ApiError } from "@/lib/api";
 import type { AgentRead, Framework } from "@/lib/api";
-
-const AgentGraph = dynamic(
-  () => import("@/components/graph/AgentGraph").then((m) => m.AgentGraph),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="h-[420px] animate-pulse rounded-md bg-muted" />
-    ),
-  },
-);
 
 type Mode = "starter" | "detection";
 
@@ -124,7 +116,7 @@ export function WizardDone({
               </Alert>
             )}
           {graphQuery.data && (
-            <AgentGraph ref={graphRef} graph={graphQuery.data} />
+            <AgentGraphLazy ref={graphRef} graph={graphQuery.data} />
           )}
         </CardContent>
       </Card>

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardDone.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import dynamic from "next/dynamic";
+import { useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,7 +13,18 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { api, ApiError } from "@/lib/api";
 import type { AgentRead, Framework } from "@/lib/api";
+
+const AgentGraph = dynamic(
+  () => import("@/components/graph/AgentGraph").then((m) => m.AgentGraph),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[420px] animate-pulse rounded-md bg-muted" />
+    ),
+  },
+);
 
 type Mode = "starter" | "detection";
 
@@ -41,26 +55,66 @@ export function WizardDone({
   mode,
   onGoToChat,
 }: WizardDoneProps) {
+  const graphQuery = useQuery({
+    queryKey: ["agent-graph"],
+    queryFn: () => api.getAgentGraph(),
+    retry: (failureCount, err) => {
+      if (err instanceof ApiError && err.status === 404) return false;
+      return failureCount < 2;
+    },
+  });
+
   return (
-    <Card className="w-full max-w-lg">
-      <CardHeader>
-        <CardTitle>{agent.name} is ready</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        <div className="space-y-2 text-sm">
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground">Framework</span>
-            <Badge variant="secondary">{framework}</Badge>
+    <div className="w-full max-w-lg space-y-4">
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>{agent.name} is ready</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-2 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground">Framework</span>
+              <Badge variant="secondary">{framework}</Badge>
+            </div>
           </div>
-        </div>
-        <Alert>
-          <AlertTitle>Set up your model credentials</AlertTitle>
-          <AlertDescription>{envReminder(framework, mode)}</AlertDescription>
-        </Alert>
-        <div className="flex justify-end">
-          <Button onClick={onGoToChat}>Go to chat</Button>
-        </div>
-      </CardContent>
-    </Card>
+          <Alert>
+            <AlertTitle>Set up your model credentials</AlertTitle>
+            <AlertDescription>{envReminder(framework, mode)}</AlertDescription>
+          </Alert>
+          <div className="flex justify-end">
+            <Button onClick={onGoToChat}>Go to chat</Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle className="text-base">Your agent</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {graphQuery.isLoading && (
+            <div className="h-[420px] animate-pulse rounded-md bg-muted" />
+          )}
+          {graphQuery.isError &&
+            graphQuery.error instanceof ApiError &&
+            graphQuery.error.status === 404 && (
+              <p className="text-sm text-muted-foreground">
+                Graph view isn&apos;t available for this agent type yet.
+              </p>
+            )}
+          {graphQuery.isError &&
+            !(
+              graphQuery.error instanceof ApiError &&
+              graphQuery.error.status === 404
+            ) && (
+              <Alert>
+                <AlertTitle>Graph unavailable</AlertTitle>
+                <AlertDescription>Try reloading the page.</AlertDescription>
+              </Alert>
+            )}
+          {graphQuery.data && <AgentGraph graph={graphQuery.data} />}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
@@ -197,10 +197,20 @@ test("EMPTY → user picks LangGraph → confirms → done shows OPENAI_API_KEY"
   await expect(page.locator(".react-flow__node").first()).toBeVisible({
     timeout: 10_000,
   });
-  // Export dropdown is rendered in the "Your agent" card header.
-  await expect(
-    page.getByRole("button", { name: /export/i }),
-  ).toBeVisible();
+  // Export dropdown is rendered in the "Your agent" card header — and
+  // clicking "Download PNG" actually fires a real download. This is the
+  // only test that exercises the end-to-end ref chain (Lazy → Suspense
+  // → AgentGraph → handle → bounds → html-to-image). Catches future
+  // regressions of either the next/dynamic ref-hijack fix or the dagre
+  // node-dimension / viewport-transform fixes.
+  const exportButton = page.getByRole("button", { name: /^export/i });
+  await expect(exportButton).toBeVisible();
+  await exportButton.click();
+  const [download] = await Promise.all([
+    page.waitForEvent("download", { timeout: 15_000 }),
+    page.getByRole("menuitem", { name: /download png/i }).click(),
+  ]);
+  expect(download.suggestedFilename()).toMatch(/\.png$/);
 });
 
 test("ONE_DETECTED → user clicks Use → done shows generic env reminder", async ({

--- a/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
@@ -197,6 +197,10 @@ test("EMPTY → user picks LangGraph → confirms → done shows OPENAI_API_KEY"
   await expect(page.locator(".react-flow__node").first()).toBeVisible({
     timeout: 10_000,
   });
+  // Export dropdown is rendered in the "Your agent" card header.
+  await expect(
+    page.getByRole("button", { name: /export/i }),
+  ).toBeVisible();
 });
 
 test("ONE_DETECTED → user clicks Use → done shows generic env reminder", async ({

--- a/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
@@ -21,6 +21,7 @@ interface MockState {
   createStarter?: () => { status: number; body: unknown };
   createFromDetection?: () => { status: number; body: unknown };
   login?: () => { status: number; body: unknown };
+  graph?: () => { status: number; body: unknown };
 }
 
 async function setupMocks(page: Page, state: MockState) {
@@ -90,6 +91,17 @@ async function setupMocks(page: Page, state: MockState) {
       });
     });
   }
+
+  if (state.graph) {
+    await page.route("**/agent/graph", async (route: Route) => {
+      const r = state.graph!();
+      await route.fulfill({
+        status: r.status,
+        contentType: "application/json",
+        body: JSON.stringify(r.body),
+      });
+    });
+  }
 }
 
 const EMPTY_SCAN = {
@@ -141,12 +153,36 @@ const STARTER_AGENT_RESPONSE = {
   reload: { status: "reloaded", message: "Reloaded." },
 };
 
+const GRAPH_RESPONSE = {
+  format_version: "1",
+  metadata: {
+    framework: "LANGGRAPH",
+    agent_name: "Starter Agent",
+    root_id: "agent:root",
+    warnings: [],
+  },
+  nodes: [
+    {
+      kind: "agent",
+      id: "agent:root",
+      name: "Starter Agent",
+      agent_kind: "llm",
+      is_root: true,
+      description: null,
+      model: null,
+      loop_max_iterations: null,
+    },
+  ],
+  edges: [],
+};
+
 test("EMPTY → user picks LangGraph → confirms → done shows OPENAI_API_KEY", async ({
   page,
 }) => {
   await setupMocks(page, {
     scan: () => EMPTY_SCAN,
     createStarter: () => ({ status: 200, body: STARTER_AGENT_RESPONSE }),
+    graph: () => ({ status: 200, body: GRAPH_RESPONSE }),
   });
   await page.goto("/onboarding");
   await expect(page.getByText(/let's create your first idun agent/i)).toBeVisible();
@@ -156,6 +192,11 @@ test("EMPTY → user picks LangGraph → confirms → done shows OPENAI_API_KEY"
   await page.getByRole("button", { name: /create starter/i }).click();
   await expect(page.getByText(/Starter Agent is ready/i)).toBeVisible();
   await expect(page.getByText("OPENAI_API_KEY")).toBeVisible();
+  // Graph card visible with at least one agent node rendered by ReactFlow
+  await expect(page.getByText("Your agent", { exact: true })).toBeVisible();
+  await expect(page.locator(".react-flow__node").first()).toBeVisible({
+    timeout: 10_000,
+  });
 });
 
 test("ONE_DETECTED → user clicks Use → done shows generic env reminder", async ({
@@ -170,6 +211,7 @@ test("ONE_DETECTED → user clicks Use → done shows generic env reminder", asy
         data: { ...STARTER_AGENT_RESPONSE.data, name: "My Agent" },
       },
     }),
+    graph: () => ({ status: 200, body: GRAPH_RESPONSE }),
   });
   await page.goto("/onboarding");
   await expect(page.getByText(/found your agent/i)).toBeVisible();
@@ -178,6 +220,11 @@ test("ONE_DETECTED → user clicks Use → done shows generic env reminder", asy
   await expect(
     page.getByText(/make sure your agent's environment variables are set/i),
   ).toBeVisible();
+  // Graph card visible with at least one agent node rendered by ReactFlow
+  await expect(page.getByText("Your agent", { exact: true })).toBeVisible();
+  await expect(page.locator(".react-flow__node").first()).toBeVisible({
+    timeout: 10_000,
+  });
 });
 
 test("MANY_DETECTED → user picks the second → confirms → done", async ({
@@ -207,12 +254,18 @@ test("MANY_DETECTED → user picks the second → confirms → done", async ({
         data: { ...STARTER_AGENT_RESPONSE.data, name: "B Agent" },
       },
     }),
+    graph: () => ({ status: 200, body: GRAPH_RESPONSE }),
   });
   await page.goto("/onboarding");
   await expect(page.getByText(/pick your agent/i)).toBeVisible();
   await page.getByLabel(/B Agent/).click();
   await page.getByRole("button", { name: /use selected/i }).click();
   await expect(page.getByText(/B Agent is ready/i)).toBeVisible();
+  // Graph card visible with at least one agent node rendered by ReactFlow
+  await expect(page.getByText("Your agent", { exact: true })).toBeVisible();
+  await expect(page.locator(".react-flow__node").first()).toBeVisible({
+    timeout: 10_000,
+  });
 });
 
 test("ALREADY_CONFIGURED → wizard auto-redirects to /", async ({ page }) => {
@@ -250,6 +303,7 @@ test("Reload failure → error screen shows diagnostic + Retry → second attemp
       }
       return { status: 200, body: STARTER_AGENT_RESPONSE };
     },
+    graph: () => ({ status: 200, body: GRAPH_RESPONSE }),
   });
   await page.goto("/onboarding");
   await page.getByLabel(/langgraph/i).click();
@@ -261,6 +315,11 @@ test("Reload failure → error screen shows diagnostic + Retry → second attemp
   await expect(page.locator("p", { hasText: /edit your.*agent\.py/i })).toBeVisible();
   await page.getByRole("button", { name: /retry/i }).click();
   await expect(page.getByText(/Starter Agent is ready/i)).toBeVisible();
+  // Graph card visible with at least one agent node rendered by ReactFlow
+  await expect(page.getByText("Your agent", { exact: true })).toBeVisible();
+  await expect(page.locator(".react-flow__node").first()).toBeVisible({
+    timeout: 10_000,
+  });
 });
 
 test("Re-scan: EMPTY → user clicks Re-scan → backend returns ONE_DETECTED → screen flips", async ({

--- a/services/idun_agent_standalone_ui/lib/__tests__/graph-export.test.ts
+++ b/services/idun_agent_standalone_ui/lib/__tests__/graph-export.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("html-to-image", () => ({
+  toPng: vi.fn().mockResolvedValue("data:image/png;base64,FAKEPNG"),
+  toSvg: vi.fn().mockResolvedValue("data:image/svg+xml;FAKESVG"),
+  toBlob: vi.fn().mockResolvedValue(new Blob(["x"], { type: "image/png" })),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getAgentGraphMermaid: vi.fn().mockResolvedValue({ mermaid: "graph TD\n  a-->b" }),
+  },
+}));
+
+import * as htmlToImage from "html-to-image";
+import {
+  copyMermaidToClipboard,
+  copyPngToClipboard,
+  exportToPng,
+  exportToSvg,
+  slugifyAgentName,
+} from "../graph-export";
+
+const sampleBounds = { x: 0, y: 0, width: 100, height: 100 };
+
+describe("slugifyAgentName", () => {
+  it("lowercases and replaces spaces with dashes", () => {
+    expect(slugifyAgentName("My Cool Agent")).toBe("my-cool-agent");
+  });
+  it("collapses non-ASCII", () => {
+    expect(slugifyAgentName("naïve Agent")).toBe("nave-agent");
+  });
+  it("collapses multiple consecutive dashes", () => {
+    expect(slugifyAgentName("foo   bar")).toBe("foo-bar");
+  });
+  it("strips leading/trailing dashes", () => {
+    expect(slugifyAgentName("--foo--")).toBe("foo");
+  });
+  it("falls back to 'agent' for empty result", () => {
+    expect(slugifyAgentName("***")).toBe("agent");
+    expect(slugifyAgentName("")).toBe("agent");
+  });
+});
+
+describe("exportToPng", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("calls html-to-image.toPng with bounds-derived dimensions", async () => {
+    const canvas = document.createElement("div");
+    await exportToPng(canvas, "Test", { bounds: sampleBounds });
+    expect(htmlToImage.toPng).toHaveBeenCalledOnce();
+    const opts = vi.mocked(htmlToImage.toPng).mock.calls[0][1]!;
+    // 100 + 2 * 24 padding = 148
+    expect(opts.width).toBe(148);
+    expect(opts.height).toBe(148);
+    expect(opts.pixelRatio).toBe(2);
+    expect(opts.backgroundColor).toBe("#ffffff");
+  });
+
+  it("triggers an anchor download with slugified filename", async () => {
+    const canvas = document.createElement("div");
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    await exportToPng(canvas, "My Agent", { bounds: sampleBounds });
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+});
+
+describe("exportToSvg", () => {
+  beforeEach(() => vi.clearAllMocks());
+  it("calls html-to-image.toSvg", async () => {
+    const canvas = document.createElement("div");
+    await exportToSvg(canvas, "Test", { bounds: sampleBounds });
+    expect(htmlToImage.toSvg).toHaveBeenCalledOnce();
+  });
+});
+
+describe("copyPngToClipboard", () => {
+  it("writes a PNG ClipboardItem to navigator.clipboard", async () => {
+    const writeSpy = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { write: writeSpy },
+      configurable: true,
+    });
+    // jsdom doesn't ship ClipboardItem; stub it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).ClipboardItem = class {
+      constructor(public payload: Record<string, Blob>) {}
+    };
+    const canvas = document.createElement("div");
+    await copyPngToClipboard(canvas, { bounds: sampleBounds });
+    expect(writeSpy).toHaveBeenCalledOnce();
+  });
+
+  it("throws when clipboard image API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    const canvas = document.createElement("div");
+    await expect(
+      copyPngToClipboard(canvas, { bounds: sampleBounds }),
+    ).rejects.toThrow(/clipboard/i);
+  });
+});
+
+describe("copyMermaidToClipboard", () => {
+  it("writes the mermaid source via clipboard.writeText", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    await copyMermaidToClipboard();
+    expect(writeText).toHaveBeenCalledWith("graph TD\n  a-->b");
+  });
+});

--- a/services/idun_agent_standalone_ui/lib/api/index.ts
+++ b/services/idun_agent_standalone_ui/lib/api/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { apiFetch, j } from "./client";
+import type { AgentGraph } from "./types/graph";
 import type {
   AgentCapabilities,
   AgentPatch,
@@ -190,4 +191,11 @@ export const api = {
       method: "POST",
       body: j(body),
     }),
+
+  // Engine surface — graph visualizer (LangGraph + ADK)
+  getAgentGraph: () => apiFetch<AgentGraph>("/agent/graph"),
+  getAgentGraphMermaid: () =>
+    apiFetch<{ mermaid: string }>("/agent/graph/mermaid"),
+  getAgentGraphAscii: () =>
+    apiFetch<{ ascii: string }>("/agent/graph/ascii"),
 };

--- a/services/idun_agent_standalone_ui/lib/api/types/graph.ts
+++ b/services/idun_agent_standalone_ui/lib/api/types/graph.ts
@@ -22,7 +22,12 @@ export type EdgeKind =
   | "tool_attach"
   | "graph_edge";
 
-export interface AgentNode {
+// `extends Record<string, unknown>` satisfies @xyflow/react v12's
+// `Node<TData extends Record<string, unknown>>` / `Edge<TData ...>`
+// generic constraint when these types are used as ReactFlow payloads.
+// Doesn't change the wire shape — Pydantic emits the same JSON.
+
+export interface AgentNode extends Record<string, unknown> {
   kind: "agent";
   id: string;
   name: string;
@@ -33,7 +38,7 @@ export interface AgentNode {
   loop_max_iterations: number | null;
 }
 
-export interface ToolNode {
+export interface ToolNode extends Record<string, unknown> {
   kind: "tool";
   id: string;
   name: string;
@@ -44,7 +49,7 @@ export interface ToolNode {
 
 export type AgentGraphNode = AgentNode | ToolNode;
 
-export interface AgentGraphEdge {
+export interface AgentGraphEdge extends Record<string, unknown> {
   source: string;
   target: string;
   kind: EdgeKind;

--- a/services/idun_agent_standalone_ui/lib/api/types/graph.ts
+++ b/services/idun_agent_standalone_ui/lib/api/types/graph.ts
@@ -1,0 +1,68 @@
+/**
+ * TypeScript mirror of idun_agent_schema.engine.graph (Pydantic).
+ *
+ * The schema package is the source of truth — when those models change, this
+ * file must follow. Discriminated unions on `kind`.
+ */
+
+export type AgentKind =
+  | "llm"
+  | "sequential"
+  | "parallel"
+  | "loop"
+  | "custom";
+
+export type ToolKind = "native" | "mcp" | "built_in";
+
+export type EdgeKind =
+  | "parent_child"
+  | "sequential_step"
+  | "parallel_branch"
+  | "loop_step"
+  | "tool_attach"
+  | "graph_edge";
+
+export interface AgentNode {
+  kind: "agent";
+  id: string;
+  name: string;
+  agent_kind: AgentKind;
+  is_root: boolean;
+  description: string | null;
+  model: string | null;
+  loop_max_iterations: number | null;
+}
+
+export interface ToolNode {
+  kind: "tool";
+  id: string;
+  name: string;
+  tool_kind: ToolKind;
+  description: string | null;
+  mcp_server_name: string | null;
+}
+
+export type AgentGraphNode = AgentNode | ToolNode;
+
+export interface AgentGraphEdge {
+  source: string;
+  target: string;
+  kind: EdgeKind;
+  order: number | null;
+  condition: string | null;
+  label: string | null;
+}
+
+export interface AgentGraphMetadata {
+  framework: "LANGGRAPH" | "ADK" | "HAYSTACK";
+  agent_name: string;
+  root_id: string;
+  warnings: string[];
+}
+
+export interface AgentGraph {
+  format_version: "1";
+  metadata: AgentGraphMetadata;
+  nodes: AgentGraphNode[];
+  edges: AgentGraphEdge[];
+}

--- a/services/idun_agent_standalone_ui/lib/api/types/index.ts
+++ b/services/idun_agent_standalone_ui/lib/api/types/index.ts
@@ -8,3 +8,14 @@ export * from "./prompts";
 export * from "./integrations";
 export * from "./sessions";
 export * from "./onboarding";
+export type {
+  AgentGraph,
+  AgentGraphEdge,
+  AgentGraphMetadata,
+  AgentGraphNode,
+  AgentKind,
+  AgentNode,
+  EdgeKind,
+  ToolKind,
+  ToolNode,
+} from "./graph";

--- a/services/idun_agent_standalone_ui/lib/graph-export.ts
+++ b/services/idun_agent_standalone_ui/lib/graph-export.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure helpers for exporting the AgentGraph canvas as image / clipboard data.
+ *
+ * Side effects (clipboard writes, anchor downloads) happen here so the
+ * `<ExportMenu>` UI shell stays free of DOM trickery and easy to test.
+ */
+
+import { toBlob, toPng, toSvg } from "html-to-image";
+
+import { api } from "@/lib/api";
+
+export interface ExportConfig {
+  bounds: { x: number; y: number; width: number; height: number };
+  /** px around the fitted bounds. Default 24. */
+  padding?: number;
+  /** Raster scale factor. Default 2. SVG ignores this. */
+  pixelRatio?: number;
+  /** Background fill. Default white. */
+  background?: string;
+}
+
+export function slugifyAgentName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return slug || "agent";
+}
+
+function htmlToImageOpts(cfg: ExportConfig) {
+  const padding = cfg.padding ?? 24;
+  const w = cfg.bounds.width + 2 * padding;
+  const h = cfg.bounds.height + 2 * padding;
+  return {
+    width: w,
+    height: h,
+    pixelRatio: cfg.pixelRatio ?? 2,
+    backgroundColor: cfg.background ?? "#ffffff",
+    style: {
+      transform: `translate(${-cfg.bounds.x + padding}px, ${
+        -cfg.bounds.y + padding
+      }px)`,
+      transformOrigin: "0 0",
+      width: `${w}px`,
+      height: `${h}px`,
+    },
+    filter: (node: HTMLElement) => {
+      const cls = node.classList;
+      if (!cls) return true;
+      // Strip ReactFlow chrome from the export — we want just nodes + edges
+      // on a clean white plate, not the dotted background, minimap, controls,
+      // or the attribution badge.
+      return !(
+        cls.contains("react-flow__minimap") ||
+        cls.contains("react-flow__controls") ||
+        cls.contains("react-flow__attribution") ||
+        cls.contains("react-flow__background")
+      );
+    },
+  };
+}
+
+function triggerDownload(dataUrl: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = dataUrl;
+  a.download = filename;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+export async function exportToPng(
+  canvas: HTMLElement,
+  agentName: string,
+  cfg: ExportConfig,
+): Promise<void> {
+  const dataUrl = await toPng(canvas, htmlToImageOpts(cfg));
+  triggerDownload(dataUrl, `${slugifyAgentName(agentName)}-graph.png`);
+}
+
+export async function exportToSvg(
+  canvas: HTMLElement,
+  agentName: string,
+  cfg: ExportConfig,
+): Promise<void> {
+  const dataUrl = await toSvg(canvas, htmlToImageOpts(cfg));
+  triggerDownload(dataUrl, `${slugifyAgentName(agentName)}-graph.svg`);
+}
+
+export async function copyPngToClipboard(
+  canvas: HTMLElement,
+  cfg: ExportConfig,
+): Promise<void> {
+  if (!navigator.clipboard?.write) {
+    throw new Error("Clipboard image API not available");
+  }
+  const blob = await toBlob(canvas, htmlToImageOpts(cfg));
+  if (!blob) throw new Error("Failed to render image blob");
+  await navigator.clipboard.write([
+    new ClipboardItem({ "image/png": blob }),
+  ]);
+}
+
+export async function copyMermaidToClipboard(): Promise<void> {
+  if (!navigator.clipboard?.writeText) {
+    throw new Error("Clipboard API not available");
+  }
+  const { mermaid } = await api.getAgentGraphMermaid();
+  await navigator.clipboard.writeText(mermaid);
+}

--- a/services/idun_agent_standalone_ui/lib/graph-export.ts
+++ b/services/idun_agent_standalone_ui/lib/graph-export.ts
@@ -68,8 +68,11 @@ function triggerDownload(dataUrl: string, filename: string): void {
   a.download = filename;
   a.style.display = "none";
   document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
+  try {
+    a.click();
+  } finally {
+    a.remove();
+  }
 }
 
 export async function exportToPng(

--- a/services/idun_agent_standalone_ui/lib/graph-export.ts
+++ b/services/idun_agent_standalone_ui/lib/graph-export.ts
@@ -39,12 +39,12 @@ function htmlToImageOpts(cfg: ExportConfig) {
     pixelRatio: cfg.pixelRatio ?? 2,
     backgroundColor: cfg.background ?? "#ffffff",
     style: {
-      transform: `translate(${-cfg.bounds.x + padding}px, ${
-        -cfg.bounds.y + padding
-      }px)`,
-      transformOrigin: "0 0",
       width: `${w}px`,
       height: `${h}px`,
+      transform: `translate(${-cfg.bounds.x + padding}px, ${
+        -cfg.bounds.y + padding
+      }px) scale(1)`,
+      transformOrigin: "0 0",
     },
     filter: (node: HTMLElement) => {
       const cls = node.classList;

--- a/services/idun_agent_standalone_ui/package.json
+++ b/services/idun_agent_standalone_ui/package.json
@@ -44,6 +44,7 @@
     "@tailwindcss/postcss": "^4.0.0",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/services/idun_agent_standalone_ui/package.json
+++ b/services/idun_agent_standalone_ui/package.json
@@ -12,9 +12,11 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@hookform/resolvers": "^3.9.0",
     "@monaco-editor/react": "^4.6.0",
     "@tanstack/react-query": "^5.59.0",
+    "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/services/idun_agent_standalone_ui/package.json
+++ b/services/idun_agent_standalone_ui/package.json
@@ -21,6 +21,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "driver.js": "^1.3.0",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^0.453.0",
     "next": "^15.0.0",
     "next-themes": "^0.4.6",

--- a/services/idun_agent_standalone_ui/pnpm-lock.yaml
+++ b/services/idun_agent_standalone_ui/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -1639,6 +1642,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -4540,6 +4549,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@types/aria-query@5.0.4': {}
 

--- a/services/idun_agent_standalone_ui/pnpm-lock.yaml
+++ b/services/idun_agent_standalone_ui/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@dagrejs/dagre':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.10.0(react-hook-form@7.73.1(react@19.2.5))
@@ -17,6 +20,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.100.1(react@19.2.5)
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -253,6 +259,12 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dagrejs/dagre@3.0.0':
+    resolution: {integrity: sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==}
+
+  '@dagrejs/graphlib@4.0.1':
+    resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -1640,6 +1652,24 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1727,6 +1757,15 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1819,6 +1858,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -1870,6 +1912,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -3022,6 +3102,21 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
     engines: {node: '>=12.20.0'}
@@ -3190,6 +3285,12 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dagrejs/dagre@3.0.0':
+    dependencies:
+      '@dagrejs/graphlib': 4.0.1
+
+  '@dagrejs/graphlib@4.0.1': {}
 
   '@emnapi/runtime@1.10.0':
     dependencies:
@@ -4457,6 +4558,27 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -4565,6 +4687,29 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   agent-base@7.1.4: {}
 
   ansi-regex@5.0.1: {}
@@ -4644,6 +4789,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   cli-width@4.1.0:
     optional: true
 
@@ -4697,6 +4844,42 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-urls@5.0.0:
     dependencies:
@@ -6176,6 +6359,13 @@ snapshots:
     optional: true
 
   zod@3.25.76: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5
 
   zustand@5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
     optionalDependencies:

--- a/services/idun_agent_standalone_ui/pnpm-lock.yaml
+++ b/services/idun_agent_standalone_ui/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       driver.js:
         specifier: ^1.3.0
         version: 1.4.0
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       lucide-react:
         specifier: ^0.453.0
         version: 0.453.0(react@19.2.5)
@@ -2170,6 +2173,9 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -5123,6 +5129,8 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-to-image@1.11.13: {}
 
   html-url-attributes@3.0.1: {}
 

--- a/services/idun_agent_standalone_ui/vitest.config.ts
+++ b/services/idun_agent_standalone_ui/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     include: [
       "__tests__/**/*.{test,spec}.{ts,tsx}",
       "components/**/__tests__/**/*.{test,spec}.{ts,tsx}",
+      "lib/**/__tests__/**/*.{test,spec}.{ts,tsx}",
     ],
     exclude: ["node_modules", ".next", "out", "e2e"],
   },

--- a/services/idun_agent_standalone_ui/vitest.config.ts
+++ b/services/idun_agent_standalone_ui/vitest.config.ts
@@ -11,7 +11,10 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
     // Keep Playwright's e2e/ tree out of the Vitest run; it has its own runner.
-    include: ["__tests__/**/*.{test,spec}.{ts,tsx}"],
+    include: [
+      "__tests__/**/*.{test,spec}.{ts,tsx}",
+      "components/**/__tests__/**/*.{test,spec}.{ts,tsx}",
+    ],
     exclude: ["node_modules", ".next", "out", "e2e"],
   },
   resolve: {

--- a/services/idun_agent_standalone_ui/vitest.setup.ts
+++ b/services/idun_agent_standalone_ui/vitest.setup.ts
@@ -1,1 +1,11 @@
 import "@testing-library/jest-dom";
+
+// ReactFlow requires ResizeObserver (not available in jsdom).
+// Provide a no-op stub so canvas components can mount in tests.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/services/idun_agent_web/src/services/agents.ts
+++ b/services/idun_agent_web/src/services/agents.ts
@@ -227,12 +227,12 @@ export function performHealthCheck(
 }
 
 export async function fetchAgentGraph(baseUrl: string): Promise<string | null> {
-    const url = buildAgentUrl(baseUrl, '/agent/graph');
+    const url = buildAgentUrl(baseUrl, '/agent/graph/mermaid');
     try {
         const res = await agentFetch(url);
         if (!res.ok) return null;
         const data = await res.json();
-        return data.graph ?? null;
+        return data.mermaid ?? null;
     } catch {
         return null;
     }


### PR DESCRIPTION
## Summary

Two related features building the graph visualization story for the standalone UI:

### 1. ADK + LangGraph Graph Visualizer
- New JSON IR contract in `idun_agent_schema` (`engine/graph.py`) — versioned, framework-agnostic.
- Engine introspection: `BaseAgent.get_graph_ir()` + per-adapter implementations for **LangGraph** (walks `CompiledStateGraph.get_graph()`, filters `__end__` sentinel) and **ADK** (walks `App.root_agent` recursively, classifies tools as native/MCP/built_in, handles `Sequential`/`Parallel`/`Loop` workflow agents). Haystack returns 404.
- Three engine routes: `GET /agent/graph` (IR), `/agent/graph/mermaid` (string), `/agent/graph/ascii` (string). Cycle-safe ASCII renderer.
- Standalone UI renders the IR via custom ReactFlow component (`@xyflow/react` + `@dagrejs/dagre`) — card-rich agent nodes, color-coded tool pills, per-`EdgeKind` styling, dagre TB auto-layout.
- Mounted on `WizardDone` (post-onboarding) and `app/admin/agent` (admin tab).
- Admin web (`idun_agent_web`) gets a 3-line URL swap to keep its Mermaid renderer working with the new contract.

### 2. Graph Export Actions
- `Export ▾` dropdown on the graph card with 4 actions:
  - **Copy as image** (PNG to clipboard)
  - **Download PNG** (whole-graph fit, 2x retina, white background)
  - **Download SVG** (vector)
  - **Copy Mermaid source** (calls `/agent/graph/mermaid` and writes to clipboard)
- Pure helpers in `lib/graph-export.ts` using `html-to-image`. `<AgentGraph>` exposes a ref handle for canvas/bounds capture; switched from `next/dynamic` to `React.lazy` to preserve ref forwarding.
- Sonner toasts for success/failure; graceful fallback when clipboard API isn't available.

### Heavy verification

- **8 real-world topology fixtures** (LangGraph chat/conditional + ADK simple/with_tools/sequential/parallel/loop/nested) covered by integration tests (`test_graph_routes.py`) hitting all 3 routes.
- **Empirical Playwright smoke** (`.claude/smoke-test/`, gitignored) booted the standalone for each fixture, opened chromium, screenshotted the rendered canvas. Found and fixed:
  1. ASCII renderer recursion bomb on cyclic LangGraph IRs (`5a938ffb`).
  2. `next/dynamic` ref hijack breaking 3 of 4 export actions (`7bd423cd`).
  3. Dagre layout missing node dimensions + viewport transform leak — exports were clipped/mispositioned (`172611af`).
- Final smoke (`.claude/smoke-test/export.mjs`) verified all 4 export actions produce real artifacts: PNG (132 KB, valid header, all 7 nodes visible), SVG (990 KB), both clipboard paths fire success toasts.
- E2E spec extended to click "Download PNG" and verify the real download fires — the only test exercising the full ref chain (Lazy → Suspense → AgentGraph → handle → bounds → html-to-image).

### Specs + plans (committed)
- `docs/superpowers/specs/2026-04-30-adk-langgraph-graph-visualizer-design.md`
- `docs/superpowers/plans/2026-04-30-adk-langgraph-graph-visualizer.md`
- `docs/superpowers/specs/2026-05-05-graph-export-actions-design.md`
- `docs/superpowers/plans/2026-05-05-graph-export-actions.md`

## Test Plan

- [x] Schema unit tests pass (`libs/idun_agent_schema/tests/standalone/test_graph.py` — 4 tests)
- [x] Engine unit tests pass (`libs/idun_agent_engine/tests/unit/...` — base, mermaid, ascii, langgraph IR, ADK IR, route — 25 tests)
- [x] Engine integration tests pass (`tests/integration/test_graph_routes.py` — 26 tests across 8 fixtures)
- [x] Standalone-UI vitest passes (149 tests)
- [x] Standalone-UI E2E asserts Export button + click-through download
- [x] Empirical PNG/SVG output visually verified (no clipping, viewport-independent fit)
- [ ] Reviewer to spot-check the rendered graph in dev — boot `make build-standalone-ui` then `idun-standalone serve` against any LangGraph or ADK config and visit `/admin/agent/`.