### PR TITLE
fix: integration route teardown across reloads (#527)

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/core/app_factory.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/core/app_factory.py
@@ -156,37 +156,6 @@ def create_app(
     # Remove when /agent/invoke shim is fully removed.
     register_invoke_route(app, input_model)
 
-    # Register integration routers based on config
-    if validated_config.integrations:
-        from idun_agent_schema.engine.integrations import IntegrationProvider
-
-        from ..integrations.discord.handler import router as discord_router
-        from ..integrations.teams.handler import router as teams_router
-        from ..integrations.whatsapp.handler import router as whatsapp_router
-
-        for integration in validated_config.integrations:
-            match integration.provider:
-                case IntegrationProvider.WHATSAPP if integration.enabled:
-                    app.include_router(
-                        whatsapp_router,
-                        prefix="/integrations/whatsapp",
-                        tags=["WhatsApp"],
-                    )
-                case IntegrationProvider.DISCORD if integration.enabled:
-                    app.include_router(
-                        discord_router,
-                        prefix="/integrations/discord",
-                        tags=["Discord"],
-                    )
-                case IntegrationProvider.TEAMS if integration.enabled:
-                    app.include_router(
-                        teams_router,
-                        prefix="/integrations/teams",
-                        tags=["Teams"],
-                    )
-                case _:
-                    pass
-
     # Mount the static UI last so explicit routes (everything above) win.
     # When no UI dir is configured, fall back to the JSON info payload at /.
     if not _maybe_mount_static_ui(app):

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/base.py
@@ -21,7 +21,13 @@ class BaseIntegration(ABC):
 
     @abstractmethod
     async def setup(self, app: FastAPI, agent: BaseAgent) -> None:
-        """Register webhook routes and initialize provider client."""
+        """Register webhook routes and initialize provider client.
+
+        All routes and ``app.state`` mutations must be registered
+        synchronously inside this call. Anything registered after
+        ``setup()`` returns will not be cleaned up by ``cleanup_agent``
+        and will leak across reloads.
+        """
 
     @abstractmethod
     async def shutdown(self) -> None:
@@ -60,7 +66,21 @@ async def setup_integrations(
     configs: list[IntegrationConfig],
     agent: BaseAgent,
 ) -> list[BaseIntegration]:
-    """Create and wire all enabled integrations into the FastAPI app."""
+    """Create and wire all enabled integrations into the FastAPI app.
+
+    Routes added by each integration's ``setup()`` are tracked on
+    ``app.state.integration_routes`` so ``cleanup_agent`` can remove
+    them on reload. Each integration must register its routes and
+    ``app.state`` mutations synchronously inside ``setup()``; lazy
+    registration after ``setup()`` returns is not tracked and will
+    leak across reloads.
+    """
+    before = list(app.router.routes)
+    logger.info(
+        "setup_integrations: starting configs=%d existing_routes=%d",
+        len(configs),
+        len(before),
+    )
     integrations: list[BaseIntegration] = []
     for config in configs:
         if not config.enabled:
@@ -73,4 +93,12 @@ async def setup_integrations(
             logger.info(f"Integration {config.provider} set up successfully")
         except Exception:
             logger.exception(f"Failed to set up integration {config.provider}")
+    tracked = [r for r in app.router.routes if r not in before]
+    app.state.integration_routes = tracked
+    logger.info(
+        "setup_integrations: complete integrations=%d routes_tracked=%d paths=%s",
+        len(integrations),
+        len(tracked),
+        [getattr(r, "path", "<unknown>") for r in tracked],
+    )
     return integrations

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/discord/integration.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/discord/integration.py
@@ -37,6 +37,9 @@ class DiscordIntegration(BaseIntegration):
         self._client = DiscordClient(self._discord_config)
         app.state.discord_client = self._client
         app.state.discord_public_key = self._discord_config.public_key
+        from .handler import router
+
+        app.include_router(router, prefix="/integrations/discord", tags=["Discord"])
         logger.info("Discord integration configured")
 
     async def shutdown(self) -> None:

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/slack/handler.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/slack/handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, Request, Response
@@ -38,7 +39,22 @@ async def _handle_message(
 
 @router.post("/webhook")
 async def slack_webhook(request: Request) -> Response:
-    """Receive and handle a Slack event."""
+    """Receive and handle a Slack event.
+
+    Slack expects a 2xx response within three seconds; agent runs are
+    routinely slower than that. Acknowledge the event immediately and
+    process the agent run in a background task that posts the reply
+    via ``chat.postMessage``.
+    """
+    retry_num = request.headers.get("X-Slack-Retry-Num")
+    if retry_num:
+        logger.info(
+            "Skipping Slack retry attempt num=%s reason=%s",
+            retry_num,
+            request.headers.get("X-Slack-Retry-Reason"),
+        )
+        return Response(status_code=200)
+
     body = await request.body()
     body_str = body.decode("utf-8")
 
@@ -68,11 +84,14 @@ async def slack_webhook(request: Request) -> Response:
 
     event = payload.event
 
-    if event.type != "message" or event.bot_id:
-        logger.warning(
-            "Skipping non-user message event (type=%s, bot_id=%s)",
+    if event.type != "message" or event.bot_id or event.subtype or event.app_id:
+        logger.info(
+            "Skipping non-user message event "
+            "(type=%s, bot_id=%s, subtype=%s, app_id=%s)",
             event.type,
             event.bot_id,
+            event.subtype,
+            event.app_id,
         )
         return Response(status_code=200)
 
@@ -82,6 +101,8 @@ async def slack_webhook(request: Request) -> Response:
         logger.error("Slack webhook received but agent or client not initialized")
         return Response(status_code=503, content="Slack integration not ready")
 
-    await _handle_message(event.user, event.channel, event.text, agent, client)
+    asyncio.create_task(
+        _handle_message(event.user, event.channel, event.text, agent, client)
+    )
 
     return Response(status_code=200)

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/integration.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/teams/integration.py
@@ -49,6 +49,9 @@ class TeamsIntegration(BaseIntegration):
         app.state.teams_adapter = adapter
         app.state.teams_bot = bot
         self._app = app
+        from .handler import router
+
+        app.include_router(router, prefix="/integrations/teams", tags=["Teams"])
         logger.info("Teams integration configured")
 
     async def shutdown(self) -> None:

--- a/libs/idun_agent_engine/src/idun_agent_engine/integrations/whatsapp/integration.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/integrations/whatsapp/integration.py
@@ -31,6 +31,9 @@ class WhatsAppIntegration(BaseIntegration):
         self._client = WhatsAppClient(self._config.config)
         app.state.whatsapp_client = self._client
         app.state.whatsapp_verify_token = self._config.config.verify_token
+        from .handler import router
+
+        app.include_router(router, prefix="/integrations/whatsapp", tags=["WhatsApp"])
         logger.info("WhatsApp integration configured")
 
     async def shutdown(self) -> None:

--- a/libs/idun_agent_engine/src/idun_agent_engine/prompts/helpers.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/prompts/helpers.py
@@ -45,29 +45,37 @@ def get_prompts_from_file(config_path: str | Path) -> list[PromptConfig]:
 
 
 def get_prompts_from_api() -> list[PromptConfig]:
-    """Fetch prompts from the Idun Manager API."""
+    """Fetch prompts from the Idun Manager API.
+
+    Returns an empty list when the manager env vars are unset or the
+    manager is unreachable. Connection and read timeouts are short
+    so a missing manager never stalls a request that calls this.
+    """
     api_key = os.environ.get("IDUN_AGENT_API_KEY")
     manager_host = os.environ.get("IDUN_MANAGER_HOST")
 
-    if not api_key:
-        raise ValueError("Environment variable 'IDUN_AGENT_API_KEY' is not set")
-    if not manager_host:
-        raise ValueError("Environment variable 'IDUN_MANAGER_HOST' is not set")
+    if not api_key or not manager_host:
+        logger.debug(
+            "Skipping prompt API fetch (IDUN_AGENT_API_KEY or IDUN_MANAGER_HOST unset)"
+        )
+        return []
 
     host = manager_host.removesuffix("/")
     url = f"{host}/api/v1/agents/config"
     headers = {"auth": f"Bearer {api_key}"}
 
     try:
-        response = requests.get(url=url, headers=headers, timeout=30)
+        response = requests.get(url=url, headers=headers, timeout=(2, 3))
         response.raise_for_status()
     except requests.RequestException as e:
-        raise ValueError(f"Failed to fetch config from API: {e}") from e
+        logger.warning("Could not load prompts from manager (%s)", e)
+        return []
 
     try:
         raw = yaml.safe_load(response.text)
     except yaml.YAMLError as e:
-        raise ValueError(f"Failed to parse config YAML: {e}") from e
+        logger.warning("Could not parse prompt config from manager (%s)", e)
+        return []
 
     config_data = _unwrap_engine_config(raw)
     prompts = _extract_prompts(config_data)
@@ -76,7 +84,11 @@ def get_prompts_from_api() -> list[PromptConfig]:
 
 
 def get_prompts(config_path: str | Path | None = None) -> list[PromptConfig]:
-    """Return prompts: config_path > IDUN_CONFIG_PATH env > Manager API."""
+    """Return prompts: config_path > IDUN_CONFIG_PATH env > Manager API.
+
+    Never raises on a missing or unreachable source. Callers receive
+    an empty list and decide whether to use a default prompt.
+    """
     if config_path:
         return get_prompts_from_file(config_path)
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -70,6 +70,34 @@ async def cleanup_agent(app: FastAPI):
                 logger.exception("integration shutdown failed during reload")
         app.state.integrations = []
 
+    tracked = getattr(app.state, "integration_routes", [])
+    if tracked:
+        logger.info(
+            "cleanup_agent: removing %d integration route(s) paths=%s",
+            len(tracked),
+            [getattr(r, "path", "<unknown>") for r in tracked],
+        )
+        removed = 0
+        for route in tracked:
+            try:
+                app.router.routes.remove(route)
+                removed += 1
+                logger.debug(
+                    "cleanup_agent: removed integration route path=%s",
+                    getattr(route, "path", "<unknown>"),
+                )
+            except ValueError:
+                logger.warning(
+                    "cleanup_agent: tracked integration route already absent path=%s",
+                    getattr(route, "path", "<unknown>"),
+                )
+        logger.info(
+            "cleanup_agent: integration route removal complete removed=%d remaining_routes=%d",
+            removed,
+            len(app.router.routes),
+        )
+    app.state.integration_routes = []
+
 
 async def configure_app(app: FastAPI, engine_config):
     """Initialize the agent, MCP registry, guardrails, and app state with the given engine config.

--- a/libs/idun_agent_engine/tests/integration/test_integration_reload_no_leak.py
+++ b/libs/idun_agent_engine/tests/integration/test_integration_reload_no_leak.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import APIRouter, FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+from idun_agent_schema.engine.integrations import IntegrationConfig, IntegrationProvider
+
+from idun_agent_engine.integrations import base as integrations_base
+from idun_agent_engine.integrations.base import BaseIntegration, setup_integrations
+from idun_agent_engine.server.lifespan import cleanup_agent
+
+
+class _FakeIntegration(BaseIntegration):
+    def __init__(self, instance_id: str) -> None:
+        self.instance_id = instance_id
+        self.shutdown_called = False
+
+    async def setup(self, app: FastAPI, agent) -> None:
+        app.state.fake_instance = self.instance_id
+        router = APIRouter()
+
+        @router.post("/webhook")
+        async def webhook(request: Request) -> dict:
+            return {"instance": request.app.state.fake_instance}
+
+        app.include_router(router, prefix="/integrations/fake")
+
+    async def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+def _any_config() -> IntegrationConfig:
+    return IntegrationConfig(
+        provider=IntegrationProvider.WHATSAPP,
+        enabled=True,
+        config={
+            "access_token": "tok",
+            "phone_number_id": "123",
+            "verify_token": "verify",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_webhook_lifecycle_through_real_http(monkeypatch):
+    instances = iter([_FakeIntegration("v1"), _FakeIntegration("v2")])
+    monkeypatch.setattr(
+        integrations_base, "_create_integration", lambda _cfg: next(instances)
+    )
+
+    app = FastAPI()
+    agent = AsyncMock()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await setup_integrations(app, [_any_config()], agent)
+        first = await client.post("/integrations/fake/webhook")
+        assert first.status_code == 200
+        assert first.json() == {"instance": "v1"}
+
+        await cleanup_agent(app)
+        gone = await client.post("/integrations/fake/webhook")
+        assert gone.status_code == 404
+
+        await setup_integrations(app, [_any_config()], agent)
+        second = await client.post("/integrations/fake/webhook")
+        assert second.status_code == 200
+        assert second.json() == {"instance": "v2"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_non_integration_routes(monkeypatch):
+    monkeypatch.setattr(
+        integrations_base, "_create_integration", lambda _cfg: _FakeIntegration("v1")
+    )
+
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health() -> dict:
+        return {"ok": True}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await setup_integrations(app, [_any_config()], AsyncMock())
+        webhook_before = await client.post("/integrations/fake/webhook")
+        assert webhook_before.status_code == 200
+
+        await cleanup_agent(app)
+        health_after = await client.get("/health")
+        webhook_after = await client.post("/integrations/fake/webhook")
+
+    assert health_after.status_code == 200
+    assert webhook_after.status_code == 404
+
+
+class _FailingIntegration(BaseIntegration):
+    async def setup(self, app: FastAPI, agent) -> None:
+        raise RuntimeError("setup boom")
+
+    async def shutdown(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_partial_setup_failure_still_cleans_up(monkeypatch):
+    instances = iter([_FakeIntegration("ok"), _FailingIntegration()])
+    monkeypatch.setattr(
+        integrations_base, "_create_integration", lambda _cfg: next(instances)
+    )
+
+    app = FastAPI()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await setup_integrations(app, [_any_config(), _any_config()], AsyncMock())
+        ok_response = await client.post("/integrations/fake/webhook")
+        assert ok_response.status_code == 200
+
+        await cleanup_agent(app)
+        gone = await client.post("/integrations/fake/webhook")
+
+    assert gone.status_code == 404

--- a/libs/idun_agent_engine/tests/unit/integrations/test_setup.py
+++ b/libs/idun_agent_engine/tests/unit/integrations/test_setup.py
@@ -3,10 +3,33 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from idun_agent_schema.engine.integrations import IntegrationConfig, IntegrationProvider
 
-from idun_agent_engine.integrations.base import setup_integrations
+from idun_agent_engine.integrations import base as integrations_base
+from idun_agent_engine.integrations.base import BaseIntegration, setup_integrations
+
+
+class _RouteRegisteringFake(BaseIntegration):
+    async def setup(self, app, agent) -> None:
+        router = APIRouter()
+
+        @router.post("/webhook")
+        async def webhook() -> dict:
+            return {"ok": True}
+
+        app.include_router(router, prefix="/integrations/fake")
+
+    async def shutdown(self) -> None:
+        return None
+
+
+class _FailingFake(BaseIntegration):
+    async def setup(self, app, agent) -> None:
+        raise RuntimeError("setup boom")
+
+    async def shutdown(self) -> None:
+        return None
 
 
 def _make_whatsapp_config(enabled: bool = True) -> IntegrationConfig:
@@ -55,3 +78,58 @@ class TestSetupIntegrations:
         integrations = await setup_integrations(app, [], agent)
 
         assert len(integrations) == 0
+
+    @pytest.mark.asyncio
+    async def test_records_added_routes_on_app_state(self, monkeypatch):
+        monkeypatch.setattr(
+            integrations_base,
+            "_create_integration",
+            lambda _cfg: _RouteRegisteringFake(),
+        )
+        app = FastAPI()
+        agent = AsyncMock()
+        before = len(app.router.routes)
+
+        await setup_integrations(app, [_make_whatsapp_config()], agent)
+
+        tracked = app.state.integration_routes
+        assert isinstance(tracked, list)
+        assert len(tracked) == 1
+        assert all(r in app.router.routes for r in tracked)
+        assert len(app.router.routes) == before + 1
+
+    @pytest.mark.asyncio
+    async def test_disabled_integration_does_not_add_tracked_routes(self):
+        app = FastAPI()
+        agent = AsyncMock()
+
+        await setup_integrations(app, [_make_whatsapp_config(enabled=False)], agent)
+
+        assert app.state.integration_routes == []
+
+    @pytest.mark.asyncio
+    async def test_empty_config_list_initializes_empty_tracking(self):
+        app = FastAPI()
+        agent = AsyncMock()
+
+        await setup_integrations(app, [], agent)
+
+        assert app.state.integration_routes == []
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_still_tracks_succeeded_routes(self, monkeypatch):
+        instances = iter([_RouteRegisteringFake(), _FailingFake()])
+        monkeypatch.setattr(
+            integrations_base,
+            "_create_integration",
+            lambda _cfg: next(instances),
+        )
+        app = FastAPI()
+        agent = AsyncMock()
+
+        integrations = await setup_integrations(
+            app, [_make_whatsapp_config(), _make_whatsapp_config()], agent
+        )
+
+        assert len(integrations) == 1
+        assert len(app.state.integration_routes) == 1

--- a/libs/idun_agent_engine/tests/unit/prompts/test_helpers.py
+++ b/libs/idun_agent_engine/tests/unit/prompts/test_helpers.py
@@ -190,7 +190,7 @@ class TestGetPromptsFromApi:
         mock_get.assert_called_once_with(
             url="http://localhost:8000/api/v1/agents/config",
             headers={"auth": "Bearer test-key"},
-            timeout=30,
+            timeout=(2, 3),
         )
 
     @patch("idun_agent_engine.prompts.helpers.requests.get")
@@ -214,31 +214,29 @@ class TestGetPromptsFromApi:
         mock_get.assert_called_once_with(
             url="http://localhost:8000/api/v1/agents/config",
             headers={"auth": "Bearer key"},
-            timeout=30,
+            timeout=(2, 3),
         )
 
-    def test_raises_without_api_key(self) -> None:
+    def test_returns_empty_without_api_key(self) -> None:
         from idun_agent_engine.prompts.helpers import get_prompts_from_api
 
         with patch.dict(
             "os.environ",
             {"IDUN_AGENT_API_KEY": "", "IDUN_MANAGER_HOST": "http://localhost"},
         ):
-            with pytest.raises(ValueError, match="IDUN_AGENT_API_KEY"):
-                get_prompts_from_api()
+            assert get_prompts_from_api() == []
 
-    def test_raises_without_manager_host(self) -> None:
+    def test_returns_empty_without_manager_host(self) -> None:
         from idun_agent_engine.prompts.helpers import get_prompts_from_api
 
         with patch.dict(
             "os.environ",
             {"IDUN_AGENT_API_KEY": "key", "IDUN_MANAGER_HOST": ""},
         ):
-            with pytest.raises(ValueError, match="IDUN_MANAGER_HOST"):
-                get_prompts_from_api()
+            assert get_prompts_from_api() == []
 
     @patch("idun_agent_engine.prompts.helpers.requests.get")
-    def test_raises_on_http_error(self, mock_get: Mock) -> None:
+    def test_returns_empty_on_http_error(self, mock_get: Mock) -> None:
         import requests as req
 
         from idun_agent_engine.prompts.helpers import get_prompts_from_api
@@ -256,11 +254,10 @@ class TestGetPromptsFromApi:
                 "IDUN_MANAGER_HOST": "http://localhost:8000",
             },
         ):
-            with pytest.raises(ValueError, match="Failed to fetch config"):
-                get_prompts_from_api()
+            assert get_prompts_from_api() == []
 
     @patch("idun_agent_engine.prompts.helpers.requests.get")
-    def test_raises_on_invalid_yaml_response(self, mock_get: Mock) -> None:
+    def test_returns_empty_on_invalid_yaml_response(self, mock_get: Mock) -> None:
         from idun_agent_engine.prompts.helpers import get_prompts_from_api
 
         mock_response = Mock()
@@ -275,8 +272,7 @@ class TestGetPromptsFromApi:
                 "IDUN_MANAGER_HOST": "http://localhost:8000",
             },
         ):
-            with pytest.raises(ValueError, match="Failed to parse"):
-                get_prompts_from_api()
+            assert get_prompts_from_api() == []
 
 
 @pytest.mark.unit

--- a/libs/idun_agent_engine/tests/unit/server/test_cleanup_integration_routes.py
+++ b/libs/idun_agent_engine/tests/unit/server/test_cleanup_integration_routes.py
@@ -1,0 +1,76 @@
+"""Tests for integration route teardown inside cleanup_agent."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import APIRouter, FastAPI
+
+from idun_agent_engine.server.lifespan import cleanup_agent
+
+
+def _add_fake_integration_route(app: FastAPI) -> None:
+    router = APIRouter()
+
+    @router.post("/webhook")
+    async def webhook() -> dict:
+        return {"ok": True}
+
+    app.include_router(router, prefix="/integrations/fake")
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_tracked_integration_routes():
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health() -> dict:
+        return {"ok": True}
+
+    before = list(app.router.routes)
+    _add_fake_integration_route(app)
+    app.state.integration_routes = [r for r in app.router.routes if r not in before]
+
+    await cleanup_agent(app)
+
+    paths = [getattr(r, "path", "") for r in app.router.routes]
+    assert "/health" in paths
+    assert "/integrations/fake/webhook" not in paths
+    assert app.state.integration_routes == []
+
+
+@pytest.mark.asyncio
+async def test_cleanup_calls_each_integration_shutdown():
+    app = FastAPI()
+    integration_a = AsyncMock()
+    integration_b = AsyncMock()
+    app.state.integrations = [integration_a, integration_b]
+
+    await cleanup_agent(app)
+
+    integration_a.shutdown.assert_awaited_once()
+    integration_b.shutdown.assert_awaited_once()
+    assert app.state.integrations == []
+
+
+@pytest.mark.asyncio
+async def test_cleanup_is_idempotent_without_tracking_attribute():
+    app = FastAPI()
+
+    await cleanup_agent(app)
+
+    assert getattr(app.state, "integration_routes", None) == []
+
+
+@pytest.mark.asyncio
+async def test_cleanup_called_twice_does_not_raise():
+    app = FastAPI()
+    before = list(app.router.routes)
+    _add_fake_integration_route(app)
+    app.state.integration_routes = [r for r in app.router.routes if r not in before]
+
+    await cleanup_agent(app)
+    await cleanup_agent(app)
+
+    assert app.state.integration_routes == []

--- a/libs/idun_agent_schema/src/idun_agent_schema/engine/integrations/slack_webhook.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/engine/integrations/slack_webhook.py
@@ -14,6 +14,8 @@ class SlackMessageEvent(BaseModel):
     channel: str = ""
     ts: str = ""
     bot_id: str | None = None
+    subtype: str | None = None
+    app_id: str | None = None
 
 
 class SlackEventPayload(BaseModel):

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/engine_reload.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/engine_reload.py
@@ -1,18 +1,13 @@
 """Build the engine reload callable for the standalone runtime.
 
-Phase 3 case (b): the engine does not expose a public ``reconfigure``
-method on its FastAPI app. It does expose two app-level lifecycle
-hooks at ``idun_agent_engine.server.lifespan`` — ``cleanup_agent(app)``
-and ``configure_app(app, engine_config)``. We rebuild the agent in
-place by tearing down the old one and re-running the configure step
-on the same FastAPI app instance, which is exactly what the engine
-itself does on its own ``POST /reload`` route.
-
-The legacy ``idun_agent_standalone.reload`` module (kept for reference
-only — not imported here) does the same dance with extra recovery
-machinery; the standalone Phase 3 reload pipeline owns rollback +
-runtime_state recording, so the callable just translates engine
-exceptions to ``ReloadInitFailed``.
+The engine exposes two app level lifecycle hooks at
+``idun_agent_engine.server.lifespan``: ``cleanup_agent(app)`` and
+``configure_app(app, engine_config)``. We rebuild the agent in place
+by tearing down the old one and re running the configure step on the
+same FastAPI app instance, which is exactly what the engine itself
+does on its own ``POST /reload`` route. The standalone reload
+pipeline owns rollback and runtime_state recording, so the callable
+just translates engine exceptions to ``ReloadInitFailed``.
 """
 
 from __future__ import annotations
@@ -20,7 +15,6 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 
 from fastapi import FastAPI
-from fastapi.routing import APIRoute
 from idun_agent_engine.server.lifespan import cleanup_agent, configure_app
 from idun_agent_schema.engine.engine import EngineConfig
 
@@ -46,31 +40,10 @@ def build_engine_reload_callable(
             try:
                 await cleanup_agent(engine_app)
             except Exception:
-                # Teardown errors are noisy but not fatal — the engine
-                # logs them, we proceed to reconfigure regardless.
                 logger.exception("engine_reload.cleanup_failed continuing to configure")
-            _prune_integration_routes(engine_app)
             await configure_app(engine_app, config)
         except Exception as exc:
             logger.exception("engine_reload.configure_failed")
             raise ReloadInitFailed(str(exc)) from exc
 
     return _reload
-
-
-# TODO(#527): drop once the engine grows ``teardown_integrations`` and
-# calls it from ``configure_app``. Until then, the engine never removes
-# integration routes added by ``setup_integrations``, so deleted or
-# disabled integrations leave dead handlers behind.
-def _prune_integration_routes(app: FastAPI) -> None:
-    """Strip engine integration routes by prefix before reconfigure."""
-    routes = app.router.routes
-    before = len(routes)
-    app.router.routes = [
-        r
-        for r in routes
-        if not (isinstance(r, APIRoute) and r.path.startswith("/integrations/"))
-    ]
-    removed = before - len(app.router.routes)
-    if removed:
-        logger.info("engine_reload.pruned_integration_routes count=%d", removed)


### PR DESCRIPTION
## Summary

Closes #527.

The engine's `setup_integrations` appended webhook routes on every reload but had no matching teardown. Net effect: deleted integrations left dead handlers behind, and repeat reloads stacked duplicate routes for the same integration.

This PR tracks routes added during `setup_integrations` and removes them in `cleanup_agent`. The standalone's prefix-based prune workaround is dropped. Three integrations (WhatsApp, Discord, Teams) that had been registering routes from `core/app_factory.py` are moved into their own `setup()` methods, matching what Slack and Google Chat already do — so all five integrations now go through the same lifecycle.

While smoke-testing the fix end-to-end, two unrelated request-path hangs surfaced and are addressed here too:
- `prompts/helpers.py:get_prompts_from_api` blocked the event loop for 30s on a missing manager. Now fail-soft with a (2, 3) connect/read timeout — returns `[]` so callers fall through to their default prompt.
- The Slack handler awaited the agent before returning 200; runs longer than 3s caused Slack to retry up to three times, posting the agent's reply 3×. Webhooks now ack immediately, run the agent in a background task, and short-circuit `X-Slack-Retry-Num`. Schema gained `subtype` and `app_id` on `SlackMessageEvent` so bot-message echoes are filtered uniformly.

## Commits

| Commit | Scope |
|---|---|
| `feat(engine): track and remove integration routes on reload` | The #527 fix proper. `setup_integrations` snapshots `app.router.routes` before/after, stashes the delta on `app.state.integration_routes`. `cleanup_agent` removes those routes in place via `list.remove()` (preserves list identity), then resets the tracking list. Includes the contract docstring on `BaseIntegration.setup`: routes and `app.state` mutations must register synchronously inside `setup()`. |
| `refactor(engine): unify integration route registration to setup()` | Moves `app.include_router(...)` for WhatsApp / Discord / Teams from `app_factory.create_app` into each integration's `setup()`. Deletes the `match integration.provider:` block from `app_factory.py`. All five integrations now share one lifecycle. |
| `fix(standalone): drop integration route prune workaround` | Removes `_prune_integration_routes` from `services/engine_reload.py` and its `TODO(#527)` comment. The engine handles teardown now. |
| `fix(engine): make prompt fetch fail-soft with short timeouts` | `get_prompts_from_api` now returns `[]` on missing env, unreachable host, HTTP error, or invalid YAML instead of raising. Timeout dropped from `30` to `(2, 3)`. Existing tests updated. |
| `fix(engine): ack slack webhooks immediately and skip retries` | Slack handler returns 200 before running the agent (background task). Skips events carrying `X-Slack-Retry-Num`. Schema gains `subtype` and `app_id` so the existing bot-message filter catches more cases. |

## Tests

New:
- `tests/integration/test_integration_reload_no_leak.py` — three ASGITransport-driven tests. The lead one (`test_webhook_lifecycle_through_real_http`) is the issue #527 reproducer: boot fake v1 → POST gets `{instance: v1}` → cleanup → POST gets 404 → boot fake v2 → POST gets `{instance: v2}` (proves no leftover v1). Also covers `cleanup preserves /health` and `partial setup failure still cleans up`.
- `tests/unit/server/test_cleanup_integration_routes.py` — unit cleanup behavior: tracked routes removed, non-integration routes preserved, idempotent on repeat calls and missing state attribute.

Extended:
- `tests/unit/integrations/test_setup.py` — gains `records_added_routes_on_app_state`, `disabled_integration_does_not_add_tracked_routes`, `empty_config_list_initializes_empty_tracking`, `partial_failure_still_tracks_succeeded_routes`. Uses a route-registering fake via `monkeypatch` on `_create_integration`.
- `tests/unit/prompts/test_helpers.py` — five tests updated for fail-soft behavior; timeouts asserted as `(2, 3)`.

Suite status: engine 424 passed / 5 pre-existing ADK failures unrelated to this PR / 32 skipped. Standalone 186 passed / 1 skipped.

## Test plan

- [ ] `uv run pytest libs/idun_agent_engine/tests` passes (excluding the 5 pre-existing ADK failures).
- [ ] `uv run pytest libs/idun_agent_standalone/tests` passes.
- [ ] Smoke test against a live standalone with Discord + Slack + Teams configured:
  - `POST /integrations/{provider}/...` returns non-404 after boot.
  - `DELETE /admin/api/v1/integrations/{id}` followed by the same POST returns 404.
  - `POST /admin/api/v1/integrations` recreates the route; OpenAPI shows each path exactly once.
- [ ] Slack channel: a single `hello` produces one reply. No retries, no echo loop.

## Notes

- Engine version intentionally **not bumped** in this PR; bump separately when shipping.
- The MCP-server-hangs-the-thread issue surfaced during smoke testing is already tracked in #550; not addressed here.