### PR TITLE
ci: fix uv build artifact path on workspace members

### DIFF
--- a/.github/workflows/publish_engine_testpypi.yml
+++ b/.github/workflows/publish_engine_testpypi.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build wheel and sdist (schema)
         working-directory: libs/idun_agent_schema
         run: |
-          uv build --no-sources
+          uv build --no-sources --out-dir dist
 
       - name: Update engine version and local schema dependency
         working-directory: libs/idun_agent_engine
@@ -76,7 +76,7 @@ jobs:
       - name: Build wheel and sdist (engine)
         working-directory: libs/idun_agent_engine
         run: |
-          uv build --no-sources
+          uv build --no-sources --out-dir dist
 
       - name: Check distribution metadata
         run: |
@@ -173,7 +173,7 @@ jobs:
         working-directory: libs/idun_agent_engine
         run: |
           echo "Building engine with schema from TestPyPI..."
-          UV_INDEX_URL=https://test.pypi.org/simple/ UV_EXTRA_INDEX_URL=https://pypi.org/simple/ uv build --no-sources
+          UV_INDEX_URL=https://test.pypi.org/simple/ UV_EXTRA_INDEX_URL=https://pypi.org/simple/ uv build --no-sources --out-dir dist
 
       - name: Publish to TestPyPI
         id: publish

--- a/.github/workflows/publish_schema_testpypi.yml
+++ b/.github/workflows/publish_schema_testpypi.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build wheel and sdist (schema)
         working-directory: libs/idun_agent_schema
         run: |
-          uv build --no-sources
+          uv build --no-sources --out-dir dist
 
       - name: Check distribution metadata
         working-directory: libs/idun_agent_schema

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build schema package
         working-directory: libs/idun_agent_schema
         run: |
-          uv build --wheel --sdist
+          uv build --wheel --sdist --out-dir dist
           ls -lh dist/
 
       - name: Publish to PyPI
@@ -112,7 +112,7 @@ jobs:
       - name: Build engine package
         working-directory: libs/idun_agent_engine
         run: |
-          uv build --wheel --sdist
+          uv build --wheel --sdist --out-dir dist
           ls -lh dist/
 
       - name: Publish to PyPI


### PR DESCRIPTION
## Summary

- Recent `uv` versions resolve the **workspace root** when running `uv build` inside a workspace member — artifacts land in repo-root `dist/` instead of the member's `dist/`.
- TestPyPI workflows for schema and engine then fail at `twine check` (paths are empty), which is what's currently red on PR #524.
- Fix: pass `--out-dir dist` to every `uv build` so output stays scoped to the per-package working directory.
- Same one-flag fix applied to `release.yml`'s tag-triggered builds for consistency — happy to drop those two lines if reviewers want a tighter scope.

## Files
- `.github/workflows/publish_schema_testpypi.yml` (1 build)
- `.github/workflows/publish_engine_testpypi.yml` (3 builds: schema-local + engine-local + engine-publish)
- `.github/workflows/release.yml` (2 builds: schema + engine)

## Test plan
- [x] Reproduced the bug locally — `uv build --no-sources` from `libs/idun_agent_schema/` writes to repo-root `dist/`.
- [x] Verified `uv build --no-sources --out-dir /tmp/schema-out` writes to the requested path.
- [ ] CI on this branch runs the schema + engine workflows green.
- [ ] After merge into `feat/standalone-admin-db-rework`, PR #524's red CI checks turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)