### PR TITLE
feat(standalone-ui): MCP tool discovery + agent health verify

### DIFF
--- a/services/idun_agent_standalone_ui/__tests__/api/health.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/health.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, api } from "@/lib/api";
+
+describe("checkAgentHealth", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("GETs /health on the engine surface and returns the body on 200", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: "ok",
+          service: "idun-agent-engine",
+          version: "0.5.1",
+          agent_name: "demo",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await api.checkAgentHealth();
+
+    expect(result.status).toBe("ok");
+    expect(result.agent_name).toBe("demo");
+
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/health");
+    // No method on default GET — apiFetch infers it
+    expect((init as RequestInit).method).toBeUndefined();
+  });
+
+  it("throws ApiError on 503 agent_not_ready so callers can render a failure", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "agent_not_ready", message: "Engine not configured." },
+        }),
+        { status: 503, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await expect(api.checkAgentHealth()).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/api/mcp.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/mcp.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+
+describe("mcp api", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("discoverMcpTools() POSTs /admin/api/v1/mcp-servers/{id}/tools and returns the connection-check envelope", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          details: { toolCount: 2, tools: ["search", "fetch"] },
+          error: null,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await api.discoverMcpTools("abc-123");
+
+    expect(result.ok).toBe(true);
+    expect(result.details).toMatchObject({
+      toolCount: 2,
+      tools: ["search", "fetch"],
+    });
+
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/admin/api/v1/mcp-servers/abc-123/tools");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBeUndefined();
+  });
+
+  it("discoverMcpTools() returns ok=false with the upstream error on connection failure", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ok: false,
+          details: null,
+          error: "ECONNREFUSED",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await api.discoverMcpTools("abc-123");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("ECONNREFUSED");
+  });
+});

--- a/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { RotateCcw } from "lucide-react";
+import { Loader2, RotateCcw, Wifi, WifiOff } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -149,6 +149,61 @@ export default function AgentPage() {
   const [yamlOpen, setYamlOpen] = useState(false);
   const [restartRequired, setRestartRequired] = useState(false);
 
+  type VerifyStatus = "idle" | "checking" | "connected" | "failed";
+  const VERIFY_MAX_ATTEMPTS = 4;
+  const VERIFY_INTERVAL_MS = 5000;
+  const [verifyStatus, setVerifyStatus] = useState<VerifyStatus>("idle");
+  const [verifyAttempt, setVerifyAttempt] = useState(0);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+  const [verifiedName, setVerifiedName] = useState<string | null>(null);
+  const verifyAbort = useRef<AbortController | null>(null);
+
+  useEffect(
+    () => () => {
+      verifyAbort.current?.abort();
+    },
+    [],
+  );
+
+  async function verifyConnection() {
+    verifyAbort.current?.abort();
+    const controller = new AbortController();
+    verifyAbort.current = controller;
+    setVerifyStatus("checking");
+    setVerifyError(null);
+    setVerifiedName(null);
+
+    for (let i = 0; i < VERIFY_MAX_ATTEMPTS; i++) {
+      if (controller.signal.aborted) return;
+      setVerifyAttempt(i + 1);
+      try {
+        const health = await api.checkAgentHealth();
+        if (controller.signal.aborted) return;
+        if (health.status === "ok") {
+          setVerifiedName(health.agent_name ?? null);
+          setVerifyStatus("connected");
+          return;
+        }
+      } catch (e) {
+        if (controller.signal.aborted) return;
+        const detail =
+          e instanceof ApiError
+            ? ((e.detail as { error?: { message?: string } } | undefined)
+                ?.error?.message ?? `Engine returned ${e.status}.`)
+            : e instanceof Error
+              ? e.message
+              : "Unreachable.";
+        setVerifyError(detail);
+      }
+      if (i < VERIFY_MAX_ATTEMPTS - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, VERIFY_INTERVAL_MS),
+        );
+      }
+    }
+    if (!controller.signal.aborted) setVerifyStatus("failed");
+  }
+
   useEffect(() => {
     setActiveTab(initialFramework);
   }, [initialFramework]);
@@ -274,6 +329,70 @@ export default function AgentPage() {
           </AlertDescription>
         </Alert>
       )}
+
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-3">
+          <div className="space-y-1">
+            <CardTitle>Connection</CardTitle>
+            <CardDescription>
+              Probe the engine&apos;s health endpoint. Useful after a restart or
+              a config change.
+            </CardDescription>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={verifyConnection}
+            disabled={verifyStatus === "checking"}
+          >
+            {verifyStatus === "checking" ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Checking…
+              </>
+            ) : (
+              <>
+                <Wifi className="mr-2 h-4 w-4" />
+                Verify connection
+              </>
+            )}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {verifyStatus === "idle" && (
+            <p className="text-sm text-muted-foreground">
+              Click <em>Verify connection</em> to probe <code>/health</code>.
+            </p>
+          )}
+          {verifyStatus === "checking" && (
+            <p className="text-sm text-muted-foreground italic">
+              Attempt {verifyAttempt} of {VERIFY_MAX_ATTEMPTS}, retrying every{" "}
+              {VERIFY_INTERVAL_MS / 1000}s…
+            </p>
+          )}
+          {verifyStatus === "connected" && (
+            <Alert className="border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400">
+              <Wifi />
+              <AlertTitle>Agent is healthy</AlertTitle>
+              <AlertDescription>
+                {verifiedName
+                  ? `Engine reports the running agent as "${verifiedName}".`
+                  : "Engine is responsive."}
+              </AlertDescription>
+            </Alert>
+          )}
+          {verifyStatus === "failed" && (
+            <Alert variant="destructive">
+              <WifiOff />
+              <AlertTitle>Could not reach the agent</AlertTitle>
+              <AlertDescription>
+                {verifyError ??
+                  `No response after ${VERIFY_MAX_ATTEMPTS} attempts. Make sure the engine is running.`}
+              </AlertDescription>
+            </Alert>
+          )}
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>

--- a/services/idun_agent_standalone_ui/app/admin/mcp/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/mcp/page.tsx
@@ -2,7 +2,18 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { FileCode, Pencil, Plus, RotateCcw, Trash2, X } from "lucide-react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  FileCode,
+  Loader2,
+  Pencil,
+  Plus,
+  RotateCcw,
+  Trash2,
+  Wrench,
+  X,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -31,6 +42,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   Form,
   FormControl,
@@ -65,7 +84,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
-import { ApiError, type McpRead, api } from "@/lib/api";
+import { ApiError, type ConnectionCheckResult, type McpRead, api } from "@/lib/api";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -303,6 +322,14 @@ export default function McpPage() {
   const [yamlOpen, setYamlOpen] = useState(false);
   const [restartRequired, setRestartRequired] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [discoverFor, setDiscoverFor] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+
+  const discoverTools = useMutation({
+    mutationFn: (id: string) => api.discoverMcpTools(id),
+  });
 
   // Re-sync the working list whenever the query result changes (initial load
   // or post-save invalidate). Only resets when there are no pending edits to
@@ -605,6 +632,26 @@ export default function McpPage() {
                         <Button
                           variant="ghost"
                           size="icon"
+                          onClick={() => {
+                            if (row.id !== null) {
+                              setDiscoverFor({ id: row.id, name: row.name });
+                              discoverTools.reset();
+                              discoverTools.mutate(row.id);
+                            }
+                          }}
+                          disabled={row.id === null}
+                          aria-label={`Discover tools on ${row.name}`}
+                          title={
+                            row.id === null
+                              ? "Save the server first"
+                              : "Discover tools"
+                          }
+                        >
+                          <Wrench className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
                           onClick={() => openSheetFor(i)}
                           aria-label={`Edit ${row.name}`}
                         >
@@ -862,6 +909,145 @@ export default function McpPage() {
         title="Edit MCP servers configuration"
         description="Update the full list of servers. Save here only updates the local list — apply with Save all."
       />
+
+      {/* Tool discovery */}
+      <Dialog
+        open={discoverFor !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDiscoverFor(null);
+            discoverTools.reset();
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {discoverFor ? `Tools — ${discoverFor.name}` : "Tools"}
+            </DialogTitle>
+            <DialogDescription>
+              Probes the server and lists its tools. Doubles as a connection
+              check.
+            </DialogDescription>
+          </DialogHeader>
+
+          <DiscoverResult
+            isPending={discoverTools.isPending}
+            isError={discoverTools.isError}
+            error={discoverTools.error}
+            data={discoverTools.data}
+          />
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => discoverFor && discoverTools.mutate(discoverFor.id)}
+              disabled={discoverTools.isPending || discoverFor === null}
+            >
+              <RotateCcw className="mr-2 h-4 w-4" />
+              Retry
+            </Button>
+            <Button
+              onClick={() => {
+                setDiscoverFor(null);
+                discoverTools.reset();
+              }}
+            >
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function extractTools(details: Record<string, unknown> | null): string[] {
+  if (!details) return [];
+  const raw = (details as { tools?: unknown }).tools;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((t) => {
+      if (typeof t === "string") return t;
+      if (t && typeof t === "object" && "name" in t) {
+        const name = (t as { name?: unknown }).name;
+        return typeof name === "string" ? name : null;
+      }
+      return null;
+    })
+    .filter((t): t is string => t !== null);
+}
+
+function DiscoverResult({
+  isPending,
+  isError,
+  error,
+  data,
+}: {
+  isPending: boolean;
+  isError: boolean;
+  error: unknown;
+  data: ConnectionCheckResult | undefined;
+}) {
+  if (isPending) {
+    return (
+      <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Probing server…
+      </div>
+    );
+  }
+  if (isError) {
+    const message =
+      error instanceof ApiError
+        ? ((error.detail as { error?: { message?: string } } | undefined)?.error
+            ?.message ?? `Request failed (${error.status}).`)
+        : error instanceof Error
+          ? error.message
+          : "Request failed.";
+    return (
+      <Alert variant="destructive">
+        <AlertCircle />
+        <AlertTitle>Could not reach the server</AlertTitle>
+        <AlertDescription>{message}</AlertDescription>
+      </Alert>
+    );
+  }
+  if (!data) return null;
+  if (!data.ok) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle />
+        <AlertTitle>Connection failed</AlertTitle>
+        <AlertDescription>
+          {data.error ?? "The server did not respond to a tool listing."}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  const tools = extractTools(data.details);
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-sm text-emerald-700 dark:text-emerald-400">
+        <CheckCircle2 className="h-4 w-4" />
+        Connected — {tools.length} tool{tools.length === 1 ? "" : "s"} discovered.
+      </div>
+      {tools.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          The server reports no tools.
+        </p>
+      ) : (
+        <ul className="max-h-64 space-y-1 overflow-y-auto rounded-md border border-border bg-muted/30 p-2 text-sm">
+          {tools.map((name) => (
+            <li
+              key={name}
+              className="rounded px-2 py-1 font-mono text-xs text-foreground"
+            >
+              {name}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/services/idun_agent_standalone_ui/lib/api/index.ts
+++ b/services/idun_agent_standalone_ui/lib/api/index.ts
@@ -121,6 +121,10 @@ export const api = {
     apiFetch<MutationResponse<DeleteResult>>(`${ADMIN}/mcp-servers/${id}`, {
       method: "DELETE",
     }),
+  discoverMcpTools: (id: string) =>
+    apiFetch<ConnectionCheckResult>(`${ADMIN}/mcp-servers/${id}/tools`, {
+      method: "POST",
+    }),
 
   // guardrails (collection)
   listGuardrails: () => apiFetch<GuardrailRead[]>(`${ADMIN}/guardrails`),
@@ -208,4 +212,14 @@ export const api = {
     apiFetch<{ mermaid: string }>("/agent/graph/mermaid"),
   getAgentGraphAscii: () =>
     apiFetch<{ ascii: string }>("/agent/graph/ascii"),
+
+  // Engine surface — health probe (used by the agent page Verify button).
+  // Returns 503 with `agent_not_ready` until the engine is materialized.
+  checkAgentHealth: () =>
+    apiFetch<{
+      status: string;
+      service: string;
+      version: string;
+      agent_name: string | null;
+    }>("/health"),
 };


### PR DESCRIPTION
## Summary

Two operator-facing affordances closing the most-cited gaps from the standalone vs manager UX comparison. Both wire UI to admin/engine endpoints that already ship — pure UI work.

### MCP page — Discover tools per server
- New per-row Wrench button calls existing `POST /admin/api/v1/mcp-servers/{id}/tools`.
- Dialog surfaces probing/connected/error states.
- Connected state lists discovered tool names; error state shows upstream message.
- Doubles as a per-server connection check.

### Agent page — Verify connection card
- New Card above Configuration with a Verify button hitting engine `/health`.
- Mirrors manager's ConnectionVerifier (4 attempts, 5s interval).
- Success alert names the running agent (`/health` returns `agent_name`).
- Failure alert surfaces upstream error or attempt-exhausted message.
- Cleans up its AbortController on unmount.

## Files
- `lib/api/index.ts` — `discoverMcpTools(id)`, `checkAgentHealth()` wrappers.
- `app/admin/mcp/page.tsx` — Wrench button per row, results Dialog.
- `app/admin/agent/page.tsx` — Connection Card with retry loop.
- `__tests__/api/mcp.test.ts` — success + connection-failure envelopes.
- `__tests__/api/health.test.ts` — 200 ok body + 503 agent_not_ready ApiError.

## Test plan
- [x] `vitest run __tests__/api/` — 14 tests pass.
- [x] `tsc --noEmit` — no new errors on touched files.
- [ ] Verify locally on the umbrella by hitting Verify Connection on the agent page and Discover Tools on a configured MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)