### PR TITLE
feat(config-ux/A): status & errors

### DIFF
--- a/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/runtime.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/runtime.py
@@ -1,0 +1,55 @@
+"""``/admin/api/v1/runtime/status`` router.
+
+Read-only operator-facing endpoint exposing the singleton
+``runtime_state`` row. Returns the existing
+``StandaloneRuntimeReload`` schema (lastStatus / lastMessage /
+lastError / lastReloadedAt). 404 when no row exists yet — fresh
+install, no reload has been attempted.
+
+The UI polls this every 60s to drive the shell-level
+ReloadFailedBanner and the per-page RuntimeStatusCard.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi import status as http_status
+from idun_agent_schema.standalone import (
+    StandaloneAdminError,
+    StandaloneErrorCode,
+    StandaloneReloadStatus,
+)
+from idun_agent_schema.standalone.runtime_status import StandaloneRuntimeReload
+
+from idun_agent_standalone.api.v1.deps import SessionDep
+from idun_agent_standalone.api.v1.errors import AdminAPIError
+from idun_agent_standalone.core.logging import get_logger
+from idun_agent_standalone.services import runtime_state
+
+router = APIRouter(prefix="/admin/api/v1/runtime", tags=["admin"])
+
+logger = get_logger(__name__)
+
+
+@router.get("/status", response_model=StandaloneRuntimeReload)
+async def get_runtime_status(session: SessionDep) -> StandaloneRuntimeReload:
+    """Return the singleton runtime_state row as a reload-outcome payload.
+
+    404 when no row exists yet (fresh install, no save attempted).
+    """
+    row = await runtime_state.get(session)
+    if row is None:
+        raise AdminAPIError(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            error=StandaloneAdminError(
+                code=StandaloneErrorCode.NOT_FOUND,
+                message="No reload outcome recorded yet.",
+            ),
+        )
+    last_status = StandaloneReloadStatus(row.last_status) if row.last_status else None
+    return StandaloneRuntimeReload(
+        last_status=last_status,
+        last_message=row.last_message,
+        last_error=row.last_error,
+        last_reloaded_at=row.last_reloaded_at,
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -53,6 +53,9 @@ from idun_agent_standalone.api.v1.routers.onboarding import (
 from idun_agent_standalone.api.v1.routers.prompts import (
     router as prompts_router,
 )
+from idun_agent_standalone.api.v1.routers.runtime import (
+    router as runtime_router,
+)
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.core.security import SESSION_COOKIE_NAME
 from idun_agent_standalone.core.settings import AuthMode, StandaloneSettings
@@ -232,6 +235,7 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
     app.include_router(guardrails_router, dependencies=admin_auth)
     app.include_router(prompts_router, dependencies=admin_auth)
     app.include_router(integrations_router, dependencies=admin_auth)
+    app.include_router(runtime_router, dependencies=admin_auth)
     app.include_router(onboarding_router, dependencies=admin_auth)
     app.include_router(runtime_config_router)
 

--- a/libs/idun_agent_standalone/tests/integration/api/v1/conftest.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/conftest.py
@@ -1,0 +1,81 @@
+"""Shared fixtures for ``/admin/api/v1/*`` integration tests.
+
+Existing tests in this directory each compose their own ``admin_app``
+fixture that mounts a single router. The fixture below is the shared
+multi-router composition needed when a test exercises a write through
+one router and reads back the after-effect through another (PATCH
+``/agent`` → reload pipeline records into ``runtime_state`` → GET
+``/runtime/status`` reflects it).
+"""
+
+from __future__ import annotations
+
+import pytest_asyncio
+from fastapi import FastAPI
+from idun_agent_schema.engine.engine import EngineConfig
+from idun_agent_standalone.api.v1.deps import (
+    get_reload_callable,
+    get_session,
+)
+from idun_agent_standalone.api.v1.errors import (
+    register_admin_exception_handlers,
+)
+from idun_agent_standalone.api.v1.routers.agent import router as agent_router
+from idun_agent_standalone.api.v1.routers.runtime import router as runtime_router
+from idun_agent_standalone.infrastructure.db.models.agent import (
+    StandaloneAgentRow,
+)
+from idun_agent_standalone.services.reload import ReloadInitFailed
+
+
+async def _seed_agent(async_session) -> None:
+    """Seed the singleton agent row used by the failing-reload fixture."""
+    row = StandaloneAgentRow(
+        name="Ada",
+        base_engine_config={
+            "server": {"api": {"port": 8000}},
+            "agent": {
+                "type": "LANGGRAPH",
+                "config": {
+                    "name": "ada",
+                    "graph_definition": "agent.py:graph",
+                },
+            },
+        },
+    )
+    async_session.add(row)
+    await async_session.commit()
+
+
+@pytest_asyncio.fixture
+async def standalone_app_with_failing_reload(async_session) -> FastAPI:
+    """Standalone admin app whose engine reload callable always fails.
+
+    Mounts the agent + runtime routers against the in-memory
+    ``async_session`` from the top-level conftest and overrides
+    ``reload_callable`` so any PATCH that reaches round 3 raises
+    ``ReloadInitFailed``. This drives the failure-recording branch of
+    ``services/reload.commit_with_reload`` end-to-end.
+    """
+
+    async def failing_reload(_engine_config: EngineConfig) -> None:
+        raise ReloadInitFailed("simulated engine init failure")
+
+    await _seed_agent(async_session)
+
+    app = FastAPI()
+    register_admin_exception_handlers(app)
+    app.include_router(agent_router)
+    app.include_router(runtime_router)
+    app.state.reload_callable = failing_reload
+
+    async def override_session():
+        yield async_session
+
+    async def override_reload_callable():
+        return failing_reload
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_reload_callable] = override_reload_callable
+
+    return app

--- a/libs/idun_agent_standalone/tests/integration/api/v1/test_runtime_route.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/test_runtime_route.py
@@ -1,0 +1,29 @@
+"""Integration test: bad save -> runtime_state row updates -> GET reflects it."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_failed_reload_surfaces_in_runtime_status(
+    standalone_app_with_failing_reload,
+):
+    """A round-3 failure must show up on the runtime/status endpoint."""
+    transport = ASGITransport(app=standalone_app_with_failing_reload)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Trigger a save that the failing reload_callable rejects.
+        save_response = await client.patch(
+            "/admin/api/v1/agent",
+            json={"name": "trigger-failure"},
+        )
+        assert save_response.status_code == 500
+
+        # Read the runtime status — the row should now reflect the failure.
+        status_response = await client.get("/admin/api/v1/runtime/status")
+    assert status_response.status_code == 200
+    body = status_response.json()
+    assert body["lastStatus"] == "reload_failed"
+    assert body["lastMessage"].startswith("Engine reload failed")
+    assert body["lastError"] is not None

--- a/libs/idun_agent_standalone/tests/unit/api/v1/routers/conftest.py
+++ b/libs/idun_agent_standalone/tests/unit/api/v1/routers/conftest.py
@@ -1,0 +1,88 @@
+"""Shared fixtures for ``/admin/api/v1/*`` router unit tests.
+
+These fixtures spin up an in-memory SQLite database plus a minimal
+FastAPI app shell wired only with the admin exception handlers and the
+specific router under test. ``IDUN_ADMIN_AUTH_MODE`` is forced to
+``NONE`` so ``require_auth`` is a pass-through — auth gating gets its
+own dedicated coverage in ``test_require_auth.py``.
+
+The ``sessionmaker`` fixture is a real ``async_sessionmaker`` so tests
+can open their own ``async with sessionmaker() as session:`` block to
+seed rows independently of the request session, which mirrors how the
+production app composes its DB access.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from idun_agent_standalone.api.v1.deps import get_session
+from idun_agent_standalone.api.v1.errors import (
+    register_admin_exception_handlers,
+)
+from idun_agent_standalone.core.settings import AuthMode
+from idun_agent_standalone.infrastructure.db import (
+    models,  # noqa: F401  registers ORMs on Base
+)
+from idun_agent_standalone.infrastructure.db.session import Base
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    create_async_engine,
+)
+from sqlalchemy.ext.asyncio import (
+    async_sessionmaker as _async_sessionmaker,
+)
+
+
+@pytest.fixture
+async def db_engine() -> AsyncIterator[AsyncEngine]:
+    """In-memory async SQLite engine with all standalone ORMs created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def sessionmaker(db_engine: AsyncEngine) -> _async_sessionmaker:
+    """Async sessionmaker bound to the in-memory engine."""
+    return _async_sessionmaker(db_engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def unconfigured_app(sessionmaker: _async_sessionmaker) -> FastAPI:
+    """A minimal admin FastAPI app with the runtime router mounted.
+
+    "Unconfigured" describes the runtime posture, not the app — there
+    is no agent row and no engine in this fixture, mirroring the
+    fresh-install state where ``GET /admin/api/v1/runtime/status`` is
+    most likely to return 404 before the operator's first save.
+    """
+    from idun_agent_standalone.api.v1.routers.runtime import (
+        router as runtime_router,
+    )
+
+    app = FastAPI()
+    register_admin_exception_handlers(app)
+    app.include_router(runtime_router)
+
+    settings = SimpleNamespace(
+        auth_mode=AuthMode.NONE,
+        session_secret="x" * 32,
+        session_ttl_hours=24,
+    )
+    app.state.settings = settings
+    app.state.sessionmaker = sessionmaker
+
+    async def override_session() -> AsyncIterator:
+        async with sessionmaker() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_session
+    return app

--- a/libs/idun_agent_standalone/tests/unit/api/v1/routers/test_runtime.py
+++ b/libs/idun_agent_standalone/tests/unit/api/v1/routers/test_runtime.py
@@ -1,0 +1,43 @@
+"""Unit tests for /admin/api/v1/runtime/status."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from idun_agent_schema.standalone import StandaloneReloadStatus
+from idun_agent_standalone.services import runtime_state
+
+
+@pytest.mark.asyncio
+async def test_returns_404_when_no_row(unconfigured_app, sessionmaker):
+    transport = ASGITransport(app=unconfigured_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/runtime/status")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_returns_persisted_reload_row(unconfigured_app, sessionmaker):
+    async with sessionmaker() as session:
+        await runtime_state.record_reload_outcome(
+            session,
+            status=StandaloneReloadStatus.RELOAD_FAILED,
+            message="Engine reload failed; config not saved.",
+            error="ImportError: no module named 'app'",
+            config_hash=None,
+            reloaded_at=datetime(2026, 5, 5, 12, 0, tzinfo=UTC),
+        )
+        await session.commit()
+
+    transport = ASGITransport(app=unconfigured_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/runtime/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["lastStatus"] == "reload_failed"
+    assert body["lastMessage"] == "Engine reload failed; config not saved."
+    assert body["lastError"].startswith("ImportError")
+    assert body["lastReloadedAt"] is not None

--- a/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
@@ -117,6 +117,7 @@ describe("apiFetch fieldErrors parsing", () => {
   });
 
   it("parses fieldErrors out of the admin error envelope", async () => {
+    expect.assertions(4);
     fetchMock.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -132,20 +133,19 @@ describe("apiFetch fieldErrors parsing", () => {
         { status: 422, headers: { "content-type": "application/json" } },
       ),
     );
-    let caught: unknown = null;
     try {
       await apiFetch("/admin/api/v1/agent");
     } catch (e) {
-      caught = e;
+      expect(e).toBeInstanceOf(ApiError);
+      const err = e as ApiError;
+      expect(err.fieldErrors).toHaveLength(2);
+      expect(err.fieldErrors[0].field).toBe("agent.config.graphDefinition");
+      expect(err.fieldErrors[1].code).toBeNull();
     }
-    expect(caught).toBeInstanceOf(ApiError);
-    const err = caught as ApiError;
-    expect(err.fieldErrors).toHaveLength(2);
-    expect(err.fieldErrors[0].field).toBe("agent.config.graphDefinition");
-    expect(err.fieldErrors[1].code).toBeNull();
   });
 
   it("exposes empty fieldErrors when none present", async () => {
+    expect.assertions(2);
     fetchMock.mockResolvedValueOnce(
       new Response(
         JSON.stringify({

--- a/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/client.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError, apiFetch } from "@/lib/api/client";
+
 type ApiFetch = typeof import("@/lib/api/client").apiFetch;
 
 describe("apiFetch 401 redirect", () => {
@@ -99,5 +101,64 @@ describe("apiFetch 401 redirect", () => {
     await expect(apiFetch("/admin/api/v1/agent")).rejects.toThrow();
     // href is unchanged — apiFetch did not redirect.
     expect(window.location.href).toBe("SENTINEL_NO_REDIRECT");
+  });
+});
+
+describe("apiFetch fieldErrors parsing", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("parses fieldErrors out of the admin error envelope", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "validation_failed",
+            message: "Bad config",
+            fieldErrors: [
+              { field: "agent.config.graphDefinition", message: "bad path", code: "invalid" },
+              { field: "agent.config.name", message: "required", code: null },
+            ],
+          },
+        }),
+        { status: 422, headers: { "content-type": "application/json" } },
+      ),
+    );
+    let caught: unknown = null;
+    try {
+      await apiFetch("/admin/api/v1/agent");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ApiError);
+    const err = caught as ApiError;
+    expect(err.fieldErrors).toHaveLength(2);
+    expect(err.fieldErrors[0].field).toBe("agent.config.graphDefinition");
+    expect(err.fieldErrors[1].code).toBeNull();
+  });
+
+  it("exposes empty fieldErrors when none present", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "internal_error", message: "boom" },
+        }),
+        { status: 500, headers: { "content-type": "application/json" } },
+      ),
+    );
+    try {
+      await apiFetch("/admin/api/v1/agent");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).fieldErrors).toEqual([]);
+    }
   });
 });

--- a/services/idun_agent_standalone_ui/__tests__/api/form-errors.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/form-errors.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { applyFieldErrors } from "@/lib/api/form-errors";
+import { ApiError } from "@/lib/api/client";
+
+function makeForm() {
+  const setError = vi.fn();
+  return { setError } as any;
+}
+
+describe("applyFieldErrors", () => {
+  it("returns false for a non-ApiError", () => {
+    const form = makeForm();
+    expect(applyFieldErrors(form, new Error("boom"))).toBe(false);
+    expect(form.setError).not.toHaveBeenCalled();
+  });
+
+  it("returns false for an ApiError with no fieldErrors", () => {
+    const form = makeForm();
+    const err = new ApiError(500, { error: { code: "boom", message: "x" } });
+    expect(applyFieldErrors(form, err)).toBe(false);
+    expect(form.setError).not.toHaveBeenCalled();
+  });
+
+  it("calls setError per FieldError using the literal field path when no map", () => {
+    const form = makeForm();
+    const err = new ApiError(422, {
+      error: {
+        code: "validation_failed",
+        message: "x",
+        fieldErrors: [
+          { field: "name", message: "required", code: null },
+          { field: "definition", message: "bad", code: "invalid" },
+        ],
+      },
+    });
+    expect(applyFieldErrors(form, err)).toBe(true);
+    expect(form.setError).toHaveBeenCalledTimes(2);
+    expect(form.setError).toHaveBeenCalledWith("name", {
+      message: "required",
+      type: "server",
+    });
+    expect(form.setError).toHaveBeenCalledWith("definition", {
+      message: "bad",
+      type: "invalid",
+    });
+  });
+
+  it("translates field paths through the optional pathMap", () => {
+    const form = makeForm();
+    const err = new ApiError(422, {
+      error: {
+        code: "validation_failed",
+        message: "x",
+        fieldErrors: [
+          { field: "agent.config.graphDefinition", message: "bad", code: null },
+        ],
+      },
+    });
+    const ok = applyFieldErrors(form, err, {
+      "agent.config.graphDefinition": "definition",
+    });
+    expect(ok).toBe(true);
+    expect(form.setError).toHaveBeenCalledWith("definition", {
+      message: "bad",
+      type: "server",
+    });
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/api/runtime.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/api/runtime.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { api, ApiError } from "@/lib/api";
+
+describe("getRuntimeStatus", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("GETs /admin/api/v1/runtime/status and returns the typed payload", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          lastStatus: "reload_failed",
+          lastMessage: "Engine reload failed; config not saved.",
+          lastError: "ImportError: no module named 'app'",
+          lastReloadedAt: "2026-05-05T12:00:00Z",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await api.getRuntimeStatus();
+
+    expect(result.lastStatus).toBe("reload_failed");
+    expect(result.lastError).toContain("ImportError");
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/admin/api/v1/runtime/status");
+    expect((init as RequestInit).method).toBeUndefined();
+  });
+
+  it("throws ApiError on 404 (no row yet)", async () => {
+    expect.assertions(1);
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: { code: "not_found", message: "no row" } }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      ),
+    );
+    try {
+      await api.getRuntimeStatus();
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+    }
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/reload-failed-banner.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/reload-failed-banner.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ReloadFailedBanner } from "@/components/admin/ReloadFailedBanner";
+import type { RuntimeStatus } from "@/lib/api/types";
+
+function renderWithStatus(status: RuntimeStatus | null) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  // Pre-seed the query cache so the component renders synchronously.
+  queryClient.setQueryData(["runtime-status"], status);
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ReloadFailedBanner />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ReloadFailedBanner", () => {
+  it("renders nothing when no status row exists yet", () => {
+    renderWithStatus(null);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders nothing when last_status is reloaded", () => {
+    renderWithStatus({
+      lastStatus: "reloaded",
+      lastMessage: "Saved and reloaded.",
+      lastError: null,
+      lastReloadedAt: "2026-05-05T12:00:00Z",
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders nothing when last_status is restart_required", () => {
+    renderWithStatus({
+      lastStatus: "restart_required",
+      lastMessage: "Saved. Restart required to apply.",
+      lastError: null,
+      lastReloadedAt: "2026-05-05T12:00:00Z",
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders the banner with the error when last_status is reload_failed", () => {
+    renderWithStatus({
+      lastStatus: "reload_failed",
+      lastMessage: "Engine reload failed; config not saved.",
+      lastError: "ImportError: no module named 'app'",
+      lastReloadedAt: "2026-05-05T12:00:00Z",
+    });
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/engine reload failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/importerror/i)).toBeInTheDocument();
+  });
+});

--- a/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
@@ -15,12 +15,14 @@ import {
   AdkIcon,
   LangGraphIcon,
 } from "@/components/admin/provider-icons";
+import { RuntimeStatusCard } from "@/components/admin/RuntimeStatusCard";
 import {
   AgentGraphLazy,
   type AgentGraphHandle,
 } from "@/components/graph/AgentGraphLazy";
 import { ExportMenu } from "@/components/graph/ExportMenu";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -156,6 +158,7 @@ export default function AgentPage() {
   const [verifyAttempt, setVerifyAttempt] = useState(0);
   const [verifyError, setVerifyError] = useState<string | null>(null);
   const [verifiedName, setVerifiedName] = useState<string | null>(null);
+  const [verifiedVersion, setVerifiedVersion] = useState<string | null>(null);
   const verifyAbort = useRef<AbortController | null>(null);
 
   useEffect(
@@ -180,6 +183,7 @@ export default function AgentPage() {
         const health = await api.checkAgentHealth();
         if (controller.signal.aborted) return;
         if (health.status === "ok") {
+          setVerifiedVersion(health.version ?? null);
           setVerifiedName(health.agent_name ?? null);
           setVerifyStatus("connected");
           return;
@@ -312,12 +316,19 @@ export default function AgentPage() {
 
   return (
     <div className="flex flex-col gap-6 p-6 max-w-4xl">
-      <header className="space-y-1">
-        <h1 className="font-serif text-2xl font-medium text-foreground">Agent</h1>
-        <p className="text-sm text-muted-foreground">
-          Identity and graph definition for the running agent. Memory is configured
-          on its own page.
-        </p>
+      <header className="flex flex-row items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="font-serif text-2xl font-medium text-foreground">Agent</h1>
+          <p className="text-sm text-muted-foreground">
+            Identity and graph definition for the running agent. Memory is configured
+            on its own page.
+          </p>
+        </div>
+        {verifiedVersion && (
+          <Badge variant="outline" className="font-mono text-xs">
+            engine {verifiedVersion}
+          </Badge>
+        )}
       </header>
 
       {restartRequired && (
@@ -393,6 +404,8 @@ export default function AgentPage() {
           )}
         </CardContent>
       </Card>
+
+      <RuntimeStatusCard />
 
       <Card>
         <CardHeader>

--- a/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/agent/page.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { ApiError, type AgentRead, api } from "@/lib/api";
+import { applyFieldErrors } from "@/lib/api/form-errors";
 
 type Framework = "langgraph" | "adk";
 
@@ -253,6 +254,11 @@ export default function AgentPage() {
       qc.invalidateQueries({ queryKey: ["agent"] });
     },
     onError: (e) => {
+      const handled = applyFieldErrors(form, e, {
+        "agent.config.graphDefinition": "definition",
+        "agent.config.name": "name",
+      });
+      if (handled) return;
       const detail = e instanceof ApiError ? e.detail : undefined;
       const message = (detail as { error?: { message?: string } } | undefined)?.error
         ?.message;

--- a/services/idun_agent_standalone_ui/app/admin/layout.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/layout.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { AppSidebar } from "@/components/admin/AppSidebar";
 import { AuthGuard } from "@/components/admin/AuthGuard";
 import { GlobalCommand } from "@/components/admin/GlobalCommand";
+import { ReloadFailedBanner } from "@/components/admin/ReloadFailedBanner";
 import { Topbar } from "@/components/admin/Topbar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -37,6 +38,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
           <SidebarInset>
             <Topbar onOpenCommand={() => setCommandOpen(true)} />
             <main className="flex-1 overflow-y-auto bg-background">
+              <ReloadFailedBanner />
               {children}
             </main>
           </SidebarInset>

--- a/services/idun_agent_standalone_ui/components/admin/ReloadFailedBanner.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/ReloadFailedBanner.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { ApiError, api } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Sticky shell-level banner that appears only when the last reload
+ * attempt failed. Polls /admin/api/v1/runtime/status every 60s.
+ *
+ * Mounts in app/admin/layout.tsx so every admin page gets it without
+ * each page wiring it up. 404 from the backend (fresh install, no
+ * row yet) is treated as "nothing to show".
+ */
+export function ReloadFailedBanner() {
+  const { data } = useQuery({
+    queryKey: ["runtime-status"],
+    queryFn: async () => {
+      try {
+        return await api.getRuntimeStatus();
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) return null;
+        throw err;
+      }
+    },
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchOnWindowFocus: false,
+  });
+
+  if (!data || data.lastStatus !== "reload_failed") {
+    return null;
+  }
+
+  return (
+    <div className="sticky top-0 z-40 border-b border-destructive/20 bg-destructive/5 px-6 py-3">
+      <Alert variant="destructive" className="border-0 bg-transparent p-0">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle>
+          {data.lastMessage ?? "Engine reload failed; config not saved."}
+        </AlertTitle>
+        {data.lastError && (
+          <AlertDescription className="font-mono text-xs">
+            {data.lastError}
+          </AlertDescription>
+        )}
+      </Alert>
+    </div>
+  );
+}

--- a/services/idun_agent_standalone_ui/components/admin/RuntimeStatusCard.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/RuntimeStatusCard.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { CheckCircle2, RotateCcw, AlertTriangle } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ApiError, api } from "@/lib/api";
+import type { RuntimeStatus } from "@/lib/api/types";
+
+const POLL_INTERVAL_MS = 60_000;
+
+function StatusBadge({ status }: { status: RuntimeStatus["lastStatus"] }) {
+  if (status === "reloaded") {
+    return (
+      <Badge className="border-emerald-500/30 bg-emerald-500/15 text-emerald-700 dark:text-emerald-400">
+        <CheckCircle2 className="mr-1 h-3 w-3" />
+        Reloaded
+      </Badge>
+    );
+  }
+  if (status === "restart_required") {
+    return (
+      <Badge className="border-amber-500/30 bg-amber-500/15 text-amber-700 dark:text-amber-400">
+        <RotateCcw className="mr-1 h-3 w-3" />
+        Restart required
+      </Badge>
+    );
+  }
+  if (status === "reload_failed") {
+    return (
+      <Badge className="border-destructive/30 bg-destructive/10 text-destructive">
+        <AlertTriangle className="mr-1 h-3 w-3" />
+        Reload failed
+      </Badge>
+    );
+  }
+  return <Badge variant="outline">Unknown</Badge>;
+}
+
+export function RuntimeStatusCard() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["runtime-status"],
+    queryFn: async () => {
+      try {
+        return await api.getRuntimeStatus();
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) return null;
+        throw err;
+      }
+    },
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchOnWindowFocus: false,
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Runtime status</CardTitle>
+        <CardDescription>
+          The last reload outcome. Polls every {POLL_INTERVAL_MS / 1000}s.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm">
+        {isLoading && (
+          <p className="text-muted-foreground">Loading…</p>
+        )}
+        {!isLoading && !data && (
+          <p className="text-muted-foreground italic">
+            No reload has been attempted yet.
+          </p>
+        )}
+        {data && (
+          <>
+            <div className="flex items-center gap-2">
+              <span className="font-medium">Status:</span>
+              <StatusBadge status={data.lastStatus} />
+            </div>
+            {data.lastMessage && (
+              <div>
+                <span className="font-medium">Message:</span>{" "}
+                <span className="text-muted-foreground">{data.lastMessage}</span>
+              </div>
+            )}
+            {data.lastError && (
+              <div>
+                <span className="font-medium">Error:</span>{" "}
+                <pre className="mt-1 max-h-32 overflow-auto rounded-md bg-muted p-2 font-mono text-xs">
+                  {data.lastError}
+                </pre>
+              </div>
+            )}
+            {data.lastReloadedAt && (
+              <div>
+                <span className="font-medium">Last reloaded:</span>{" "}
+                <span className="text-muted-foreground">
+                  {new Date(data.lastReloadedAt).toLocaleString()}
+                </span>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/services/idun_agent_standalone_ui/lib/api/client.ts
+++ b/services/idun_agent_standalone_ui/lib/api/client.ts
@@ -6,15 +6,38 @@
  *   lands back on their original page after authenticating. Skips the
  *   `?next=` round-trip when the request already came from /login.
  * - Throws ApiError on non-2xx so TanStack Query surfaces the failure.
+ *   ApiError carries `fieldErrors` pre-parsed from the standard admin
+ *   error envelope so consumers (forms via applyFieldErrors) don't need
+ *   to traverse `error.detail.error.fieldErrors`.
  */
 
+import type { FieldError } from "./types";
+
 export class ApiError extends Error {
+  public readonly fieldErrors: FieldError[];
+
   constructor(
     public status: number,
     public detail: unknown,
   ) {
     super(`API ${status}`);
+    this.fieldErrors = extractFieldErrors(detail);
   }
+}
+
+function extractFieldErrors(detail: unknown): FieldError[] {
+  if (!detail || typeof detail !== "object") return [];
+  const error = (detail as { error?: unknown }).error;
+  if (!error || typeof error !== "object") return [];
+  const raw = (error as { fieldErrors?: unknown }).fieldErrors;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (item): item is FieldError =>
+      item != null &&
+      typeof item === "object" &&
+      typeof (item as { field?: unknown }).field === "string" &&
+      typeof (item as { message?: unknown }).message === "string",
+  );
 }
 
 let redirected = false;
@@ -26,9 +49,6 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     ...init,
   });
   if (res.status === 401 && typeof window !== "undefined" && !redirected) {
-    // When the request was made FROM /login, skip the redirect entirely so
-    // the login page's own catch block can render the error (toast + clear
-    // field). A hard navigation back to /login would clobber that UX.
     if (window.location.pathname.startsWith("/login")) {
       throw new ApiError(401, null);
     }

--- a/services/idun_agent_standalone_ui/lib/api/client.ts
+++ b/services/idun_agent_standalone_ui/lib/api/client.ts
@@ -14,7 +14,7 @@
 import type { FieldError } from "./types";
 
 export class ApiError extends Error {
-  public readonly fieldErrors: FieldError[];
+  public readonly fieldErrors: readonly FieldError[];
 
   constructor(
     public status: number,
@@ -25,19 +25,19 @@ export class ApiError extends Error {
   }
 }
 
-function extractFieldErrors(detail: unknown): FieldError[] {
+function extractFieldErrors(detail: unknown): readonly FieldError[] {
   if (!detail || typeof detail !== "object") return [];
   const error = (detail as { error?: unknown }).error;
   if (!error || typeof error !== "object") return [];
   const raw = (error as { fieldErrors?: unknown }).fieldErrors;
   if (!Array.isArray(raw)) return [];
-  return raw.filter(
-    (item): item is FieldError =>
-      item != null &&
-      typeof item === "object" &&
-      typeof (item as { field?: unknown }).field === "string" &&
-      typeof (item as { message?: unknown }).message === "string",
-  );
+  return raw.filter((item): item is FieldError => {
+    if (item == null || typeof item !== "object") return false;
+    const o = item as { field?: unknown; message?: unknown; code?: unknown };
+    if (typeof o.field !== "string") return false;
+    if (typeof o.message !== "string") return false;
+    return typeof o.code === "string" || o.code === null;
+  });
 }
 
 let redirected = false;

--- a/services/idun_agent_standalone_ui/lib/api/form-errors.ts
+++ b/services/idun_agent_standalone_ui/lib/api/form-errors.ts
@@ -1,0 +1,37 @@
+/**
+ * Routes backend field_errors into react-hook-form fields.
+ *
+ * The standalone admin contract emits 422 envelopes with a
+ * `fieldErrors` array of `{ field, message, code }`. The frontend's
+ * field paths sometimes differ from the backend's dotted paths
+ * (e.g. backend `agent.config.graphDefinition` vs form `definition`),
+ * so callers may pass an explicit pathMap.
+ *
+ * Returns:
+ *   - `true`  if at least one field error was applied; the caller
+ *             should suppress its top-level toast since the form is
+ *             now showing the errors inline.
+ *   - `false` if the error wasn't an ApiError, or had no fieldErrors;
+ *             the caller should fall back to a generic toast.
+ */
+
+import type { UseFormReturn } from "react-hook-form";
+
+import { ApiError } from "./client";
+
+export function applyFieldErrors(
+  form: UseFormReturn<any>,
+  error: unknown,
+  pathMap?: Record<string, string>,
+): boolean {
+  if (!(error instanceof ApiError)) return false;
+  if (error.fieldErrors.length === 0) return false;
+  for (const fe of error.fieldErrors) {
+    const formPath = pathMap?.[fe.field] ?? fe.field;
+    form.setError(formPath as any, {
+      message: fe.message,
+      type: fe.code ?? "server",
+    });
+  }
+  return true;
+}

--- a/services/idun_agent_standalone_ui/lib/api/index.ts
+++ b/services/idun_agent_standalone_ui/lib/api/index.ts
@@ -35,6 +35,7 @@ import type {
   PromptCreate,
   PromptPatch,
   PromptRead,
+  RuntimeStatus,
   ScanResponse,
   SingletonDeleteResult,
 } from "./types";
@@ -222,4 +223,8 @@ export const api = {
       version: string;
       agent_name: string | null;
     }>("/health"),
+
+  // Runtime status (singleton — last reload outcome)
+  getRuntimeStatus: () =>
+    apiFetch<RuntimeStatus>(`${ADMIN}/runtime/status`),
 };

--- a/services/idun_agent_standalone_ui/lib/api/types/index.ts
+++ b/services/idun_agent_standalone_ui/lib/api/types/index.ts
@@ -19,3 +19,4 @@ export type {
   ToolKind,
   ToolNode,
 } from "./graph";
+export type { ReloadStatusKind, RuntimeStatus } from "./runtime";

--- a/services/idun_agent_standalone_ui/lib/api/types/runtime.ts
+++ b/services/idun_agent_standalone_ui/lib/api/types/runtime.ts
@@ -1,0 +1,11 @@
+export type ReloadStatusKind =
+  | "reloaded"
+  | "restart_required"
+  | "reload_failed";
+
+export type RuntimeStatus = {
+  lastStatus: ReloadStatusKind | null;
+  lastMessage: string | null;
+  lastError: string | null;
+  lastReloadedAt: string | null; // ISO 8601
+};


### PR DESCRIPTION
## Summary

Bundle A from the config-UX umbrella. Three deliverables:

- `GET /admin/api/v1/runtime/status` — exposes the persisted `runtime_state` row as a `StandaloneRuntimeReload` payload (returns 404 when no row yet).
- `applyFieldErrors(form, error, pathMap?)` helper + pre-parsed `ApiError.fieldErrors` — routes backend `field_errors` directly to react-hook-form fields.
- `<ReloadFailedBanner>` mounted in the admin layout (60s polling); `<RuntimeStatusCard>` on `/admin/agent`; engine version chip in the agent page header.

## Spec
`docs/superpowers/specs/2026-05-05-config-ux-bundles-design.md` — Bundle A section.

## Test plan
- [x] standalone narrowed pytest gate — 374 passed, 1 skipped (env clean) / 310 passed when 4 pre-existing huggingface_hub collection errors are excluded
- [x] engine narrowed pytest gate — 486 passed, 17 skipped, 8 failed (guardrails tests requiring external API keys; pre-existing pattern, not introduced by this PR; Bundle A does not touch engine)
- [x] vitest — 165 tests across 34 files all PASS
- [x] tsc --noEmit on touched files (no errors on Bundle A files)
- [x] make precommit — Ruff UP046 on `libs/idun_agent_schema/src/idun_agent_schema/standalone/common.py:40` is pre-existing on base `feat/config-ux` (verified by running precommit on the base branch); Bundle A does not touch that file

## Commits
adee35ff feat(standalone-ui): wire applyFieldErrors into agent page mutation
3a1d3d17 feat(standalone-ui): runtime status card + engine version chip on /admin/agent
475cbc15 feat(standalone-ui): RuntimeStatusCard component
3718a67b feat(standalone-ui): mount ReloadFailedBanner in admin layout
dd530f56 feat(standalone-ui): ReloadFailedBanner shell component
32418b3c feat(standalone-ui): api.getRuntimeStatus typed wrapper
f6d98574 feat(standalone-ui): applyFieldErrors helper for react-hook-form
8de4e328 fix(standalone-ui): readonly fieldErrors + assertion gates + code validation
4e74bf12 feat(standalone-ui): parse fieldErrors on ApiError at throw site
3c5b1fb5 test(standalone): integration test for runtime/status round-trip
a5b838fe feat(standalone): GET /admin/api/v1/runtime/status route

🤖 Generated with [Claude Code](https://claude.com/claude-code)