### PR TITLE
chore(claude): wire idun-team plugin via committed settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "idun": {
+      "source": {
+        "source": "github",
+        "repo": "Idun-Group/idun-dev"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "idun-team@idun": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,6 @@ poetry.lock
 .cursor/rules/claude-mem-context.mdc
 
 # Local agent / tooling state (never commit)
-/.claude/settings.json
 /.claude/scheduled_tasks.lock
 /.claude/worktrees/
 /.claude/smoke-test/


### PR DESCRIPTION
## Summary

Wires the new `idun-team` Claude Code plugin (from `Idun-Group/idun-dev`) into this repo via committed `.claude/settings.json`.

After this PR merges, every dev who clones this repo and opens it in Claude Code is prompted twice (trust marketplace + install plugin). Accepting once auto-installs `idun-team`. From then on, `idun-team`'s `CLAUDE.md`, skills, and (eventually) agents/commands/hooks auto-load in every session in this repo. Auto-update on session start.

## Changes

- `.gitignore`: remove `/.claude/settings.json` line so the new file actually tracks.
- `.claude/settings.json`: register `Idun-Group/idun-dev` as a known plugin marketplace; enable `idun-team@idun`.

## Test plan

- [ ] Reviewer: in a fresh checkout of this branch, open the repo in Claude Code. Confirm marketplace-trust + plugin-install prompts fire.
- [ ] Reviewer: after accepting, confirm `/plugin` lists `idun-team@idun` enabled.
- [ ] Reviewer: ask Claude "what's our branch naming convention?" — confirm answer cites idun-team's CLAUDE.md (mentions `feat/*`, `fix/*`, ..., `learning/*`).
- [ ] Reviewer: do NOT run `/preserve` against the team's idun-dev repo without coordinating first.

## Background

See `Idun-Group/idun-dev` repo for plugin source. v0.1.0 design and plan: `tasks/idun-dev-bootstrap-08-05-2026/SPEC.md` and `PLAN.md` in that repo.

## Risk

Low for v0.1.0: only adds an `idun-team` plugin that ships one skill (`/preserve`). Plugin's `CLAUDE.md` duplicates the existing `## Conventions` and `## Development Principles` blocks here for now — deduplication is a v0.2 concern. **Branch protection on `idun-dev/main` is unavailable on the org's current GitHub tier and deferred to v0.1.1**; mitigation is single-author-on-main + PR-then-manual-merge for collaborators + `git revert` rollback if needed.