### PR TITLE
docs(claude): overhaul CLAUDE.md system for post-pivot architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Package managers: `uv` (Python workspace), `pnpm` (Node — only in `services/id
 
 ```bash
 # First-time setup
-uv sync --all-groups          # full workspace install
+make sync                      # uv sync --all-groups (full workspace install)
 make dev                       # editable installs of the three libs
 
 # Fast inner loop
@@ -48,7 +48,7 @@ make ci                        # lint + mypy + pytest
 # Standalone runtime
 idun-standalone setup          # alembic migrations + seed from IDUN_CONFIG_PATH
 idun-standalone serve          # uvicorn under create_standalone_app
-idun-standalone init <name>    # first-run launcher (migrate + seed + open browser + serve)
+idun-standalone init           # first-run launcher (migrate + seed + open browser + serve)
 
 # Standalone UI dev
 cd services/idun_agent_standalone_ui

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,119 +1,66 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (and humans) working in `idun-agent-platform`.
 
 ## Project Overview
 
-Idun Agent Platform is a self-hosted control plane that wraps LangGraph/ADK agents into production-ready services. It's a monorepo with three layers: a Python SDK/engine, a FastAPI management backend, and a React admin UI.
+Idun Agent Platform is the open-source toolkit for shipping a single LangGraph or Google ADK agent to production. Developers `pip install idun-agent-standalone`, point at their agent module, and get a FastAPI service with a chat UI, admin panel, and built-in MCP, guardrails, observability, and auth — deployable on a laptop or Cloud Run with no manager service required.
 
-## Repository Structure
+## Constitution
 
-- `libs/idun_agent_schema/` — Shared Pydantic models (published to PyPI)
-- `libs/idun_agent_engine/` — SDK runtime that wraps agents into FastAPI services (published to PyPI)
-- `libs/idun_agent_standalone/` — Single-process agent (chat UI + admin + traces) — published to PyPI as `idun-agent-standalone`
-- `services/idun_agent_manager/` — FastAPI + PostgreSQL backend for agent config CRUD, auth, policy enforcement
-- `services/idun_agent_web/` — React 19 + Vite + TypeScript admin dashboard
-- `services/idun_agent_standalone_ui/` — Next.js 15 SPA bundled into the standalone wheel
-- `docs/` — Mintlify documentation site (deployed to docs.idunplatform.com)
-- `old-docs/` — Legacy MkDocs documentation (archived, do not edit)
+These principles are load-bearing. Read them before deciding how to structure new work.
 
-## Per-Service Documentation
+- **Schema flows first.** Pydantic models in `idun_agent_schema` change before consumers (engine, standalone, UI types).
+- **Engine is the runtime source of truth.** `idun_agent_standalone` never duplicates engine logic — it composes it.
+- **Standalone is the open-source product target.** Single-process, single-tenant, deployable on Cloud Run with `pip install`. One agent per install.
+- **DB is steady-state truth in standalone.** YAML seeds at first boot only; runtime mutations flow through the admin REST.
+- **Reload over restart.** Admin mutations route through the validate-rebuild-reload pipeline; engine init failures roll back the DB write.
+- **AG-UI is the streaming contract.** Don't invent another protocol.
+- **Async throughout.** All Python I/O paths are async — agents, sessions, DB, HTTP.
 
-Each package/service has its own `CLAUDE.md` with detailed architecture, module maps, and conventions. **Always read the relevant CLAUDE.md before working on a specific package:**
+## Repository Map
 
-- `libs/idun_agent_schema/CLAUDE.md` — Schema library: Pydantic models, config hierarchy, discriminated unions, manager schemas
-- `libs/idun_agent_engine/CLAUDE.md` — Engine SDK: agent adapters, config flow, server endpoints, guardrails, observability, MCP, CLI
-- `libs/idun_agent_standalone/CLAUDE.md` — Standalone runtime: admin REST, traces capture, reload orchestration, auth, Docker
-- `services/idun_agent_manager/CLAUDE.md` — Manager API: routes, auth (OIDC + basic), multi-tenancy, database models, migrations
-- `services/idun_agent_web/CLAUDE.md` — Web UI: routes, auth flow, API layer, styling, i18n, state management
-- `services/idun_agent_standalone_ui/CLAUDE.md` — Standalone UI: Next.js app, theme system, admin editors, traces viewer
+| Path | Purpose | Read its CLAUDE.md when… |
+| --- | --- | --- |
+| `libs/idun_agent_schema` | Shared Pydantic models | Changing config shape, enums, validation |
+| `libs/idun_agent_engine` | Engine SDK runtime | Touching agent adapters, AG-UI streaming, MCP, guardrails, observability |
+| `libs/idun_agent_standalone` | Single-process runtime | Working on admin REST, reload pipeline, auth, CLI |
+| `services/idun_agent_standalone_ui` | Bundled Next.js UI | Working on chat, admin pages, theme, traces viewer |
+| `docs/` | Mintlify public docs | Writing user-facing documentation |
 
-## Build & Development Commands
+## Quick Commands
 
-**Package manager:** UV (Python), npm (Node.js)
-
-```bash
-# Install all Python dependencies
-make sync                    # or: uv sync --all-groups
-
-# Install libs in editable mode
-make dev
-
-# Run full dev stack (PostgreSQL + Manager + Web)
-docker compose -f docker-compose.dev.yml up --build
-
-# Run manager locally (port 8000)
-make dev-manager
-
-# Run frontend locally (port 3000)
-cd services/idun_agent_web && npm install && npm run dev
-```
-
-## Testing
+Package managers: `uv` (Python workspace), `pnpm` (Node — only in `services/idun_agent_standalone_ui`).
 
 ```bash
-make test                    # Run all tests (uv run pytest -q)
-make pytest                  # Run all tests (uv run pytest)
+# First-time setup
+uv sync --all-groups          # full workspace install
+make dev                       # editable installs of the three libs
 
-# Run a single test file
-uv run pytest libs/idun_agent_engine/tests/unit/agent/test_langgraph.py -v
+# Fast inner loop
+make test                      # all pytest
+make lint                      # ruff check
+make format                    # black + ruff format
+make mypy                      # mypy on engine
+make precommit                 # all pre-commit hooks
+make ci                        # lint + mypy + pytest
 
-# Run a specific test
-uv run pytest tests/unit/agent/test_langgraph.py::test_name -v
+# Standalone runtime
+idun-standalone setup          # alembic migrations + seed from IDUN_CONFIG_PATH
+idun-standalone serve          # uvicorn under create_standalone_app
+idun-standalone init <name>    # first-run launcher (migrate + seed + open browser + serve)
 
-# Skip tests requiring external services
-uv run pytest -m "not requires_langfuse and not requires_phoenix and not requires_postgres"
+# Standalone UI dev
+cd services/idun_agent_standalone_ui
+pnpm install
+pnpm dev                       # local Next.js dev server
+
+# Wheel build (UI bundled into standalone wheel)
+make build-standalone-ui       # builds Next.js, copies static export into the standalone package
+make build-standalone-wheel    # builds the Python wheel
 ```
 
-Tests are in `libs/idun_agent_engine/tests/` with `unit/` and `integration/` subdirectories.
-
-Local `pytest` runs do not globally auto-load the repository `.env` file. Manager tests may read values from `.env` through Pydantic `BaseSettings` (`env_file=".env"`), while engine tests generally rely on environment variables already exported in the shell unless a specific module explicitly calls `load_dotenv()`. If a test needs secrets or service credentials, ensure the required variables are available in your environment before running `uv run pytest`.
-
-## Linting & Formatting
-
-```bash
-make lint                    # Ruff check
-make format                  # Black + Ruff format
-make mypy                    # Type check engine lib
-make precommit               # Run all pre-commit hooks
-make ci                      # lint + mypy + pytest
-```
-
-Pre-commit hooks: Ruff linter/formatter, Pyright (manual stage), Gitleaks secret detection.
-
-## Architecture
-
-**Engine** (`idun_agent_engine`): FastAPI wrapper around agent frameworks. Config-driven (YAML or programmatic). Handles streaming (AG-UI protocol), checkpointing (in-memory/SQLite/PostgreSQL), observability (Langfuse/Phoenix/LangSmith/OpenTelemetry), guardrails (PII detection, topic restriction, toxicity filtering), and MCP tool management. Entry point: `idun` CLI command.
-
-**Manager** (`idun_agent_manager`): Control plane API. Routers in `src/app/api/v1/routers/` for agents, auth (OIDC + session-based), guardrails, memory, observability, MCP servers, workspaces (multi-tenancy). Database models in `src/app/infrastructure/db/models/`. Migrations via Alembic in `alembic/`.
-
-**Web UI** (`idun_agent_web`): Pages in `src/pages/` (login, dashboard, agent forms, settings). Components in `src/components/`. Auto-generated API types in `src/generated/`. Uses styled-components, Monaco Editor, AG-UI client, i18next.
-
-## Database Migrations (Manager)
-
-```bash
-# Create a new migration
-cd services/idun_agent_manager && alembic revision --autogenerate -m "description"
-
-# Run migrations (happens automatically in dev Docker setup)
-alembic upgrade head
-```
-
-## Key Tech Stack
-
-- **Python 3.12+**, FastAPI, SQLAlchemy (async), Pydantic 2.11+, Alembic
-- **Node.js 20 LTS**, React 19, Vite 7, TypeScript
-- **PostgreSQL 16** (asyncpg driver)
-- **Agent frameworks:** LangGraph (primary), Google ADK, Haystack (experimental)
-- **Build:** Hatchling (Python packages), UV workspace with editable local deps
-
-## Conventions
-
-- Python line length: 88 (Black default)
-- Python code uses async throughout (asyncpg, SQLAlchemy async sessions)
-- Ruff for linting, Black for formatting, mypy for type checking
-- Schema changes go in `idun_agent_schema` first, then consumed by engine/manager
-- Branch naming: `feat/*`, `fix/*`, `docs/*`, `chore/*`, `misc/*`
+For service-specific test commands, see the service's CLAUDE.md.
 
 ## Development Principles
 
@@ -138,70 +85,65 @@ alembic upgrade head
 - Test infrastructure must match production patterns (same drivers, same lifecycle).
 
 ### Error Handling
+
 - Use global exception handlers for unexpected errors. Catch locally only when the response or recovery logic differs from the default.
 - `logger.exception()` for unexpected errors (preserves traceback). `logger.error()` only when you intentionally omit the traceback.
 - Never swallow exceptions silently. Never catch `Exception` to re-raise a generic message unless preventing internal detail leaks.
 
 ### Refactoring
+
 - Never reduce error safety when refactoring.
 - Extract only when there are 2+ call sites with meaningfully coupled logic.
 - Don't add abstraction layers for hypothetical future use.
 
 ### Type Safety
+
 - No `Any` unless genuinely unavoidable. Read the source to find the real type.
-- Use dataclasses, `TypedDict`, or Pydantic models for structured data that crosses module boundaries — not raw dicts.
+- Use dataclasses, `TypedDict`, or Pydantic models for structured data crossing module boundaries — not raw dicts.
 
 ### Code Changes
+
 - Read before you write. Understand existing patterns before modifying.
 - Minimize blast radius — change only what's needed for the task.
 - Preserve existing conventions even if you'd do it differently in a greenfield project.
 - Don't mix refactoring with feature work in the same change.
 - Small, focused commits — one concern per commit.
 - When proposing a change, state what could break.
-- Verify assumptions before acting on them (e.g. check if an import is circular before moving it, check if a dependency override matches before rewriting a test).
-
-### Code Quality
-- Run `make lint` and `make precommit` before committing.
-- Only add comments when the logic isn't self-evident. No restating what the code does.
-- Run `make ci` (lint + mypy + pytest) to validate changes end-to-end.
+- Verify assumptions before acting on them (e.g. check if an import is circular before moving it).
 
 ### Decision-Making
+
 - Reason from PEPs, framework docs, and established patterns. State the reasoning.
 - Don't reverse a position based on tone — only on new technical information.
 - When unsure between two valid approaches, state both with trade-offs instead of picking one arbitrarily.
 - If something feels off about a request or approach, say so and explain why. Push back with reasoning rather than complying silently.
 - If the user's suggestion would introduce a bug, reduce safety, or violate a best practice, flag it clearly before proceeding.
 
-### Keeping Documentation Current
-- When you add a major feature, change architecture, or modify conventions in a service, update the corresponding `CLAUDE.md` to reflect the change.
-- This includes new routes, new config options, new env vars, changed module structure, or deprecated behavior.
+## Documentation Workflow
 
-<!-- IDUN-KNOWLEDGE-START -->
-## Shared Knowledge — Idun Knowledge Vault (via Obsidian MCP)
+CLAUDE.md is part of the public contract — read by Claude, contributors, and AI indexers. Keep it current.
 
-This project uses the `idun-knowledge` Obsidian vault as single source of truth. It is connected via the Obsidian MCP server (auto-available in every Claude Code session).
+- **PR scope rule.** If your PR adds, removes, or renames any of: a public function/class, an HTTP route, a CLI command, an env var, a config field, a module, or a top-level directory — update the relevant CLAUDE.md in the same PR. Reviewers reject drift.
+- **Verification anchors.** Volatile blocks (route tables, env var lists, module trees) carry an HTML comment immediately above of the form `<!-- VERIFY: regenerate from <path> -->`, `<!-- VERIFY: confirm against <path>:<symbol> -->`, or `<!-- VERIFY: env vars in <path> -->`. Always verify against source before quoting them.
+- **New paths.** Adding a top-level directory or service requires a one-line entry in the Repository Map above.
+- **Service files own their detail.** Don't restate route tables, env vars, or module trees in this root. Link to the service file instead.
 
-### How to access the vault
-- Use the Obsidian MCP tools to search and read vault notes
-- Do NOT use hardcoded file paths — always go through the MCP
-- You can also write/update vault notes when preserving learnings
+### Service-level template
 
-### Before starting any work, read the relevant vault notes:
-product/architecture.md — platform architecture and tech stack
-product/conventions.md — code style, git workflow, PR rules
-product/roadmap.md — current priorities
-brand/brand-identity.md — for any UI work
-brand/design-tokens.json — design tokens for components
-brand/voice-and-tone.md — for user-facing copy
+Every CLAUDE.md under `libs/` and `services/` must contain these sections in order:
 
-### Memory System
-- Start sessions with `/resume` to load context from vault + recent session logs
-- End sessions with `/compress` to save session log to vault
-- Use `/preserve` to save permanent learnings back to the vault
+1. `# CLAUDE.md — <Package Name>`
+2. **What this is** — 2–4 sentences. What it does, what it's published as, entry points.
+3. **Module map** — directory tree with one-line description per file/folder, prefixed by `<!-- VERIFY: regenerate from src/ tree -->`.
+4. **Public API** *(or "Entry points")* — surface other parts of the system depend on.
+5. **Tests** — how to run, what's in unit/ vs integration/, infrastructure quirks.
+6. **Conventions** — rules specific to this package.
+7. **Deferred features** — table of intentionally absent things a reader might expect.
 
-### Vault Structure
-- `brand/` — Brand identity, colors, typography, voice, design tokens
-- `company/` — Strategy, positioning, clients, processes
-- `product/` — Architecture, conventions, specs, ADRs, roadmap
-- `team/` — Onboarding, Claude Code patterns, workflows
-<!-- IDUN-KNOWLEDGE-END -->
+Plus any of these domain blocks that genuinely apply, in this order: Config flow · Auth · Reload pipeline · Endpoints / routes table · Adapters / integrations table · Settings / environment variables · Build / packaging notes.
+
+## Branch and code conventions
+
+- Branch naming: `feat/*`, `fix/*`, `docs/*`, `chore/*`, `misc/*`.
+- Python line length: 88. Async throughout. Ruff + Black + Mypy.
+- Schema changes land in `idun_agent_schema` first, then engine and standalone consumers. Frontend types regenerate from the standalone OpenAPI spec.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ make precommit                 # all pre-commit hooks
 make ci                        # lint + mypy + pytest
 
 # Standalone runtime
-idun-standalone setup          # alembic migrations + seed from IDUN_CONFIG_PATH
-idun-standalone serve          # uvicorn under create_standalone_app
-idun-standalone init           # first-run launcher (migrate + seed + open browser + serve)
+idun setup          # alembic migrations + seed from IDUN_CONFIG_PATH
+idun serve          # uvicorn under create_standalone_app
+idun init           # first-run launcher (migrate + seed + open browser + serve)
 
 # Standalone UI dev
 cd services/idun_agent_standalone_ui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,16 @@ cd services/idun_agent_standalone_ui
 # Visit http://127.0.0.1:8001
 ```
 
+## Documentation
+
+The repo includes per-package `CLAUDE.md` files that orient contributors (and AI tools) on the architecture, conventions, and current scope of each library and service. These are part of the public contract:
+
+- If your PR adds, removes, or renames a public function or class, an HTTP route, a CLI command, an env var, a config field, a module, or a top-level directory — update the relevant `CLAUDE.md` in the same PR.
+- Volatile blocks (route tables, env var lists, module trees) carry a `<!-- VERIFY: ... -->` HTML comment. Treat the comment as a checklist when editing the block.
+- New top-level directories or services require a one-line entry in the root `CLAUDE.md`'s Repository Map.
+
+Reviewers reject PRs where scope-changing code is not accompanied by a CLAUDE.md update.
+
 ## Code of Conduct
 
 By contributing to this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -11,7 +11,7 @@ You are writing public-facing technical documentation for an open-source AI agen
 When facts conflict, trust in this order:
 
 1. **Code** — schema enums, route definitions, config models, test fixtures
-2. **Service-level CLAUDE.md files** — `libs/idun_agent_engine/CLAUDE.md`, `libs/idun_agent_schema/CLAUDE.md`, `services/idun_agent_manager/CLAUDE.md`, `services/idun_agent_web/CLAUDE.md`
+2. **Service-level CLAUDE.md files** — `libs/idun_agent_schema/CLAUDE.md`, `libs/idun_agent_engine/CLAUDE.md`, `libs/idun_agent_standalone/CLAUDE.md`, `services/idun_agent_standalone_ui/CLAUDE.md`
 3. **Root CLAUDE.md** — `/CLAUDE.md`
 4. **README.md** — repo root and service READMEs
 5. **Existing MkDocs pages** — `/docs/` (reference only, may be stale)
@@ -73,9 +73,9 @@ Before publishing any factual claim:
 
 1. **Framework support** — verify adapter exists in `libs/idun_agent_engine/src/idun_agent_engine/agent/`
 2. **Config options** — verify field exists in `libs/idun_agent_schema/src/idun_agent_schema/engine/`
-3. **API endpoints** — verify route exists in `services/idun_agent_manager/src/app/api/v1/routers/`
+3. **API endpoints** — engine routes in `libs/idun_agent_engine/src/idun_agent_engine/server/routers/`; standalone admin routes in `libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/`
 4. **Guardrail types** — verify enum value in schema `guardrails.py`
-5. **Environment variables** — verify in manager `Settings` class or engine config resolution
+5. **Environment variables** — verify in `libs/idun_agent_standalone/src/idun_agent_standalone/core/settings.py` for standalone, or engine config resolution for engine-only vars
 6. **Integration claims** — verify integration code exists, not just a schema entry
 
 ## Style alignment with idunplatform.com

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -149,8 +149,13 @@ mintlify-docs/
 ├── deployment/
 │   ├── overview.mdx
 │   └── gcp.mdx
-├── manager/
-│   └── overview.mdx
+├── standalone/
+│   ├── overview.mdx
+│   ├── quickstart.mdx
+│   ├── cli.mdx
+│   ├── docker-compose.mdx
+│   ├── cloud-run.mdx
+│   └── customizing-ui.mdx
 ├── cli/
 │   └── overview.mdx
 ├── api-reference/

--- a/libs/idun_agent_engine/CLAUDE.md
+++ b/libs/idun_agent_engine/CLAUDE.md
@@ -1,19 +1,14 @@
 # CLAUDE.md — Idun Agent Engine
 
-## What This Is
+## What this is
 
 `idun_agent_engine` is a Python SDK that wraps agent frameworks (LangGraph, Google ADK, Haystack) into production-ready FastAPI services. Users define their agent and configuration, and the engine handles serving, streaming (AG-UI protocol via CopilotKit), memory, Langgraph checkpointing, observability, guardrails, and MCP tool management.
 
-Published to PyPI as `idun-agent-engine`. CLI entry point: `idun`.
+Published to PyPI as `idun-agent-engine`. The library is consumed programmatically via `create_app()` / `run_server()`; the `idun` CLI lives in the separate `idun_agent_standalone` package.
 
-## Package Structure
+## Module map
 
-There are **two packages** in `src/`:
-
-- `idun_agent_engine/` — The SDK library
-- `idun_platform_cli/` — The CLI (Click + Textual TUI)
-
-## Module Map
+<!-- VERIFY: regenerate from libs/idun_agent_engine/src/idun_agent_engine/ -->
 
 ```
 idun_agent_engine/
@@ -28,8 +23,8 @@ idun_agent_engine/
 │   ├── adk/            # Google ADK adapter. Mature. Session + memory services. Stream not yet implemented.
 │   └── haystack/       # Haystack adapter. Accepts Pipeline or Agent. Basic invoke only. Experimental.
 ├── server/             # FastAPI layer
-│   ├── routers/agent   # /agent/capabilities, /agent/run, /agent/invoke (deprecated), /agent/stream (deprecated), /agent/copilotkit/stream (deprecated), /agent/config
-│   ├── routers/base    # /, /health, /reload
+│   ├── routers/agent   # /agent/capabilities, /agent/run, /agent/sessions, /agent/graph*, /agent/config
+│   ├── routers/base    # /health, /reload, /_engine/info
 │   ├── auth            # OIDCValidator — JWT validation via OIDC JWKS, require_auth dependency
 │   ├── dependencies    # DI: get_agent, get_copilotkit_agent, get_mcp_registry
 │   └── lifespan        # Startup: agent init, guardrails parsing, CopilotKit setup, SSO, telemetry
@@ -55,12 +50,6 @@ idun_agent_engine/
 │   └── helpers         # get_langchain_tools(), get_adk_tools() — convenience functions
 ├── templates/          # Pre-built LangGraph agents (translation, correction, deep_research). Ignore.
 └── telemetry/          # Anonymous usage telemetry (PostHog). Opt-out: IDUN_TELEMETRY_ENABLED=false. Tag deployment: IDUN_DEPLOYMENT_TYPE=cloud|self-hosted
-
-idun_platform_cli/
-├── main.py             # CLI entry: `idun agent serve`, `idun init`
-├── groups/agent/serve  # `idun agent serve --source file --path config.yaml` or `--source manager`
-├── groups/init         # `idun init` — launches Textual TUI for interactive config creation
-└── tui/                # Textual TUI: screens, widgets (chat, observability, guardrails, memory, MCP, serve)
 ```
 
 ## Public API
@@ -80,10 +69,9 @@ from idun_agent_engine import (
 
 ## Configuration Flow
 
-YAML config is preferred. Two sources:
+A local YAML file is the primary boot source. The engine reads `config.yaml` → validates into `EngineConfig` (Pydantic) → builds the FastAPI app → serves.
 
-1. **File-based** (`--source file`): Reads `config.yaml` → validates into `EngineConfig` (Pydantic) → builds FastAPI app → serves.
-2. **Manager-based** (`--source manager`): Requires `IDUN_AGENT_API_KEY` + `IDUN_MANAGER_HOST` env vars → fetches config from manager API → same flow. The config structure is identical in both cases.
+Optional secondary path: `POST /reload` (and `prompts.helpers` / `mcp.helpers`) can fetch config from a remote manager API when `IDUN_AGENT_API_KEY` + `IDUN_MANAGER_HOST` are set. This is a hot-reload escape hatch, not the boot path — see Deferred features.
 
 Config resolution priority in `ConfigBuilder.resolve_config()`:
 1. `engine_config` (pre-validated EngineConfig)
@@ -196,6 +184,8 @@ All adapters implement `BaseAgent` (generic ABC parameterized by config type).
 
 All adapters implement `discover_capabilities()` (returns `AgentCapabilities`) and `run()` (canonical AG-UI interaction, delegates to framework AG-UI wrapper).
 
+<!-- VERIFY: regenerate from libs/idun_agent_engine/src/idun_agent_engine/agent/ -->
+
 | Adapter | Config Model | Graph Loading | Streaming | CopilotKit |
 |---|---|---|---|---|
 | **LanggraphAgent** | `LangGraphAgentConfig` | `graph_definition` → dynamic import → accepts `StateGraph` (preferred) or `CompiledStateGraph` (extracts `.builder`, recompiles with engine checkpointer/store, logs warning) | Full AG-UI event stream via `astream_events` | `LangGraphAGUIAgent` |
@@ -216,17 +206,20 @@ All adapters implement `discover_capabilities()` (returns `AgentCapabilities`) a
 
 ## Server Endpoints
 
+<!-- VERIFY: regenerate from libs/idun_agent_engine/src/idun_agent_engine/server/routers/ -->
+
 | Endpoint | Method | Purpose |
 |---|---|---|
-| `/` | GET | Service info |
 | `/health` | GET | Health check |
-| `/docs` | GET | OpenAPI docs |
 | `/reload` | POST | Hot-reload agent config without restarting the server |
+| `/_engine/info` | GET | Engine introspection (version, capabilities, mounted endpoints) |
 | `/agent/capabilities` | GET | Agent capability discovery (input/output schemas, supported modes) |
-| `/agent/run` | POST | Canonical AG-UI interaction endpoint (accepts RunAgentInput, returns SSE) |
-| `/agent/invoke` | POST | **(Deprecated)** Invoke agent. Use `/agent/run` instead. |
-| `/agent/stream` | POST | **(Deprecated)** Stream AG-UI events. Use `/agent/run` instead. |
-| `/agent/copilotkit/stream` | POST | **(Deprecated)** Stream via CopilotKit. Use `/agent/run` instead. |
+| `/agent/run` | POST | Canonical AG-UI interaction endpoint (accepts `RunAgentInput`, returns SSE) |
+| `/agent/sessions` | GET | List session summaries from the active memory backend |
+| `/agent/sessions/{session_id}` | GET | Fetch a single session's detail |
+| `/agent/graph` | GET | Return the agent graph as `AgentGraph` |
+| `/agent/graph/mermaid` | GET | Render the agent graph as Mermaid |
+| `/agent/graph/ascii` | GET | Render the agent graph as ASCII |
 | `/agent/config` | GET | Get current agent config |
 | `/integrations/whatsapp/webhook` | GET/POST | WhatsApp webhook (GET: Meta verify, POST: receive messages) |
 | `/integrations/discord/webhook` | POST | Discord Interactions Endpoint (Ed25519 verified, handles PING + slash commands) |
@@ -280,19 +273,6 @@ Resolution priority in `get_prompts()`:
 - Supports `stdio` transport (and SSE/HTTP for LangChain adapters).
 - Provides `get_langchain_tools()` for LangGraph agents and `get_adk_toolsets()` for ADK agents.
 
-## CLI
-
-```bash
-# Serve from a config file
-idun agent serve --source file --path config.yaml
-
-# Serve from the manager (requires env vars: IDUN_AGENT_API_KEY and IDUN_MANAGER_HOST)
-idun agent serve --source manager
-
-# Interactive TUI for creating config + launching server
-idun init
-```
-
 ## Key Dependencies
 
 - `idun_agent_schema` — Shared Pydantic models (local editable dep)
@@ -302,26 +282,31 @@ idun init
 - `guardrails-ai` — Guardrails hub
 - `langfuse`, `arize-phoenix`, `opentelemetry-*`, `google-cloud-*` — Observability
 
-## Development
+## Tests
 
 ```bash
-# Run tests
 uv run pytest libs/idun_agent_engine/tests/ -v
 
 # Skip tests requiring external services
-uv run pytest -m "not requires_langfuse and not requires_phoenix and not requires_postgres"
-
-# Lint and format
-make lint && make format
-
-# Type check
-make mypy
+uv run pytest libs/idun_agent_engine/tests/ -m "not requires_langfuse and not requires_phoenix and not requires_postgres"
 ```
+
+Tests are split into `tests/unit/` (module-level) and `tests/integration/` (full-stack with the framework). Tests do not auto-load `.env`; export required vars in your shell before running.
 
 ## Conventions
 
 - All agent operations are async (`initialize`, `invoke`, `stream`).
-- Schema changes go in `idun_agent_schema` first, then consumed here.
 - Observability config is top-level in the YAML, not nested inside `agent.config` (agent-level is deprecated).
 - Dynamic imports for agent loading: file path first, Python module fallback.
 - `CompiledStateGraph` is **accepted** — the engine extracts `.builder` and recompiles with its own checkpointer/store. Compile options (`interrupt_before`/`interrupt_after`) are preserved. A warning is logged. Providing an uncompiled `StateGraph` is preferred. Note: `.builder` is an internal LangGraph attribute (verified on langgraph 1.x), not part of the public API.
+
+## Deferred features
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| `/agent/invoke` (POST) | Deprecated | Compatibility shim registered in `core/app_factory.py`. Use `/agent/run`. |
+| `/agent/stream` (POST) | Deprecated | Marked `deprecated=True` in `server/routers/agent.py`. Use `/agent/run`. |
+| `/agent/copilotkit/stream` (POST) | Deprecated | Marked `deprecated=True` in `server/routers/agent.py`. Use `/agent/run`. |
+| Haystack adapter | Present | Lives in `agent/haystack/`. Basic invoke only; no streaming, no CopilotKit. Treat as experimental. |
+| Manager-fetch config source | Present (secondary) | Hot-reload only via `POST /reload`, plus prompt/MCP helpers. Requires `IDUN_AGENT_API_KEY` + `IDUN_MANAGER_HOST`. Not the primary boot path. |
+| Textual TUI (`idun init`) | Removed | Removed in commit `556e75a2` ("chore(engine): remove TUI and streamlit demo UI"). The `idun` CLI now lives in the separate `idun_agent_standalone` package. |

--- a/libs/idun_agent_engine/CLAUDE.md
+++ b/libs/idun_agent_engine/CLAUDE.md
@@ -4,7 +4,7 @@
 
 `idun_agent_engine` is a Python SDK that wraps agent frameworks (LangGraph, Google ADK, Haystack) into production-ready FastAPI services. Users define their agent and configuration, and the engine handles serving, streaming (AG-UI protocol via CopilotKit), memory, Langgraph checkpointing, observability, guardrails, and MCP tool management.
 
-Published to PyPI as `idun-agent-engine`. The library is consumed programmatically via `create_app()` / `run_server()`; the `idun` CLI lives in the separate `idun_agent_standalone` package.
+Published to PyPI as `idun-agent-engine`. The library is consumed programmatically via `create_app()` / `run_server()`. The `idun` console script source lives in `idun_agent_standalone` but is re-exported by the engine wheel: `[project.scripts] idun = "idun_agent_standalone.cli:main"` plus a `[tool.hatch.build.targets.wheel.force-include]` of the standalone package in `pyproject.toml`. Installing `idun-agent-engine` from PyPI therefore still ships the `idun` command. For the CLI's surface area (commands, flags), see `libs/idun_agent_standalone/CLAUDE.md`.
 
 ## Module map
 
@@ -34,14 +34,22 @@ idun_agent_engine/
 ├── observability/      # Provider-agnostic tracing
 │   ├── base            # ObservabilityHandlerBase ABC, factory functions
 │   ├── langfuse/       # LangChain CallbackHandler integration
-│   ├── phoenix/        # OpenTelemetry + OpenInference instrumentation
+│   ├── langsmith/      # Env-var driven LangSmith tracing (no callbacks; uses LANGSMITH_* vars)
+│   ├── phoenix/        # OpenTelemetry + OpenInference instrumentation (remote collector)
+│   ├── phoenix_local/  # Same as phoenix/, but starts a local Phoenix server via CLI subprocess
 │   ├── gcp_trace/      # Cloud Trace exporter + OpenInference instrumentation
 │   └── gcp_logging/    # Google Cloud Logging (hooks into python logging)
 ├── integrations/       # Messaging/webhook provider integrations
 │   ├── base            # BaseIntegration ABC, setup_integrations() factory, IntegrationProvider dispatch
 │   ├── whatsapp/       # WhatsApp Cloud API: handler (webhook verify + receive), client (send_text_message)
-│   └── discord/        # Discord Interactions Endpoint: handler (Ed25519 verify + slash commands),
-│                       #   client (edit_interaction_response), verify (signature check), integration (app.state setup)
+│   ├── discord/        # Discord Interactions Endpoint: handler (Ed25519 verify + slash commands),
+│   │                   #   client (edit_interaction_response), verify (signature check), integration (app.state setup)
+│   ├── slack/          # Slack Events API: handler (HMAC signing-secret verify), client (chat.postMessage),
+│   │                   #   verify (X-Slack-Signature check), integration (app.state setup)
+│   ├── teams/          # Microsoft Teams (Bot Framework): handler (/messages, Authorization-header verified
+│   │                   #   via BotFrameworkAdapter.process_activity), integration (app.state setup)
+│   └── google_chat/    # Google Chat: handler (Bearer token verify via verify_google_chat_token),
+│                       #   verify (Google ID token check), integration (app.state setup)
 ├── prompts/            # Prompt loading and helpers
 │   ├── __init__        # Re-exports get_prompt
 │   └── helpers         # get_prompt(), get_prompts(), get_prompts_from_file(), get_prompts_from_api()
@@ -206,7 +214,7 @@ All adapters implement `discover_capabilities()` (returns `AgentCapabilities`) a
 
 ## Server Endpoints
 
-<!-- VERIFY: regenerate from libs/idun_agent_engine/src/idun_agent_engine/server/routers/ -->
+<!-- VERIFY: regenerate from server/routers/ + integrations/*/integration.py -->
 
 | Endpoint | Method | Purpose |
 |---|---|---|
@@ -223,6 +231,9 @@ All adapters implement `discover_capabilities()` (returns `AgentCapabilities`) a
 | `/agent/config` | GET | Get current agent config |
 | `/integrations/whatsapp/webhook` | GET/POST | WhatsApp webhook (GET: Meta verify, POST: receive messages) |
 | `/integrations/discord/webhook` | POST | Discord Interactions Endpoint (Ed25519 verified, handles PING + slash commands) |
+| `/integrations/slack/webhook` | POST | Slack Events API webhook (HMAC signing-secret verified via `X-Slack-Signature`) |
+| `/integrations/teams/messages` | POST | Microsoft Teams Bot Framework messages endpoint (Authorization header verified via `BotFrameworkAdapter`) |
+| `/integrations/google-chat/webhook` | POST | Google Chat webhook (Bearer token verified via Google ID token check) |
 
 `/reload` is not currently protected by the SSO dependency used on `/agent/*` routes. Because engine CORS remains wildcard, any browser origin that can reach the agent can call `/reload` cross-origin as well.
 
@@ -241,7 +252,9 @@ Top-level config. Multiple providers can be active simultaneously. All are lazy-
 | Provider | Mechanism | Callbacks? |
 |---|---|---|
 | **Langfuse** | Sets env vars → `CallbackHandler` for LangChain | Yes |
-| **Phoenix** | `phoenix.otel.register()` + `LangChainInstrumentor` | No (global instrumentation) |
+| **LangSmith** | Sets `LANGSMITH_*` env vars → automatic LangChain/LangGraph tracing | No (env-var based) |
+| **Phoenix** | `phoenix.otel.register()` + `LangChainInstrumentor` (remote collector) | No (global instrumentation) |
+| **Phoenix (local)** | Same as Phoenix, plus starts a local Phoenix server via CLI subprocess | No (global instrumentation) |
 | **GCP Trace** | `CloudTraceSpanExporter` + `LangChainInstrumentor` + optional Guardrails/VertexAI/MCP instrumentors | No (global instrumentation) |
 | **GCP Logging** | `google.cloud.logging.Client.setup_logging()` | No (hooks into python logging) |
 
@@ -309,4 +322,4 @@ Tests are split into `tests/unit/` (module-level) and `tests/integration/` (full
 | `/agent/copilotkit/stream` (POST) | Deprecated | Marked `deprecated=True` in `server/routers/agent.py`. Use `/agent/run`. |
 | Haystack adapter | Present | Lives in `agent/haystack/`. Basic invoke only; no streaming, no CopilotKit. Treat as experimental. |
 | Manager-fetch config source | Present (secondary) | Hot-reload only via `POST /reload`, plus prompt/MCP helpers. Requires `IDUN_AGENT_API_KEY` + `IDUN_MANAGER_HOST`. Not the primary boot path. |
-| Textual TUI (`idun init`) | Removed | Removed in commit `556e75a2` ("chore(engine): remove TUI and streamlit demo UI"). The `idun` CLI now lives in the separate `idun_agent_standalone` package. |
+| Textual TUI (`idun init`) | Removed | Removed in commit `556e75a2` ("chore(engine): remove TUI and streamlit demo UI"). The `idun` CLI source now lives in `idun_agent_standalone`, but the engine wheel re-exports the `idun` console script via `[project.scripts]` + `force-include` (see top of this doc). |

--- a/libs/idun_agent_schema/CLAUDE.md
+++ b/libs/idun_agent_schema/CLAUDE.md
@@ -168,11 +168,11 @@ Admin API contracts for the standalone admin surface (the in-process control pla
 | `memory.py` | `StandaloneMemoryRead`, `StandaloneMemoryPatch` |
 | `observability.py` | `StandaloneObservabilityRead`, `StandaloneObservabilityPatch` |
 | `onboarding.py` | `OnboardingState`, `ScanResponse`, `ScanResult`, `DetectedAgent`, `CreateStarterBody`, `CreateFromDetectionBody` |
+| `operational.py` | Reserved (no public types yet) — placeholder for forthcoming audit-log schemas |
 | `prompts.py` | `StandalonePromptCreate / Read / Patch` |
 | `reload.py` | `StandaloneReloadResult`, `StandaloneReloadStatus` |
 | `runtime_status.py` | `StandaloneRuntimeStatus` and friends — runtime introspection payloads |
 | `sso.py` | `StandaloneSsoRead`, `StandaloneSsoPatch` |
-| `operational.py` | Operational utilities used by the admin runtime |
 
 Many of the `Standalone*` models embed engine schemas directly (e.g. `StandaloneMaterializedConfig` wraps `EngineConfig`), so they stay in lockstep with the engine namespace.
 

--- a/libs/idun_agent_schema/CLAUDE.md
+++ b/libs/idun_agent_schema/CLAUDE.md
@@ -1,22 +1,24 @@
 # CLAUDE.md — Idun Agent Schema
 
-## What This Is
+## What this is
 
-`idun_agent_schema` is the **centralized Pydantic model library** shared across the entire Idun Agent Platform. It defines the data contracts between the engine, the manager, and the web UI. Every config structure, API payload, and managed resource schema lives here.
+`idun_agent_schema` is the **centralized Pydantic model library** shared across the Idun Agent Platform. It defines the data contracts between the engine, the standalone admin API, and the web UI. Every config structure, API payload, and managed resource schema lives here.
 
 Published to PyPI as `idun-agent-schema`. Minimal dependencies: `pydantic` + `pydantic-settings` only.
 
-**This is the source of truth for all data shapes.** Schema changes start here, then propagate to engine and manager.
+**This is the source of truth for all data shapes.** Schema changes start here, then propagate to the engine, the standalone admin API, and the web UI.
 
 ## Package Structure
 
-Three namespaces, each with its own `__init__.py`:
+Four namespaces, each with its own `__init__.py`:
 
+<!-- VERIFY: regenerate from libs/idun_agent_schema/src/idun_agent_schema/ -->
 ```
 idun_agent_schema/
 ├── engine/          # Schemas consumed by idun_agent_engine (config YAML → Pydantic)
-├── manager/         # Schemas consumed by idun_agent_manager (API request/response models)
-└── shared/          # Cross-cutting base classes
+├── manager/         # Legacy CRUD models (back-compat; superseded by standalone/)
+├── shared/          # Cross-cutting base classes
+└── standalone/      # Admin API contracts used by the standalone admin surface
 ```
 
 ## Engine Schemas (`engine/`)
@@ -25,6 +27,7 @@ These models define the YAML config structure that the engine parses.
 
 ### Core Config Hierarchy
 
+<!-- VERIFY: confirm against libs/idun_agent_schema/src/idun_agent_schema/engine/engine.py -->
 ```
 EngineConfig                    # Top-level config (engine/engine.py)
 ├── server: ServerConfig        # Server settings (engine/server.py)
@@ -142,23 +145,54 @@ Uses camelCase aliases (`ConfigDict(alias_generator=to_camel, populate_by_name=T
 
 ### Templates
 
-`templates.py`: `TranslationAgentConfig`, `CorrectionAgentConfig`, `DeepResearchAgentConfig` — extend `LangGraphAgentConfig` or `BaseAgentConfig`. Ignore these.
+`templates.py`: `TranslationAgentConfig`, `CorrectionAgentConfig`, `DeepResearchAgentConfig` — extend `LangGraphAgentConfig` or `BaseAgentConfig`. Internal-only pre-built agents; ignore unless extending the engine itself.
+
+## Standalone Schemas (`standalone/`)
+
+Admin API contracts for the standalone admin surface (the in-process control plane that replaces the old manager service). Each module exposes the `Standalone*` Pydantic models that the admin routes accept and return.
+
+<!-- VERIFY: regenerate from libs/idun_agent_schema/src/idun_agent_schema/standalone/ -->
+
+| Module | Purpose |
+|---|---|
+| `agent.py` | `StandaloneAgentRead`, `StandaloneAgentPatch` — current agent config view + partial update |
+| `auth.py` | `StandaloneAuthLoginBody`, `StandaloneAuthChangePasswordBody`, `StandaloneAuthMe`, `StandaloneAuthMutationResult` |
+| `common.py` | Shared response envelopes (`StandaloneMutationResponse`, `StandaloneDeleteResult`, `StandaloneResourceIdentity`, `StandaloneSingletonDeleteResult`) |
+| `config.py` | `StandaloneMaterializedConfig` — full materialized engine config returned by admin endpoints |
+| `diagnostics.py` | `StandaloneReadyzResponse`, `StandaloneReadyzCheckStatus`, `StandaloneConnectionCheck` |
+| `enrollment.py` | `StandaloneEnrollmentInfo`, `StandaloneEnrollmentMode`, `StandaloneEnrollmentStatus` |
+| `errors.py` | `StandaloneAdminError`, `StandaloneErrorCode`, `StandaloneFieldError` (uniform error envelope) |
+| `guardrails.py` | `StandaloneGuardrailCreate / Read / Patch` |
+| `integrations.py` | `StandaloneIntegrationCreate / Read / Patch` |
+| `mcp_servers.py` | `StandaloneMCPServerCreate / Read / Patch` |
+| `memory.py` | `StandaloneMemoryRead`, `StandaloneMemoryPatch` |
+| `observability.py` | `StandaloneObservabilityRead`, `StandaloneObservabilityPatch` |
+| `onboarding.py` | `OnboardingState`, `ScanResponse`, `ScanResult`, `DetectedAgent`, `CreateStarterBody`, `CreateFromDetectionBody` |
+| `prompts.py` | `StandalonePromptCreate / Read / Patch` |
+| `reload.py` | `StandaloneReloadResult`, `StandaloneReloadStatus` |
+| `runtime_status.py` | `StandaloneRuntimeStatus` and friends — runtime introspection payloads |
+| `sso.py` | `StandaloneSsoRead`, `StandaloneSsoPatch` |
+| `operational.py` | Operational utilities used by the admin runtime |
+
+Many of the `Standalone*` models embed engine schemas directly (e.g. `StandaloneMaterializedConfig` wraps `EngineConfig`), so they stay in lockstep with the engine namespace.
 
 ## Manager Schemas (`manager/`)
 
-CRUD models for resources managed via the manager API. Each follows the pattern: `Create`, `Read`, `Patch`.
+Legacy CRUD models from the previous manager service. **Kept for back-compat only** — new admin work should use `standalone/` schemas. Each follows the pattern: `Create`, `Read`, `Patch`.
+
+<!-- VERIFY: regenerate from libs/idun_agent_schema/src/idun_agent_schema/manager/ -->
 
 | Resource | Module | Key Fields |
 |---|---|---|
 | **Agent** | `managed_agent.py` | `name`, `status` (`AgentStatus` enum), `version`, `base_url`, `engine_config` (full `EngineConfig`) |
 | **Guardrail** | `managed_guardrail.py` | `name`, `guardrail` (`ManagerGuardrailConfig`) |
-| **MCP Server** | `managed_mcp_server.py` | `name`, `mcp_server` (`MCPServer`) |
+| **MCP Server** | `managed_mcp_server.py` | `name`, `mcp_server` (`MCPServer`), plus `MCPToolSchema`, `MCPToolsResponse` |
 | **Memory** | `managed_memory.py` | `name`, `agent_framework`, `memory` (`CheckpointConfig \| SessionServiceConfig`) |
 | **Observability** | `managed_observability.py` | `name`, `observability` (`ObservabilityConfig` V2) |
 | **SSO** | `managed_sso.py` | `name`, `sso` (`SSOConfig`) |
 | **Integration** | `managed_integration.py` | `name`, `integration` (`IntegrationConfig`) |
 | **Prompt** | `managed_prompt.py` | `prompt_id`, `content`, `tags` (Create); adds `id`, `version`, `created_at`, `updated_at` (Read); `tags` only (Patch) |
-| **API Key** | `api.py` | `api_key` (str) |
+| **API Key** | `api.py` | `ApiKeyResponse` (`api_key` str) |
 
 **`AgentStatus`** enum: `DRAFT`, `ACTIVE`, `INACTIVE`, `DEPRECATED`, `ERROR`
 
@@ -168,24 +202,35 @@ CRUD models for resources managed via the manager API. Each follows the pattern:
 
 `SharedBaseModel` (`shared/base.py`): `pydantic-settings` `BaseSettings` subclass with camelCase alias generation and env var fallback. For models that need both frontend-friendly JSON keys and env var population.
 
-## Conventions
-
-- **CamelCase aliases**: Most models use `ConfigDict(alias_generator=to_camel, populate_by_name=True)` for frontend compatibility. Fields accept both `snake_case` and `camelCase`.
-- **Discriminated unions**: Used for checkpointer configs (`type` field), ADK session/memory configs (`type` field).
-- **Env var resolution**: V1 observability supports `${VAR}` syntax in YAML values, resolved via `_resolve_env()`.
-- **Schema changes flow**: Change here first → update engine/manager consumers → update frontend generated types.
-- **Pydantic 2.11+**: Uses `model_validator`, `field_validator`, `ConfigDict`, `Field` with `alias`.
-- **No runtime dependencies beyond Pydantic** (+ `jinja2` for `PromptConfig.format()`): This package must stay lightweight. `langchain_core` is lazy-imported only inside `to_langchain()` — not a declared dependency.
-
-## Development
+## Tests
 
 ```bash
-# Lint
+# Lint + format
 uv run ruff check libs/idun_agent_schema/
-
-# Format
 uv run black libs/idun_agent_schema/
 
 # Type check
 cd libs/idun_agent_schema && uv run mypy src/
+
+# Run schema unit tests (covers the standalone/ namespace)
+uv run pytest libs/idun_agent_schema/tests/ -v
 ```
+
+Real pytest tests live in `libs/idun_agent_schema/tests/standalone/` (one file per standalone module — `test_agent.py`, `test_config.py`, `test_guardrails.py`, etc.) plus `test_namespace.py`, which guards the public re-exports of the package. The engine and shared/manager namespaces have no dedicated test suite here — their contracts are exercised by the engine and standalone test suites. If you change a schema, run `make ci` to ensure consumers still validate.
+
+## Conventions
+
+- **CamelCase aliases**: Most models use `ConfigDict(alias_generator=to_camel, populate_by_name=True)` for frontend compatibility. Fields accept both `snake_case` and `camelCase`.
+- **Discriminated unions**: Used for checkpointer configs (`type` field), ADK session/memory configs (`type` field), and several `Standalone*` payloads.
+- **Env var resolution**: V1 observability supports `${VAR}` syntax in YAML values, resolved via `_resolve_env()`.
+- **Pydantic 2.11+**: Uses `model_validator`, `field_validator`, `ConfigDict`, `Field` with `alias`.
+- **No runtime dependencies beyond Pydantic** (+ `jinja2` for `PromptConfig.format()`): This package must stay lightweight. `langchain_core` is lazy-imported only inside `to_langchain()` — not a declared dependency.
+
+## Deferred features
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| V1 observability (`engine/observability.py`) | Deprecated | V2 (`observability_v2.py`) is the standard at top-level `EngineConfig.observability`. |
+| V1 guardrails (`engine/guardrails.py`) | Deprecated | V2 (`guardrails_v2.py`) is the standard. |
+| Manager schemas (`manager/`) | Active (back-compat) | Superseded by `standalone/`. Kept so external consumers and frozen migrations keep importing without breaking. New admin work uses `standalone/`. |
+| Templates (`engine/templates.py`) | Internal-only | Pre-built LangGraph agents (translation/correction/deep_research). Ignored by external consumers. |

--- a/libs/idun_agent_standalone/CLAUDE.md
+++ b/libs/idun_agent_standalone/CLAUDE.md
@@ -8,6 +8,7 @@ Published to PyPI as `idun-agent-standalone`. CLI entry point: `idun-standalone`
 
 ## Module map
 
+<!-- VERIFY: regenerate from libs/idun_agent_standalone/src/idun_agent_standalone/ -->
 ```
 idun_agent_standalone/
 ├── cli.py                    # Click commands: setup, serve
@@ -61,12 +62,14 @@ Two modes, gated by `IDUN_ADMIN_AUTH_MODE`:
 - `none` — open admin (laptop default). `require_auth` is a pass-through.
 - `password` — bcrypt-hashed admin password + signed session cookie. Strict-minimum scope: login / logout / change-password / me, no rate-limit, no CSRF token, no sliding renewal, no rotation invalidation of outstanding sessions.
 
+<!-- VERIFY: env vars in libs/idun_agent_standalone/src/idun_agent_standalone/core/settings.py -->
 Required env vars in password mode:
 
 - `IDUN_SESSION_SECRET` — at least 32 characters; signs the `idun_session` cookie. Startup fails fast with `SettingsValidationError` when shorter.
 - `IDUN_ADMIN_PASSWORD_HASH` — bcrypt hash, only consulted at first boot to seed the admin row. Generate with `idun-standalone hash-password` and export. Once the row exists, the env var is ignored.
 - `IDUN_SESSION_TTL_HOURS` — defaults to 24, range `[1, 720]`.
 
+<!-- VERIFY: regenerate from libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/auth.py -->
 Endpoints (`/admin/api/v1/auth/`):
 
 - `GET /me` — `{authenticated, authMode}`. In `none` mode always authenticated. In `password` mode reflects the cookie/session lookup.

--- a/libs/idun_agent_standalone/CLAUDE.md
+++ b/libs/idun_agent_standalone/CLAUDE.md
@@ -4,7 +4,7 @@
 
 `idun_agent_standalone` is a single-process, single-tenant agent runtime. It wraps `idun-agent-engine` with an embedded admin REST surface, an in-process reload pipeline, and a bundled Next.js UI (chat plus admin pages). One agent per install — laptop, VM, or Cloud Run.
 
-Published to PyPI as `idun-agent-standalone`. CLI entry point: `idun-standalone`.
+Published to PyPI as `idun-agent-standalone`. CLI entry point: `idun`.
 
 ## Module map
 
@@ -44,14 +44,14 @@ Empty legacy directories (`admin/`, `auth/`, `theme/`, `traces/`) remain only as
 
 ## Key entry points
 
-- `idun-standalone init` — first-run launcher. Runs migrations + seed + opens the browser at `http://<host>:<port>/` + boots uvicorn. Idempotent. `--port` flag (or `IDUN_PORT` env), `--no-browser` flag for Cloud Run / headless. The browser handles the wizard-or-chat conditional via the chat root's `getAgent` 200/404 redirect.
-- `idun-standalone setup` — runs Alembic migrations and seeds the DB from `IDUN_CONFIG_PATH` if empty.
-- `idun-standalone serve` — runs `create_standalone_app(settings)` under uvicorn in the same event loop.
+- `idun init` — first-run launcher. Runs migrations + seed + opens the browser at `http://<host>:<port>/` + boots uvicorn. Idempotent. `--port` flag (or `IDUN_PORT` env), `--no-browser` flag for Cloud Run / headless. The browser handles the wizard-or-chat conditional via the chat root's `getAgent` 200/404 redirect.
+- `idun setup` — runs Alembic migrations and seeds the DB from `IDUN_CONFIG_PATH` if empty.
+- `idun serve` — runs `create_standalone_app(settings)` under uvicorn in the same event loop.
 - `create_standalone_app(settings: StandaloneSettings) -> FastAPI` — public async factory used by tests and embedders.
 
 ## Config flow
 
-1. **First boot**: operator runs `idun-standalone setup`. If the DB is empty and `IDUN_CONFIG_PATH` points to a YAML file, `infrastructure/scripts/seed.seed_from_yaml_if_empty` materializes the admin tables.
+1. **First boot**: operator runs `idun setup`. If the DB is empty and `IDUN_CONFIG_PATH` points to a YAML file, `infrastructure/scripts/seed.seed_from_yaml_if_empty` materializes the admin tables.
 2. **Steady state**: the DB is the source of truth. `services/engine_config.assemble_engine_config()` materializes a fresh `EngineConfig` for the engine on every (re)load.
 3. **Admin write**: every admin REST mutation runs through `services/reload.commit_with_reload`, which (a) reassembles + validates the engine config, (b) on success calls the engine reload callable so the running engine picks up the new shape, (c) on failure rolls back the DB write so the API surface remains consistent.
 
@@ -66,7 +66,7 @@ Two modes, gated by `IDUN_ADMIN_AUTH_MODE`:
 Required env vars in password mode:
 
 - `IDUN_SESSION_SECRET` — at least 32 characters; signs the `idun_session` cookie. Startup fails fast with `SettingsValidationError` when shorter.
-- `IDUN_ADMIN_PASSWORD_HASH` — bcrypt hash, only consulted at first boot to seed the admin row. Generate with `idun-standalone hash-password` and export. Once the row exists, the env var is ignored.
+- `IDUN_ADMIN_PASSWORD_HASH` — bcrypt hash, only consulted at first boot to seed the admin row. Generate with `idun hash-password` and export. Once the row exists, the env var is ignored.
 - `IDUN_SESSION_TTL_HOURS` — defaults to 24, range `[1, 720]`.
 
 <!-- VERIFY: regenerate from libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/auth.py -->
@@ -113,8 +113,8 @@ These were present in the pre-rework standalone but have **no router or service 
 | Real password auth (login, logout, change-password, /me) | `auth/` | **Implemented** in strict-minimum scope; see "Auth" above. Sliding renewal, rotation invalidation, rate-limit, CSRF token still deferred. |
 | `/admin/api/v1/theme` (theme model + admin route) | `theme/` | The runtime-config bootstrap (`runtime_config.py`) still exposes a default theme to the SPA, but there is no admin route to mutate it |
 | Traces (AG-UI run-event observer, batched writer to `trace_event`, hourly retention purge via APScheduler) | `traces/` | Backend dropped; `trace_event` table is not materialized by the baseline migration. UI pages under `/traces` will 404 against the API |
-| `idun-standalone init <name>` scaffold command | `scaffold.py` | **Restored** — see "Key entry points" above. Now a thin launcher (migrations + seed + browser + serve), not the legacy multi-file scaffolder. |
-| `idun-standalone hash-password` | `cli.py` | **Restored** — generates a bcrypt hash for `IDUN_ADMIN_PASSWORD_HASH`. |
+| `idun init <name>` scaffold command | `scaffold.py` | **Restored** — see "Key entry points" above. Now a thin launcher (migrations + seed + browser + serve), not the legacy multi-file scaffolder. |
+| `idun hash-password` | `cli.py` | **Restored** — generates a bcrypt hash for `IDUN_ADMIN_PASSWORD_HASH`. |
 | `idun-standalone export` | `config_io.py` | Removed; YAML export comes back with the materialized-config endpoints (deferred) |
 | `runtime.py` (live agent handle, observer registration after each reload) | top-level | Removed with traces |
 

--- a/services/idun_agent_standalone_ui/CLAUDE.md
+++ b/services/idun_agent_standalone_ui/CLAUDE.md
@@ -6,6 +6,7 @@ A Next.js 15 + Tailwind v4 + React 19 SPA shipped as a static export. Bundled in
 
 ## Routes
 
+<!-- VERIFY: regenerate from services/idun_agent_standalone_ui/app/ -->
 | Route | Status |
 | --- | --- |
 | `/` | Chat UI; layout switched at runtime (branded / minimal / inspector) |
@@ -16,7 +17,7 @@ A Next.js 15 + Tailwind v4 + React 19 SPA shipped as a static export. Bundled in
 | `/admin/observability` | Observability singleton — wired to `/admin/api/v1/observability` |
 | `/admin/integrations` | Integrations collection — partially migrated; still references the old `kind` field |
 | `/admin/prompts` | Prompts versioned collection — wired to `/admin/api/v1/prompts` |
-| `/admin/settings` | Theme + password sections — **runtime 404** (deferred backend; see "Half-migration state") |
+| `/admin/settings` | Theme + password sections — **runtime 404** (deferred backend; see "Deferred features") |
 | `/admin` | Dashboard with sessions list — **runtime 404** (sessions route deferred) |
 | `/login` | Password sign-in — **runtime 404** (deferred backend) |
 | `/traces`, `/traces/session` | Sessions list, run timeline, event detail — **runtime 404** (traces dropped from backend) |
@@ -38,17 +39,18 @@ All admin calls go through `lib/api/`:
 
 Errors are normalized to `ApiError` with `status` and `detail` fields.
 
-## Half-migration state
+## Deferred features
 
-`next.config.mjs` sets `typescript: { ignoreBuildErrors: true }`. This is intentional and temporary.
+| Page / feature | Status | Notes |
+| --- | --- | --- |
+| `/admin/settings` (theme + password) | Runtime 404 | Backend deferred. Page references will typecheck-fail until restored or deleted. |
+| `/admin` dashboard with sessions list | Runtime 404 | Sessions backend deferred. |
+| `/login` password sign-in | Runtime 404 | Standalone backend implements password auth in strict-minimum scope; the SPA login page wiring is on a separate branch. |
+| `/traces`, `/traces/session` | Runtime 404 | Traces backend dropped from baseline migration; `trace_event` table not materialized. |
+| `/logs` live tail | Runtime 404 | No backend route. |
+| `/admin/integrations` (still uses old `kind` field) | Half-migrated | Update to current `IntegrationConfig` shape when revisiting messaging integrations. |
 
-The Phase 6 UI rewrite migrated five admin pages (agent, memory, mcp, observability, prompts) to `lib/api/`, but several pages and components still reference the previous API client shape and the old backend features (auth login/logout/change-password, theme, traces sessions). Those pages typecheck-fail; the build flag lets the static export keep shipping.
-
-`tsc --noEmit` lists the remaining gaps — fix or delete the broken references when:
-- the corresponding backend feature returns (auth, theme, traces), or
-- the deferred decision turns into "drop the page".
-
-Once all pages compile, flip `ignoreBuildErrors` back to `false`.
+`next.config.mjs` sets `typescript: { ignoreBuildErrors: true }` to allow shipping while these gaps exist. `tsc --noEmit` lists the remaining gaps. Flip the flag back to `false` once every page above is either restored or deleted.
 
 ## AG-UI
 
@@ -63,6 +65,19 @@ npm run build       # produces ./out (static export)
 ```
 
 The repo Make target `build-standalone-ui` runs the build and copies `out/` into `libs/idun_agent_standalone/src/idun_agent_standalone/static/`.
+
+## Tests
+
+```bash
+cd services/idun_agent_standalone_ui
+
+pnpm typecheck                 # tsc --noEmit (currently leaks via ignoreBuildErrors — see Deferred)
+pnpm test                      # vitest unit tests
+pnpm test:e2e                  # playwright; auto-boots the standalone server
+pnpm build                     # static export → ./out
+```
+
+Unit tests live alongside source in `__tests__/`. End-to-end tests live in `e2e/`; the suite uses `e2e/boot-standalone.sh` to start a real Python standalone process before driving the browser.
 
 ## Conventions
 

--- a/services/idun_agent_standalone_ui/CLAUDE.md
+++ b/services/idun_agent_standalone_ui/CLAUDE.md
@@ -19,7 +19,7 @@ A Next.js 15 + Tailwind v4 + React 19 SPA shipped as a static export. Bundled in
 | `/admin/prompts` | Prompts versioned collection — wired to `/admin/api/v1/prompts` |
 | `/admin/settings` | Theme + password sections — **runtime 404** (deferred backend; see "Deferred features") |
 | `/admin` | Dashboard with sessions list — **runtime 404** (sessions route deferred) |
-| `/login` | Password sign-in — **runtime 404** (deferred backend) |
+| `/login` | Password sign-in — **runtime 404** (SPA wiring deferred; standalone backend exists) |
 | `/traces`, `/traces/session` | Sessions list, run timeline, event detail — **runtime 404** (traces dropped from backend) |
 | `/logs` | Live tail of recent events — **runtime 404** (no backend route) |
 
@@ -39,19 +39,6 @@ All admin calls go through `lib/api/`:
 
 Errors are normalized to `ApiError` with `status` and `detail` fields.
 
-## Deferred features
-
-| Page / feature | Status | Notes |
-| --- | --- | --- |
-| `/admin/settings` (theme + password) | Runtime 404 | Backend deferred. Page references will typecheck-fail until restored or deleted. |
-| `/admin` dashboard with sessions list | Runtime 404 | Sessions backend deferred. |
-| `/login` password sign-in | Runtime 404 | Standalone backend implements password auth in strict-minimum scope; the SPA login page wiring is on a separate branch. |
-| `/traces`, `/traces/session` | Runtime 404 | Traces backend dropped from baseline migration; `trace_event` table not materialized. |
-| `/logs` live tail | Runtime 404 | No backend route. |
-| `/admin/integrations` (still uses old `kind` field) | Half-migrated | Update to current `IntegrationConfig` shape when revisiting messaging integrations. |
-
-`next.config.mjs` sets `typescript: { ignoreBuildErrors: true }` to allow shipping while these gaps exist. `tsc --noEmit` lists the remaining gaps. Flip the flag back to `false` once every page above is either restored or deleted.
-
 ## AG-UI
 
 Hand-rolled SSE reader in `lib/agui.ts` — no `@ag-ui/client` dependency. Streams events from `/agent/run`, dispatches them into the chat store, and reconnects on transient failures. Keeps the bundle small.
@@ -60,8 +47,8 @@ Hand-rolled SSE reader in `lib/agui.ts` — no `@ag-ui/client` dependency. Strea
 
 ```bash
 cd services/idun_agent_standalone_ui
-npm install
-npm run build       # produces ./out (static export)
+pnpm install
+pnpm build          # produces ./out (static export)
 ```
 
 The repo Make target `build-standalone-ui` runs the build and copies `out/` into `libs/idun_agent_standalone/src/idun_agent_standalone/static/`.
@@ -77,7 +64,7 @@ pnpm test:e2e                  # playwright; auto-boots the standalone server
 pnpm build                     # static export → ./out
 ```
 
-Unit tests live alongside source in `__tests__/`. End-to-end tests live in `e2e/`; the suite uses `e2e/boot-standalone.sh` to start a real Python standalone process before driving the browser.
+Unit tests live in the top-level `__tests__/` directory, organized by surface (`__tests__/api/`, `__tests__/onboarding/`, `__tests__/tour/`, plus component-level files at the root). End-to-end tests live in `e2e/`; the suite uses `e2e/boot-standalone.sh` to start a real Python standalone process before driving the browser.
 
 ## Conventions
 
@@ -85,3 +72,16 @@ Unit tests live alongside source in `__tests__/`. End-to-end tests live in `e2e/
 - Components are grouped by surface: `components/{ui,admin,chat,traces,common}/`.
 - All fetches go through `lib/api/` — components never call `fetch` directly.
 - Styles via Tailwind utilities + CSS variables; no styled-components.
+
+## Deferred features
+
+| Page / feature | Status | Notes |
+| --- | --- | --- |
+| `/admin/settings` (theme + password) | Runtime 404 | Backend deferred. Page references will typecheck-fail until restored or deleted. |
+| `/admin` dashboard with sessions list | Runtime 404 | Sessions backend deferred. |
+| `/login` password sign-in | Runtime 404 | Standalone backend implements password auth in strict-minimum scope; the SPA login page wiring is on a separate branch. |
+| `/traces`, `/traces/session` | Runtime 404 | Traces backend dropped from baseline migration; `trace_event` table not materialized. |
+| `/logs` live tail | Runtime 404 | No backend route. |
+| `/admin/integrations` (still uses old `kind` field) | Half-migrated | Update to current `IntegrationConfig` shape when revisiting messaging integrations. |
+
+`next.config.mjs` sets `typescript: { ignoreBuildErrors: true }` to allow shipping while these gaps exist. `tsc --noEmit` lists the remaining gaps. Flip the flag back to `false` once every page above is either restored or deleted.


### PR DESCRIPTION
## Summary

- Rewrite root `CLAUDE.md` for the standalone pivot: drop manager/web/TUI references, frame standalone as the product target, add **Constitution**, **Repository Map**, and **Documentation Workflow** sections.
- Standardize service-level CLAUDE.md files on a shared template (required core sections + domain-block menu + service-level template restated in the root).
- Add `<!-- VERIFY: ... -->` anchors on volatile content (route tables, module trees, env var lists) across `engine`, `schema`, `standalone`, and `standalone-ui`.
- Schema CLAUDE.md gains a new `## Standalone Schemas` section documenting the `standalone/` namespace (19 modules) that wasn't previously covered.
- Update `docs/CLAUDE.md` source-of-truth list to match the new package layout; remove the stale `docs/manager/` tree entry.
- Add a **Documentation** section to `CONTRIBUTING.md` codifying the PR scope rule for keeping CLAUDE.md files current.
- Reconcile CLI command-name docs: the installed binary is `idun` everywhere (registered by the engine wheel via `[project.scripts]` + force-include of standalone source).

Spec + plan: see `idun-dev/tasks/claude-md-overhaul-08-05-2026/`.

## Files changed

- `CLAUDE.md` — full rewrite (~150 lines)
- `libs/idun_agent_engine/CLAUDE.md` — surgical refactor + 3 VERIFY anchors
- `libs/idun_agent_schema/CLAUDE.md` — surgical refactor + 4 VERIFY anchors + new Standalone Schemas section
- `libs/idun_agent_standalone/CLAUDE.md` — 3 VERIFY anchors + CLI naming fix
- `services/idun_agent_standalone_ui/CLAUDE.md` — Tests + Deferred features sections + 1 VERIFY anchor
- `docs/CLAUDE.md` — source-of-truth list update
- `CONTRIBUTING.md` — Documentation section added

## Test plan

- [ ] Each CLAUDE.md renders correctly on GitHub.
- [ ] No file references the removed `idun_agent_manager`, `idun_agent_web`, `make dev-manager`, or the Textual TUI as live components.
- [ ] Each service-level CLAUDE.md contains the 7 required core sections.
- [ ] VERIFY anchors point at real source paths.
- [ ] CLI commands documented (`idun setup/serve/init/hash-password`) match `libs/idun_agent_engine/pyproject.toml` `[project.scripts]`.
- [ ] `make precommit` passes (no code touched, but markdown changes pass any pre-commit hooks).

## Out of scope

- CI scripts that auto-verify CLAUDE.md content against source (future enhancement).
- Reviving deferred features.
- Updating README.md or `docs/` Mintlify content for CLI naming (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)