### PR TITLE
feat(cli): port track_command telemetry to consolidated idun CLI

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -49,16 +49,14 @@ reviews:
     - "!services/idun_agent_standalone_ui/public/**"
     - "!libs/idun_agent_standalone/src/**/_static_ui/**"
     - "!**/*.snap"
-    - "!**/*.svg"
-    - "!**/*.min.js"
-    - "!**/*.min.css"
     - "!docs/snippets/_generated/**"
 
   path_instructions:
     # ---------- Python (cross-cutting) ----------
     - path: "**/*.py"
       instructions: |
-        - All I/O paths must be async (asyncpg, httpx.AsyncClient, async SQLAlchemy sessions). Flag any blocking call inside an `async def`.
+        - Inside any `async def`, flag blocking I/O (sync DB drivers, `requests`, `time.sleep`, blocking file reads on hot paths). Use `asyncpg`, `httpx.AsyncClient`, async SQLAlchemy sessions, or `asyncio.to_thread` for unavoidable sync calls.
+        - For runtime application code under `libs/idun_agent_engine/src/**` and `libs/idun_agent_standalone/src/**`, prefer async-first APIs at module boundaries. Sync is acceptable in Alembic revisions, tests, scripts in `scripts/`, and one-off CLI utilities.
         - No `Any` unless genuinely unavoidable. Read the source for the real type. Prefer Pydantic models, dataclasses, or TypedDict for data crossing module boundaries — not raw dicts.
         - `logger.exception(...)` for unexpected errors (preserves traceback). `logger.error(...)` only when the traceback is intentionally omitted.
         - Never catch bare `Exception` to re-raise a generic message. Do not swallow exceptions silently.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -87,6 +87,18 @@ reviews:
         - Engine init failures must roll back the DB write. Flag any admin route that mutates DB state without that rollback path.
         - Don't duplicate engine logic. If a helper feels useful here, push it down into engine first.
 
+    # ---------- Telemetry / observability helpers ----------
+    - path: "**/{telemetry,observability,_telemetry}*.py"
+      instructions: |
+        Telemetry and observability code must never alter command or
+        runtime semantics. Wrap every call (singleton init, capture,
+        flush/shutdown) in its own try/except Exception and log with
+        `logger.exception(...)` to preserve the traceback. Gate
+        downstream telemetry calls on the client/handle being non-None
+        — a failed init must not skip the wrapped function or mask its
+        exceptions. Never let a telemetry failure replace the original
+        exception in an except branch.
+
     # ---------- Alembic migrations ----------
     - path: "**/alembic/versions/*.py"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -87,18 +87,6 @@ reviews:
         - Engine init failures must roll back the DB write. Flag any admin route that mutates DB state without that rollback path.
         - Don't duplicate engine logic. If a helper feels useful here, push it down into engine first.
 
-    # ---------- Telemetry / observability helpers ----------
-    - path: "**/{telemetry,observability,_telemetry}*.py"
-      instructions: |
-        Telemetry and observability code must never alter command or
-        runtime semantics. Wrap every call (singleton init, capture,
-        flush/shutdown) in its own try/except Exception and log with
-        `logger.exception(...)` to preserve the traceback. Gate
-        downstream telemetry calls on the client/handle being non-None
-        — a failed init must not skip the wrapped function or mask its
-        exceptions. Never let a telemetry failure replace the original
-        exception in an except branch.
-
     # ---------- Alembic migrations ----------
     - path: "**/alembic/versions/*.py"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,201 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit configuration for idun-agent-platform.
+# Reference: https://docs.coderabbit.ai/reference/configuration
+# Path-instruction guidance complements (does not replace) CLAUDE.md, which
+# CodeRabbit auto-loads as Code Guidelines from the repo root and per-package.
+
+language: "en-US"
+early_access: false
+tone_instructions: "Be direct and technical. Skip preamble and pleasantries. Cite the specific line and recommended fix."
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: true
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+  poem: false
+  in_progress_fortune: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    base_branches:
+      - "develop"
+      - "main"
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "[skip review]"
+
+  # Skip lock files, build output, generated assets, and the bundled UI
+  # static export that ships inside the standalone wheel.
+  path_filters:
+    - "!uv.lock"
+    - "!**/poetry.lock"
+    - "!**/.next/**"
+    - "!**/.turbo/**"
+    - "!services/idun_agent_standalone_ui/public/**"
+    - "!libs/idun_agent_standalone/src/**/_static_ui/**"
+    - "!**/*.snap"
+    - "!**/*.svg"
+    - "!**/*.min.js"
+    - "!**/*.min.css"
+    - "!docs/snippets/_generated/**"
+
+  path_instructions:
+    # ---------- Python (cross-cutting) ----------
+    - path: "**/*.py"
+      instructions: |
+        - All I/O paths must be async (asyncpg, httpx.AsyncClient, async SQLAlchemy sessions). Flag any blocking call inside an `async def`.
+        - No `Any` unless genuinely unavoidable. Read the source for the real type. Prefer Pydantic models, dataclasses, or TypedDict for data crossing module boundaries — not raw dicts.
+        - `logger.exception(...)` for unexpected errors (preserves traceback). `logger.error(...)` only when the traceback is intentionally omitted.
+        - Never catch bare `Exception` to re-raise a generic message. Do not swallow exceptions silently.
+        - Line length 88 (Black default). Don't suggest reformatting beyond what `ruff format` / `black` would do.
+        - Don't request docstrings purely for the sake of coverage; only flag missing docstrings on public APIs where the WHY is non-obvious.
+
+    # ---------- Schema library (the contract) ----------
+    - path: "libs/idun_agent_schema/**/*.py"
+      instructions: |
+        - This package is the public Pydantic contract. Any field rename, removal, or type-narrowing is a breaking change for engine, standalone, and the UI types.
+        - Flag breaking changes loudly and require a migration note in the PR description.
+        - Prefer Pydantic discriminated unions for polymorphic config. New variants must keep existing discriminator values stable.
+        - Validators should be pure: no I/O, no logging.
+
+    # ---------- Engine (runtime source of truth) ----------
+    - path: "libs/idun_agent_engine/**/*.py"
+      instructions: |
+        - This is the runtime source of truth. Standalone composes engine — never the other way around.
+        - AG-UI is the streaming contract. Don't introduce a parallel protocol or invent new event types without an ADR.
+        - Adapters (LangGraph / ADK) must stay framework-isolated. Engine code outside `agent/<framework>/` should not import framework-specific symbols.
+        - Guardrails / observability / MCP integrations are opt-in and config-driven. Failing-open vs failing-closed must be explicit.
+
+    # ---------- Standalone (single-process product) ----------
+    - path: "libs/idun_agent_standalone/**/*.py"
+      instructions: |
+        - Single-process, single-tenant. One agent per install. Reject changes that introduce multi-tenant assumptions here.
+        - DB is steady-state truth. YAML seeds run at first boot only; runtime mutations must flow through the admin REST and the validate-rebuild-reload pipeline.
+        - Engine init failures must roll back the DB write. Flag any admin route that mutates DB state without that rollback path.
+        - Don't duplicate engine logic. If a helper feels useful here, push it down into engine first.
+
+    # ---------- Alembic migrations ----------
+    - path: "**/alembic/versions/*.py"
+      instructions: |
+        - Every migration needs a working `downgrade()`. Flag empty or `pass` downgrades unless the upgrade is genuinely irreversible (and explain why in a comment).
+        - Backfills on large tables must be batched and concurrency-safe. NOT NULL on a populated column requires a backfill and a separate ALTER step.
+        - Avoid renaming columns/tables in a single revision when the running app still references the old name — split into add → backfill → switch → drop revisions.
+        - Don't import application code (models, settings) at module top level — use the bound metadata only.
+
+    # ---------- Standalone UI (Next.js / React 19 / TS) ----------
+    - path: "services/idun_agent_standalone_ui/**/*.{ts,tsx}"
+      instructions: |
+        - No `any`. Use the generated types from `src/generated/` for anything crossing the API boundary; don't hand-roll request/response shapes.
+        - AG-UI streaming uses the official client. Don't re-implement event parsing.
+        - Server-only code must not leak into client bundles. Flag `process.env` reads in components and missing `"use server"` / `"use client"` directives where they matter.
+        - Prefer composition over prop drilling more than 2 levels deep; suggest context only when state is genuinely cross-cutting.
+
+    # ---------- Tests ----------
+    - path: "**/tests/**/*.py"
+      instructions: |
+        - Test infrastructure must match production patterns: real PostgreSQL via testcontainers or the docker-compose dev DB, NOT mocks of the DB layer. The engine and manager DB lifecycles regressed in the past when mocked.
+        - No broad `except Exception` in tests — let unexpected failures surface.
+        - Descriptive test names (`test_<scenario>_<expected_outcome>`). Flag opaque names like `test_1`, `test_works`.
+        - One concern per test. Split assertions that test independent behaviours into separate tests.
+
+    # ---------- Docker ----------
+    - path: "docker/**/Dockerfile*"
+      instructions: |
+        - Multi-stage builds. The final stage must not contain build toolchains (uv, gcc, node_modules dev deps).
+        - Pin base images by digest where feasible; at minimum pin to a specific tag, not `latest`.
+        - `COPY` ordering should maximize layer cache hits: dependencies before source.
+
+    # ---------- CI / GitHub Actions ----------
+    - path: ".github/workflows/**/*.{yml,yaml}"
+      instructions: |
+        - All actions must be pinned by SHA, not by tag. Flag any `uses: org/repo@v1` style pin.
+        - Secrets must come from `secrets.*`; flag any hardcoded token or environment leak via `echo`.
+        - Long-running jobs should set explicit `timeout-minutes`.
+
+    # ---------- Mintlify docs ----------
+    - path: "docs/**/*.{md,mdx}"
+      instructions: |
+        - Check for accuracy first, prose second. Flag references to deprecated routes, removed env vars, or old config field names.
+        - Internal links must resolve to existing pages in this docs/ tree. External links should use HTTPS.
+        - Code samples must be runnable as-is when the user copies them — flag missing imports or undefined variables.
+
+    # ---------- Examples ----------
+    - path: "examples/**/*.py"
+      instructions: |
+        - Examples are public-facing. They must run as-is against the documented quickstart setup with no hidden imports.
+        - Prefer minimal config. Don't pull in optional features (Langfuse, Phoenix, MCP) unless the example is specifically about them.
+
+  tools:
+    ruff:
+      enabled: true
+    markdownlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    actionlint:
+      enabled: true
+    hadolint:
+      enabled: true
+    yamllint:
+      enabled: true
+    eslint:
+      enabled: true
+    biome:
+      enabled: false
+    languagetool:
+      enabled: true
+      level: default
+      disabled_categories:
+        - TYPOS
+        - TYPOGRAPHY
+        - CASING
+    github-checks:
+      enabled: true
+      timeout_ms: 180000
+
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+
+  pre_merge_checks:
+    title:
+      mode: warning
+      requirements: |
+        Use a Conventional Commits prefix (`feat:`, `fix:`, `docs:`, `chore:`,
+        `refactor:`, `test:`, `ci:`) optionally with a scope, e.g.
+        `feat(engine): support PostgreSQL checkpointer`. Keep titles under
+        72 characters.
+    description:
+      mode: warning
+    issue_assessment:
+      mode: warning
+    docstrings:
+      mode: "off"
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+  learnings:
+    scope: "auto"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ For service-specific test commands, see the service's CLAUDE.md.
 - Use global exception handlers for unexpected errors. Catch locally only when the response or recovery logic differs from the default.
 - `logger.exception()` for unexpected errors (preserves traceback). `logger.error()` only when you intentionally omit the traceback.
 - Never swallow exceptions silently. Never catch `Exception` to re-raise a generic message unless preventing internal detail leaks.
+- Telemetry and observability code (PostHog captures, Langfuse exporters, OpenTelemetry instrumentation, audit-log middleware) must never alter command or runtime semantics. Wrap singleton init, capture, and flush/shutdown calls in their own `try/except Exception` and log via `logger.exception(...)`. Gate downstream telemetry calls on the client/handle being non-None — a failed init must not skip the wrapped function or mask its exception.
 
 ### Refactoring
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/telemetry/telemetry.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/telemetry/telemetry.py
@@ -246,3 +246,4 @@ class IdunTelemetry:
                 executor.shutdown(wait=False, cancel_futures=False)
             except Exception:
                 pass
+            self._executor = None

--- a/libs/idun_agent_engine/src/idun_agent_engine/telemetry/telemetry.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/telemetry/telemetry.py
@@ -247,3 +247,4 @@ class IdunTelemetry:
             except Exception:
                 pass
             self._executor = None
+            self._client = None

--- a/libs/idun_agent_engine/tests/unit/telemetry/test_shutdown_reuse.py
+++ b/libs/idun_agent_engine/tests/unit/telemetry/test_shutdown_reuse.py
@@ -1,0 +1,34 @@
+"""Regression test: IdunTelemetry must remain usable after shutdown().
+
+The dataclass holds a ThreadPoolExecutor in self._executor that gets
+shut down on shutdown(). Without resetting that field, the singleton
+becomes dead-on-arrival for the next capture() call, breaking the
+"shutdown per CLI invocation" pattern used by the standalone CLI's
+track_command decorator.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from idun_agent_engine.telemetry import IdunTelemetry
+
+
+def test_capture_after_shutdown_does_not_raise() -> None:
+    """A second capture after shutdown should succeed (executor rebuilt)."""
+    telemetry = IdunTelemetry(enabled=True)
+
+    # Force the executor to materialize without making a real network call.
+    # Patch the class (not instance) because IdunTelemetry uses slots=True.
+    with patch.object(IdunTelemetry, "_get_client", return_value=None):
+        future_a = telemetry.capture("test.event", {"k": 1})
+        assert future_a is not None
+        future_a.result(timeout=2.0)
+
+        telemetry.shutdown(timeout_seconds=1.0)
+
+        future_b = telemetry.capture("test.event", {"k": 2})
+        assert future_b is not None, "capture returned None after shutdown — executor was not rebuilt"
+        future_b.result(timeout=2.0)
+
+        telemetry.shutdown(timeout_seconds=1.0)

--- a/libs/idun_agent_engine/tests/unit/telemetry/test_shutdown_reuse.py
+++ b/libs/idun_agent_engine/tests/unit/telemetry/test_shutdown_reuse.py
@@ -1,34 +1,40 @@
 """Regression test: IdunTelemetry must remain usable after shutdown().
 
-The dataclass holds a ThreadPoolExecutor in self._executor that gets
-shut down on shutdown(). Without resetting that field, the singleton
-becomes dead-on-arrival for the next capture() call, breaking the
-"shutdown per CLI invocation" pattern used by the standalone CLI's
-track_command decorator.
+The dataclass holds both a ThreadPoolExecutor in self._executor and a
+PostHog client in self._client. After shutdown() halts both, a second
+capture() must rebuild them — not silently no-op against a dead pool
+or a client whose consumer threads are terminated.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from idun_agent_engine.telemetry import IdunTelemetry
 
 
-def test_capture_after_shutdown_does_not_raise() -> None:
-    """A second capture after shutdown should succeed (executor rebuilt)."""
+def test_capture_after_shutdown_rebuilds_executor_and_client() -> None:
+    """A second capture after shutdown should succeed (executor + client rebuilt)."""
     telemetry = IdunTelemetry(enabled=True)
 
-    # Force the executor to materialize without making a real network call.
-    # Patch the class (not instance) because IdunTelemetry uses slots=True.
-    with patch.object(IdunTelemetry, "_get_client", return_value=None):
+    # Patch the class (not instance) — IdunTelemetry uses slots=True so
+    # instance-attribute monkey-patching raises AttributeError.
+    fake_client = MagicMock()
+    with patch.object(IdunTelemetry, "_get_client", return_value=fake_client):
         future_a = telemetry.capture("test.event", {"k": 1})
         assert future_a is not None
         future_a.result(timeout=2.0)
 
         telemetry.shutdown(timeout_seconds=1.0)
 
+        # After shutdown, both _executor and _client must be cleared so
+        # the next call rebuilds. Without that, _get_client returns the
+        # cached (dead) client and capture silently drops events.
+        assert telemetry._executor is None, "executor not reset on shutdown"
+        assert telemetry._client is None, "client not reset on shutdown"
+
         future_b = telemetry.capture("test.event", {"k": 2})
-        assert future_b is not None, "capture returned None after shutdown — executor was not rebuilt"
+        assert future_b is not None, "capture returned None after shutdown — singleton not rebuilt"
         future_b.result(timeout=2.0)
 
         telemetry.shutdown(timeout_seconds=1.0)

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/_telemetry.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/_telemetry.py
@@ -19,8 +19,11 @@ from typing import ParamSpec, TypeVar
 
 from idun_agent_engine.telemetry import get_telemetry
 
+from idun_agent_standalone.core.logging import get_logger
+
 P = ParamSpec("P")
 R = TypeVar("R")
+logger = get_logger(__name__)
 
 
 def track_command(name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
@@ -30,17 +33,28 @@ def track_command(name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
         @wraps(fn)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             client = get_telemetry()
-            client.capture(f"cli.{name}", {"command": name})
+            try:
+                client.capture(f"cli.{name}", {"command": name})
+            except Exception:
+                logger.exception("telemetry capture failed for cli.%s", name)
             try:
                 return fn(*args, **kwargs)
             except Exception as exc:
-                client.capture(
-                    f"cli.{name}.error",
-                    {"command": name, "error_type": type(exc).__name__},
-                )
+                try:
+                    client.capture(
+                        f"cli.{name}.error",
+                        {"command": name, "error_type": type(exc).__name__},
+                    )
+                except Exception:
+                    logger.exception(
+                        "telemetry capture failed for cli.%s.error", name
+                    )
                 raise
             finally:
-                client.shutdown(timeout_seconds=1.0)
+                try:
+                    client.shutdown(timeout_seconds=1.0)
+                except Exception:
+                    logger.exception("telemetry shutdown failed for cli.%s", name)
 
         return wrapper
 

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/_telemetry.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/_telemetry.py
@@ -32,29 +32,37 @@ def track_command(name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def decorator(fn: Callable[P, R]) -> Callable[P, R]:
         @wraps(fn)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            client = get_telemetry()
+            client = None
             try:
-                client.capture(f"cli.{name}", {"command": name})
+                client = get_telemetry()
             except Exception:
-                logger.exception("telemetry capture failed for cli.%s", name)
+                logger.exception("telemetry init failed for cli.%s", name)
+
+            if client is not None:
+                try:
+                    client.capture(f"cli.{name}", {"command": name})
+                except Exception:
+                    logger.exception("telemetry capture failed for cli.%s", name)
             try:
                 return fn(*args, **kwargs)
             except Exception as exc:
-                try:
-                    client.capture(
-                        f"cli.{name}.error",
-                        {"command": name, "error_type": type(exc).__name__},
-                    )
-                except Exception:
-                    logger.exception(
-                        "telemetry capture failed for cli.%s.error", name
-                    )
+                if client is not None:
+                    try:
+                        client.capture(
+                            f"cli.{name}.error",
+                            {"command": name, "error_type": type(exc).__name__},
+                        )
+                    except Exception:
+                        logger.exception(
+                            "telemetry capture failed for cli.%s.error", name
+                        )
                 raise
             finally:
-                try:
-                    client.shutdown(timeout_seconds=1.0)
-                except Exception:
-                    logger.exception("telemetry shutdown failed for cli.%s", name)
+                if client is not None:
+                    try:
+                        client.shutdown(timeout_seconds=1.0)
+                    except Exception:
+                        logger.exception("telemetry shutdown failed for cli.%s", name)
 
         return wrapper
 

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/_telemetry.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/_telemetry.py
@@ -1,0 +1,50 @@
+"""CLI telemetry decorator.
+
+Wraps each idun command so PostHog gets a `cli.<name>` event on entry
+and a `cli.<name>.error` event when the command raises. The
+underlying client is the engine's process-wide singleton via
+``idun_agent_engine.telemetry.get_telemetry`` — we delegate
+sanitization, opt-out, and async transport to it.
+
+Each decorated invocation calls ``shutdown(timeout_seconds=1.0)`` in
+``finally`` because CLI processes are short-lived and we want events
+flushed before exit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
+from idun_agent_engine.telemetry import get_telemetry
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def track_command(name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorator that posts cli.<name>[.error] events around a command."""
+
+    def decorator(fn: Callable[P, R]) -> Callable[P, R]:
+        @wraps(fn)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            client = get_telemetry()
+            client.capture(f"cli.{name}", {"command": name})
+            try:
+                return fn(*args, **kwargs)
+            except Exception as exc:
+                client.capture(
+                    f"cli.{name}.error",
+                    {"command": name, "error_type": type(exc).__name__},
+                )
+                raise
+            finally:
+                client.shutdown(timeout_seconds=1.0)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["track_command"]

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/cli.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/cli.py
@@ -26,6 +26,7 @@ import click
 import uvicorn
 from dotenv import load_dotenv
 
+from idun_agent_standalone._telemetry import track_command
 from idun_agent_standalone.core.logging import get_logger, setup_logging
 from idun_agent_standalone.core.settings import StandaloneSettings
 
@@ -62,6 +63,7 @@ def main() -> None:
     confirmation_prompt=True,
     help="Plaintext password to hash. Prompted if omitted.",
 )
+@track_command("hash-password")
 def hash_password_cmd(password: str) -> None:
     """Print a bcrypt hash suitable for IDUN_ADMIN_PASSWORD_HASH."""
     from idun_agent_standalone.core.security import hash_password
@@ -77,6 +79,7 @@ def hash_password_cmd(password: str) -> None:
     default=None,
     help="Path to YAML config. Overrides IDUN_CONFIG_PATH.",
 )
+@track_command("setup")
 def setup_cmd(config_path_override: str | None) -> None:
     """Create DB schema and seed from YAML if the DB is empty."""
     setup_logging()
@@ -88,6 +91,7 @@ def setup_cmd(config_path_override: str | None) -> None:
 
 
 @main.command("serve")
+@track_command("serve")
 def serve_cmd() -> None:
     """Run the standalone server (engine routes plus admin REST)."""
     setup_logging()
@@ -110,6 +114,7 @@ def serve_cmd() -> None:
     default=False,
     help="Don't open the browser automatically. Useful for Cloud Run + headless.",
 )
+@track_command("init")
 def init_cmd(port_override: int | None, no_browser: bool) -> None:
     """Initialize Idun in the current folder and launch chat + admin.
 
@@ -305,6 +310,7 @@ def agent_group() -> None:
     type=click.Path(),
     help="Path to a local config.yaml. Required when --source=file.",
 )
+@track_command("agent.serve")
 def agent_serve_cmd(source: str, path: str | None) -> None:
     """Serve an agent from a manager or file source."""
     logger = get_logger(__name__)

--- a/libs/idun_agent_standalone/tests/unit/test_telemetry.py
+++ b/libs/idun_agent_standalone/tests/unit/test_telemetry.py
@@ -106,3 +106,35 @@ def test_track_command_swallows_telemetry_failures(
     # Telemetry exceptions must not mask the original command error.
     with pytest.raises(ValueError, match="real command error"):
         boom()
+
+
+def test_track_command_runs_command_when_get_telemetry_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If get_telemetry() itself raises, the wrapped function must
+    still run and return its value, and original exceptions must
+    still propagate."""
+
+    def raising_get_telemetry() -> object:
+        raise RuntimeError("singleton init blew up")
+
+    monkeypatch.setattr(
+        "idun_agent_standalone._telemetry.get_telemetry", raising_get_telemetry
+    )
+
+    from idun_agent_standalone._telemetry import track_command
+
+    @track_command("setup")
+    def fake_cmd(value: int) -> int:
+        return value * 3
+
+    # Init failure must not surface as a command failure.
+    assert fake_cmd(4) == 12
+
+    @track_command("init")
+    def boom() -> None:
+        raise ValueError("real command error")
+
+    # Init failure must not mask the original command error.
+    with pytest.raises(ValueError, match="real command error"):
+        boom()

--- a/libs/idun_agent_standalone/tests/unit/test_telemetry.py
+++ b/libs/idun_agent_standalone/tests/unit/test_telemetry.py
@@ -76,3 +76,33 @@ def test_track_command_does_not_crash_when_disabled(
 
     assert fake_cmd(21) == 42
     mock_client.shutdown.assert_called_once_with(timeout_seconds=1.0)
+
+
+def test_track_command_swallows_telemetry_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When telemetry methods raise, the wrapped function must still
+    return its result and propagate its own exceptions unchanged."""
+    mock_client = MagicMock()
+    mock_client.capture.side_effect = RuntimeError("posthog blew up")
+    mock_client.shutdown.side_effect = RuntimeError("shutdown blew up")
+    monkeypatch.setattr(
+        "idun_agent_standalone._telemetry.get_telemetry", lambda: mock_client
+    )
+
+    from idun_agent_standalone._telemetry import track_command
+
+    @track_command("setup")
+    def fake_cmd(value: int) -> int:
+        return value * 2
+
+    # Telemetry exceptions must not surface as command failures.
+    assert fake_cmd(7) == 14
+
+    @track_command("init")
+    def boom() -> None:
+        raise ValueError("real command error")
+
+    # Telemetry exceptions must not mask the original command error.
+    with pytest.raises(ValueError, match="real command error"):
+        boom()

--- a/libs/idun_agent_standalone/tests/unit/test_telemetry.py
+++ b/libs/idun_agent_standalone/tests/unit/test_telemetry.py
@@ -1,0 +1,78 @@
+"""Tests for the standalone CLI telemetry decorator.
+
+The decorator wraps each idun command and emits a PostHog event on
+entry plus a separate error event when the command raises. We mock
+the engine telemetry singleton so tests don't actually post.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_track_command_captures_success_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_client = MagicMock()
+    monkeypatch.setattr(
+        "idun_agent_standalone._telemetry.get_telemetry", lambda: mock_client
+    )
+
+    from idun_agent_standalone._telemetry import track_command
+
+    @track_command("setup")
+    def fake_cmd() -> str:
+        return "ok"
+
+    assert fake_cmd() == "ok"
+    mock_client.capture.assert_any_call("cli.setup", {"command": "setup"})
+    # No error event on the success path.
+    assert not any(
+        call.args[0] == "cli.setup.error" for call in mock_client.capture.call_args_list
+    )
+    mock_client.shutdown.assert_called_once_with(timeout_seconds=1.0)
+
+
+def test_track_command_captures_error_event_and_reraises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_client = MagicMock()
+    monkeypatch.setattr(
+        "idun_agent_standalone._telemetry.get_telemetry", lambda: mock_client
+    )
+
+    from idun_agent_standalone._telemetry import track_command
+
+    @track_command("init")
+    def boom() -> None:
+        raise RuntimeError("explode")
+
+    with pytest.raises(RuntimeError, match="explode"):
+        boom()
+
+    mock_client.capture.assert_any_call("cli.init", {"command": "init"})
+    mock_client.capture.assert_any_call(
+        "cli.init.error", {"command": "init", "error_type": "RuntimeError"}
+    )
+    mock_client.shutdown.assert_called_once_with(timeout_seconds=1.0)
+
+
+def test_track_command_does_not_crash_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When telemetry is disabled, capture is a no-op but the wrapper
+    must still call the wrapped function and return its result."""
+    mock_client = MagicMock()
+    mock_client.capture.return_value = None
+    monkeypatch.setattr(
+        "idun_agent_standalone._telemetry.get_telemetry", lambda: mock_client
+    )
+
+    from idun_agent_standalone._telemetry import track_command
+
+    @track_command("serve")
+    def fake_cmd(value: int) -> int:
+        return value * 2
+
+    assert fake_cmd(21) == 42
+    mock_client.shutdown.assert_called_once_with(timeout_seconds=1.0)


### PR DESCRIPTION
## Summary
The migration consolidated the engine CLI into the standalone CLI but dropped the `track_command` decorator that emitted PostHog events for `idun init` / `serve` / `setup`. This restores instrumentation across all five commands and fixes a related shutdown-reusability bug in the engine telemetry singleton.

- New `libs/idun_agent_standalone/src/idun_agent_standalone/_telemetry.py`: thin decorator on top of the engine's `get_telemetry()` singleton.
- Applied to: `hash-password`, `setup`, `serve`, `init`, `agent serve`.
- Three unit tests on the decorator: success path, error path (re-raise), disabled path.
- Engine fix: `IdunTelemetry.shutdown()` now resets `self._executor = None` in `finally` so the singleton stays reusable. Without this, the second decorator invocation in any process would silently drop events (the executor was already shut down). Caught by code review; new regression test in the engine telemetry suite.
- Module-level singleton via `get_telemetry()`; `shutdown(timeout=1.0)` per call so events flush before short-lived CLI exits.
- No latency capture in v1 (deferred per spec).

Spec: `idun-dev/tasks/migrate-standalone-07-05-2026/2026-05-08-migration-loose-ends-design.md`
Plan: `idun-dev/tasks/migrate-standalone-07-05-2026/2026-05-08-migration-loose-ends-plan.md`

## Commits
- `ef01fb82` feat(standalone): add track_command telemetry decorator
- `115b0959` feat(cli): instrument idun commands with PostHog telemetry
- `f7550c53` test(telemetry): regression for shutdown executor reuse
- `bbd4be8d` fix(telemetry): reset executor on shutdown so the singleton stays reusable

## Test plan
- [x] `uv run pytest libs/idun_agent_standalone/tests/unit/test_telemetry.py -v`: 3 passed
- [x] `uv run pytest libs/idun_agent_engine/tests/unit/telemetry/ -v`: 9 passed (incl. new shutdown_reuse regression)
- [x] Standalone unit suite: green (222 tests via implementer subagent run)
- [x] Lint clean (`make lint`)
- [x] `uv run idun --help`: prints usage with all 5 commands, no traceback
- [x] Wheel install smoke: PASS (server boots, /health returns 200)
- [ ] Manual PostHog smoke (optional — requires telemetry env vars; not run in CI)

Note: pre-existing mypy errors in `agent.py` / `deep_research.py` are unaffected by this PR.

Stacks on top of #572 (migration CI + deps cleanup) for the doc-rewrite work that follows. PR2 doesn't depend on #572 mechanically — they target disjoint files — but landing both before T0 Third Batch keeps the loose-ends story tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now emits telemetry events for key commands (hash-password, setup, serve, init, agent serve) to provide usage insights and analytics.
  * Telemetry integration is resilient and will not impact CLI operation if telemetry services are unavailable or fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->