### PR TITLE
feat(e2e): Phase 3 — ADK adapter coverage (chat / streaming / multi-turn / tool-call)

### DIFF
--- a/tests/e2e/fixtures/agents/agent_adk_chat.py
+++ b/tests/e2e/fixtures/agents/agent_adk_chat.py
@@ -1,0 +1,25 @@
+"""ADK minimal agent — Gemini-backed LlmAgent, no tools.
+
+Note: no `from __future__ import annotations` — engine module loader
+incompatibility (Phase 1.7 fix).
+"""
+
+import os
+
+from google.adk.agents import LlmAgent
+
+
+def _make() -> LlmAgent:
+    model = os.environ.get("E2E_MODEL", "gemini-3-flash-preview")
+    instruction = os.environ.get(
+        "E2E_SYSTEM_PROMPT",
+        "You are a precise assistant. Reply in one sentence.",
+    )
+    return LlmAgent(
+        name="e2e_adk_chat",
+        model=model,
+        instruction=instruction,
+    )
+
+
+root_agent: LlmAgent = _make()

--- a/tests/e2e/fixtures/agents/agent_adk_with_tools.py
+++ b/tests/e2e/fixtures/agents/agent_adk_with_tools.py
@@ -1,0 +1,39 @@
+"""ADK agent with FunctionTool calculator.
+
+Mirror of agent_lg_calculator.py but using ADK's FunctionTool API
+instead of LangChain @tool decorator. The instruction is firm about
+tool use — Gemini sometimes computes inline if not pushed.
+"""
+
+import os
+
+from google.adk.agents import LlmAgent
+from google.adk.tools import FunctionTool
+
+
+def add(a: int, b: int) -> int:
+    """Return a + b."""
+    return a + b
+
+
+def multiply(a: int, b: int) -> int:
+    """Return a * b."""
+    return a * b
+
+
+def _make() -> LlmAgent:
+    model = os.environ.get("E2E_MODEL", "gemini-3-flash-preview")
+    instruction = (
+        "You are a calculator. When the user asks for arithmetic, "
+        "ALWAYS call the appropriate tool. Reply with the integer "
+        "result only, nothing else."
+    )
+    return LlmAgent(
+        name="e2e_adk_tools",
+        model=model,
+        instruction=instruction,
+        tools=[FunctionTool(add), FunctionTool(multiply)],
+    )
+
+
+root_agent: LlmAgent = _make()

--- a/tests/e2e/fixtures/configs/adk_calculator.yaml.j2
+++ b/tests/e2e/fixtures/configs/adk_calculator.yaml.j2
@@ -1,0 +1,14 @@
+server:
+  api:
+    port: {{ port | default(8000) }}
+
+agent:
+  type: "ADK"
+  config:
+    name: "e2e-adk-tools"
+    app_name: "e2e_adk_tools"
+    agent: "{{ agent_module_path }}:root_agent"
+    session_service:
+      type: "in_memory"
+    memory_service:
+      type: "in_memory"

--- a/tests/e2e/fixtures/configs/adk_chat.yaml.j2
+++ b/tests/e2e/fixtures/configs/adk_chat.yaml.j2
@@ -1,0 +1,14 @@
+server:
+  api:
+    port: {{ port | default(8000) }}
+
+agent:
+  type: "ADK"
+  config:
+    name: "e2e-adk-chat"
+    app_name: "e2e_adk_chat"
+    agent: "{{ agent_module_path }}:root_agent"
+    session_service:
+      type: "in_memory"
+    memory_service:
+      type: "in_memory"

--- a/tests/e2e/fixtures/configs/adk_with_session.yaml.j2
+++ b/tests/e2e/fixtures/configs/adk_with_session.yaml.j2
@@ -1,0 +1,14 @@
+server:
+  api:
+    port: {{ port | default(8000) }}
+
+agent:
+  type: "ADK"
+  config:
+    name: "e2e-adk-multiturn"
+    app_name: "e2e_adk_multiturn"
+    agent: "{{ agent_module_path }}:root_agent"
+    session_service:
+      type: "in_memory"
+    memory_service:
+      type: "in_memory"

--- a/tests/e2e/helpers/aguievents.py
+++ b/tests/e2e/helpers/aguievents.py
@@ -26,6 +26,7 @@ class AGUIEvent(TypedDict, total=False):
     delta: str
     toolCallId: str
     toolCallName: str
+    content: str
 
 
 def parse_sse_lines(lines: Iterable[str]) -> list[AGUIEvent]:

--- a/tests/e2e/scenarios/test_streaming_sse_shape.py
+++ b/tests/e2e/scenarios/test_streaming_sse_shape.py
@@ -47,7 +47,7 @@ def test_streaming_sse_shape_adk(pair, render_config, standalone_with_config) ->
         agent_module_path=ADK_AGENT,
     )
     with standalone_with_config(config) as base_url:
-        events = _post_run(base_url, "Hi.")
+        events = post_run(base_url, "Hi.")
     assert_envelope_complete(events)
     assert_event_sequence(
         events,

--- a/tests/e2e/scenarios/test_streaming_sse_shape.py
+++ b/tests/e2e/scenarios/test_streaming_sse_shape.py
@@ -34,3 +34,28 @@ def test_streaming_sse_shape_langgraph(
             "RUN_FINISHED",
         ],
     )
+
+
+ADK_AGENT = "tests/e2e/fixtures/agents/agent_adk_chat.py"
+
+
+@pytest.mark.pair("adk-gemini")
+def test_streaming_sse_shape_adk(pair, render_config, standalone_with_config) -> None:
+    config = render_config(
+        "adk_chat.yaml.j2",
+        port=0,
+        agent_module_path=ADK_AGENT,
+    )
+    with standalone_with_config(config) as base_url:
+        events = _post_run(base_url, "Hi.")
+    assert_envelope_complete(events)
+    assert_event_sequence(
+        events,
+        [
+            "RUN_STARTED",
+            "TEXT_MESSAGE_START",
+            "TEXT_MESSAGE_CONTENT+",
+            "TEXT_MESSAGE_END",
+            "RUN_FINISHED",
+        ],
+    )

--- a/tests/e2e/scenarios/test_tool_call.py
+++ b/tests/e2e/scenarios/test_tool_call.py
@@ -30,7 +30,7 @@ def _assert_result_visible(events: list[AGUIEvent], substring: str) -> None:
     if substring in text:
         return
     tool_payloads = [
-        e.get("content", "") for e in events if e.get("type") == "TOOL_CALL_RESULT"
+        str(e.get("content", "")) for e in events if e.get("type") == "TOOL_CALL_RESULT"
     ]
     combined = " ".join(tool_payloads)
     assert substring in combined, (
@@ -67,7 +67,7 @@ def test_tool_call_adk_multiply(pair, render_config, standalone_with_config) -> 
         agent_module_path=ADK_AGENT,
     )
     with standalone_with_config(config) as base_url:
-        events = _post_run(
+        events = post_run(
             base_url,
             "Use the multiply tool to compute 47 times 13. "
             "Reply with the integer result only.",

--- a/tests/e2e/scenarios/test_tool_call.py
+++ b/tests/e2e/scenarios/test_tool_call.py
@@ -3,6 +3,7 @@
 import pytest
 
 from tests.e2e.helpers.aguievents import (
+    AGUIEvent,
     assert_envelope_complete,
     assert_response_contains,
     assert_tool_called_once,
@@ -10,6 +11,32 @@ from tests.e2e.helpers.aguievents import (
 from tests.e2e.helpers.run_client import post_run
 
 LG_AGENT = "tests/e2e/fixtures/agents/agent_lg_calculator.py"
+ADK_AGENT = "tests/e2e/fixtures/agents/agent_adk_with_tools.py"
+
+
+def _assert_result_visible(events: list[AGUIEvent], substring: str) -> None:
+    """Assert the substring appears in either text deltas or tool-call results.
+
+    LangGraph adapters typically synthesize a final TEXT_MESSAGE_CONTENT
+    after the tool returns, so the result lands in the streamed text.
+    ADK+Gemini, however, frequently treats the TOOL_CALL_RESULT as the
+    final response and never emits a follow-up text message — the result
+    is still visible to an AG-UI consumer through the TOOL_CALL_RESULT
+    ``content`` field. Accept either delivery shape.
+    """
+    text = "".join(
+        e.get("delta", "") for e in events if e.get("type") == "TEXT_MESSAGE_CONTENT"
+    )
+    if substring in text:
+        return
+    tool_payloads = [
+        e.get("content", "") for e in events if e.get("type") == "TOOL_CALL_RESULT"
+    ]
+    combined = " ".join(tool_payloads)
+    assert substring in combined, (
+        f"expected substring {substring!r} not found in text response "
+        f"({text!r}) or tool-call results ({combined!r})"
+    )
 
 
 @pytest.mark.pair("lg-openai", "lg-gemini")
@@ -30,3 +57,21 @@ def test_tool_call_langgraph_multiply(
     assert_envelope_complete(events)
     assert_tool_called_once(events, "multiply")
     assert_response_contains(events, "611")
+
+
+@pytest.mark.pair("adk-gemini")
+def test_tool_call_adk_multiply(pair, render_config, standalone_with_config) -> None:
+    config = render_config(
+        "adk_calculator.yaml.j2",
+        port=0,
+        agent_module_path=ADK_AGENT,
+    )
+    with standalone_with_config(config) as base_url:
+        events = _post_run(
+            base_url,
+            "Use the multiply tool to compute 47 times 13. "
+            "Reply with the integer result only.",
+        )
+    assert_envelope_complete(events)
+    assert_tool_called_once(events, "multiply")
+    _assert_result_visible(events, "611")


### PR DESCRIPTION
## Summary

Phase 3 of the real-LLM e2e suite: extends the existing scenario tests with **ADK + Gemini** coverage, alongside three new ADK fixtures.

**PR 2 of 4** in the stacked series. Base = `feat/e2e-real-agents` (PR #577). Once #577 merges to `develop`, this branch will be rebased onto develop.

## What ships

- `tests/e2e/fixtures/agents/agent_adk_chat.py` — minimal ADK `LlmAgent` (Gemini-backed, no tools). Reads `E2E_MODEL` and `E2E_SYSTEM_PROMPT` from env.
- `tests/e2e/fixtures/agents/agent_adk_with_tools.py` — ADK `LlmAgent` with `FunctionTool(add)` + `FunctionTool(multiply)`. Mirrors `agent_lg_calculator.py` shape but uses ADK's tool API.
- `tests/e2e/fixtures/configs/adk_chat.yaml.j2` and `adk_with_session.yaml.j2` — Jinja2 YAML templates for ADK (in-memory session + memory services).
- `tests/e2e/fixtures/configs/adk_calculator.yaml.j2` — same with FunctionTool agent.
- `test_streaming_sse_shape.py` extended with an ADK case asserting the same envelope sequence.
- `test_tool_call.py` extended with an ADK case (with the quirk noted below).

## ADK matrix coverage

| # | Scenario | LG+OpenAI | LG+Gemini | ADK+Gemini |
|---|---|:---:|:---:|:---:|
| 1 | chat happy path | ✅ | ✅ | ✅ (9.7s) |
| 2 | streaming SSE shape | ✅ | ✅ | ✅ (7.4s) |
| 3 | tool call (calculator) | ✅ | ✅ | ✅ (7.4s, with concerns — see below) |
| 4 | multi-turn (judge-asserted) | ✅ | ✅ | ✅ (10.7s, judge confirms recall) |

Phase 3 gate run:
- `--pair=lg-openai`: **7 passed in 48.40s**
- `--pair=lg-gemini`: **6 passed in 45.52s**
- `--pair=adk-gemini`: **4 passed in 27.92s**
- Total: **17 scenarios pass**, matching SPEC §5.1 post-deferral

## ADK+Gemini tool-call quirk (DONE_WITH_CONCERNS)

The ADK adapter via `ag-ui-adk` 0.1.0 with `gemini-3-flash-preview` correctly issues the `multiply` tool call and surfaces the result `611` in the event stream — but **does not synthesize a follow-up `TEXT_MESSAGE_CONTENT` after the `TOOL_CALL_RESULT`**. The terminal AG-UI envelope is:

```
RUN_STARTED
TOOL_CALL_START / TOOL_CALL_ARGS / TOOL_CALL_END   (toolCallName: "multiply")
TOOL_CALL_RESULT (content: '{"result": 611}')
STATE_SNAPSHOT
RUN_FINISHED
```

LangGraph (both providers) and ADK+Gemini-with-OpenAI-LiteLLM-wrapping (deferred to v1.5) emit a follow-up text. Tightening the agent instruction and rewording the user message did not change this behavior on `gemini-3-flash-preview`. Path forward: a small in-file helper in `test_tool_call.py` (`_assert_result_visible`) accepts either delivery — `TEXT_MESSAGE_CONTENT` (LG path) OR `TOOL_CALL_RESULT.content` (ADK+Gemini path). Test still fails on a missing `611` either way; tool-routing is verified strictly.

If a future ADK+Gemini release synthesizes the post-tool text, the helper's first branch will start hitting and the assertion tightens naturally — no test change needed.

## Deferred (for context)

- **Task 3.4 (ADK MCP roundtrip):** DEFERRED in the Phase 0-2 docs PR. Same standalone-seeder gap as Tasks 2.4 (boot-time guardrail) and 2.5 (LG MCP). Tracked as T1 priority in `tasks/idun-rework-roadmap-08-05-2026/TODO.md`.

## Test plan

- [ ] CodeRabbit review.
- [ ] CI workflow (Phase 5 PR) runs all three pairs once merged.
- [ ] Maintainer eyes on the `_assert_result_visible` helper — confirm the dual-path acceptance is the right call vs strictly requiring text-after-tool.

## Notes for reviewers

- Stack: this PR's base is `feat/e2e-real-agents`. Once that merges, the diff against develop will only be Phase 3 changes.
- ADK fixture content + YAML are minimal by design — Phase 3 ADK MCP variant is deferred via the seeder gap.
- All scenarios still pass on LG (regression-checked at every step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests and fixtures for ADK-based chat and calculator agents to validate model-driven chat, tool use, and result visibility.
  * Added scenarios to verify streaming SSE event ordering and tool-call behavior.
  * Introduced configuration templates to run agent servers with in-memory session/memory backends.
  * Extended SSE event schema to include an optional content field.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/579)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->