### PR TITLE
ci(e2e): Phase 5 — e2e-real-llm workflow + branch-protection note

### DIFF
--- a/.github/workflows/e2e-real-llm.yml
+++ b/.github/workflows/e2e-real-llm.yml
@@ -21,12 +21,29 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GUARDRAILS_API_KEY: ${{ secrets.GUARDRAILS_API_KEY }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          if [[ -n "$OPENAI_API_KEY" && ( -n "$GOOGLE_API_KEY" || -n "$GEMINI_API_KEY" ) ]]; then
+          missing=()
+          [[ -z "$OPENAI_API_KEY" ]] && missing+=("OPENAI_API_KEY")
+          [[ -z "$GOOGLE_API_KEY" && -z "$GEMINI_API_KEY" ]] && missing+=("GOOGLE_API_KEY|GEMINI_API_KEY")
+          [[ -z "$GUARDRAILS_API_KEY" ]] && missing+=("GUARDRAILS_API_KEY")
+
+          if [[ ${#missing[@]} -eq 0 ]]; then
             echo "has_secrets=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Secrets missing. Auto-skip only on fork PRs (where secrets are
+          # genuinely unavailable). Internal PRs missing secrets are a
+          # configuration bug — fail loudly.
+          echo "has_secrets=false" >> $GITHUB_OUTPUT
+          if [[ "$IS_FORK" == "true" ]]; then
+            echo "::notice::Skipping e2e-real-llm: secrets unavailable on fork PR. Missing: ${missing[*]}"
+            exit 0
           else
-            echo "has_secrets=false" >> $GITHUB_OUTPUT
-            echo "::notice::Skipping e2e-real-llm: secrets unavailable (likely a fork PR)."
+            echo "::error::Internal PR missing required e2e secrets: ${missing[*]}. Fix repo secrets configuration."
+            exit 1
           fi
 
   pytest-matrix:

--- a/.github/workflows/e2e-real-llm.yml
+++ b/.github/workflows/e2e-real-llm.yml
@@ -1,0 +1,132 @@
+name: E2E (real LLM)
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+# Cancel in-flight runs on the same PR when a new commit lands.
+concurrency:
+  group: e2e-real-llm-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Check secrets availability
+    runs-on: ubuntu-latest
+    outputs:
+      has_secrets: ${{ steps.check.outputs.has_secrets }}
+    steps:
+      - id: check
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          if [[ -n "$OPENAI_API_KEY" && ( -n "$GOOGLE_API_KEY" || -n "$GEMINI_API_KEY" ) ]]; then
+            echo "has_secrets=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_secrets=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping e2e-real-llm: secrets unavailable (likely a fork PR)."
+          fi
+
+  pytest-matrix:
+    name: pytest e2e — ${{ matrix.pair }}
+    needs: preflight
+    if: needs.preflight.outputs.has_secrets == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pair:
+          - lg-openai
+          - lg-gemini
+          - adk-gemini
+    env:
+      E2E_PAIR: ${{ matrix.pair }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GUARDRAILS_API_KEY: ${{ secrets.GUARDRAILS_API_KEY }}
+      IDUN_TELEMETRY_ENABLED: "false"
+      # Force AI Studio auth (bypasses any host Vertex env that might
+      # leak through — defense in depth; CI runner shouldn't have it,
+      # but matches the conftest's explicit override).
+      GOOGLE_GENAI_USE_VERTEXAI: "false"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install workspace dependencies
+        run: uv sync --group dev
+
+      - name: Run pytest e2e for matrix pair
+        run: uv run pytest tests/e2e/ -v --pair=${{ matrix.pair }} --maxfail=3
+
+  playwright:
+    name: Playwright e2e (real LLM)
+    needs: preflight
+    if: needs.preflight.outputs.has_secrets == 'true'
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      LLM_PROVIDER: openai
+      LLM_MODEL: gpt-5.4-mini
+      IDUN_TELEMETRY_ENABLED: "false"
+      GOOGLE_GENAI_USE_VERTEXAI: "false"
+      # Admin REST guardrail-add scenario also needs Guardrails Hub.
+      GUARDRAILS_API_KEY: ${{ secrets.GUARDRAILS_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install workspace dependencies
+        run: uv sync --group dev
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install UI dependencies
+        working-directory: services/idun_agent_standalone_ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        working-directory: services/idun_agent_standalone_ui
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright real-LLM specs
+        working-directory: services/idun_agent_standalone_ui
+        run: pnpm exec playwright test e2e/chat-real-llm.spec.ts e2e/admin-edit-and-reload.spec.ts
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-${{ github.run_id }}
+          path: services/idun_agent_standalone_ui/test-results/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Phase 5 of the real-LLM e2e suite: a new GitHub Actions workflow that runs the full pytest matrix (3 pairs in parallel) plus the 2 Playwright specs on every PR to `main` / `develop`. Auto-skips on fork PRs via a secrets-presence preflight gate.

**PR 4 of 5** in the stacked series (Phase 6 docs follows). Base = `feat/e2e-real-agents-phase-4-playwright` (PR #580).

## What ships

- `.github/workflows/e2e-real-llm.yml` (new, 132 lines).

### Workflow shape

```
preflight (checks secrets)
   ├── if has_secrets:
   │   ├── pytest-matrix (lg-openai, lg-gemini, adk-gemini — fail-fast: false)
   │   └── playwright (LG+OpenAI standalone, both real-LLM specs)
   └── if not (fork PR): both downstream jobs skipped → required-check stays green via "skipped" status
```

### Key decisions

- **Secrets gate accepts `GOOGLE_API_KEY` OR `GEMINI_API_KEY`** (AI Studio's modern naming). The Phase 0-2 fixture work made the local + CI auth path tolerant of either.
- **`GOOGLE_GENAI_USE_VERTEXAI=false` set explicitly** in both jobs (defense-in-depth — mirrors the conftest.py override that was needed because some host `.env` files leak Vertex env vars).
- **`GUARDRAILS_API_KEY`** required for the reload-pipeline scenario AND the Playwright admin-edit-and-reload spec (both add a BAN_LIST guard via admin REST, which Guardrails Hub installs at reload time).
- **`fail-fast: false`** on the matrix — one provider's outage doesn't tank the others.
- **`--maxfail=3`** per pytest shard — some headroom for transient rate-limit retries.
- **Playwright artifacts** uploaded on failure with 7-day retention.
- **Concurrency group cancels in-flight runs** when a new commit lands on the PR.

## Cost projection

Per SPEC §7.4: ~80 PR runs/month × ~17 LLM-driven test invocations per run × ~500 tokens × cheapest tier (`gpt-5.4-mini` + `gemini-3-flash-preview`) → **< $1/month**. No circuit breaker in v1; revisit only if observed monthly LLM spend exceeds $50.

## Branch-protection follow-up

Documented in `tasks/e2e-real-agents-08-05-2026/INSTRUCTION.md` (idun-dev `c13d0c7`). After this PR merges to develop, a repo admin needs to flip the four required checks on:

- `pytest e2e — lg-openai`
- `pytest e2e — lg-gemini`
- `pytest e2e — adk-gemini`
- `Playwright e2e (real LLM)`

Skipped jobs (fork PRs hitting the secrets gate) don't block the required-check evaluation.

## Test plan

- [ ] Workflow runs on this draft PR (4 jobs: 3 pytest pairs + 1 Playwright).
- [ ] All 4 jobs pass green.
- [ ] CodeRabbit review.
- [ ] Verify fork-PR auto-skip behavior in a follow-up (manually re-fork from a no-secrets account).

## Notes for reviewers

- Action versions match the existing `ci.yml` and `standalone-ci.yml` conventions.
- Style note: this workflow uses bare `- uses: actions/checkout@v4` (mirrors `standalone-ci.yml`); `ci.yml` uses `- name: Checkout` labels. Both styles exist in-repo; not worth normalizing here.
- Optional follow-up: enable `cache: "pnpm"` on the Playwright job's `setup-node` step (matches `standalone-ci.yml`). Defer until we measure CI runtime cost — likely a few seconds saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end testing infrastructure with automated testing against real LLM providers and UI automation to ensure improved reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->