### PR TITLE
docs(e2e): Phase 6 — CONTRIBUTING rule + tests/e2e run-book

### DIFF
--- a/.github/workflows/e2e-real-llm.yml
+++ b/.github/workflows/e2e-real-llm.yml
@@ -21,12 +21,29 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GUARDRAILS_API_KEY: ${{ secrets.GUARDRAILS_API_KEY }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          if [[ -n "$OPENAI_API_KEY" && ( -n "$GOOGLE_API_KEY" || -n "$GEMINI_API_KEY" ) ]]; then
+          missing=()
+          [[ -z "$OPENAI_API_KEY" ]] && missing+=("OPENAI_API_KEY")
+          [[ -z "$GOOGLE_API_KEY" && -z "$GEMINI_API_KEY" ]] && missing+=("GOOGLE_API_KEY|GEMINI_API_KEY")
+          [[ -z "$GUARDRAILS_API_KEY" ]] && missing+=("GUARDRAILS_API_KEY")
+
+          if [[ ${#missing[@]} -eq 0 ]]; then
             echo "has_secrets=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Secrets missing. Auto-skip only on fork PRs (where secrets are
+          # genuinely unavailable). Internal PRs missing secrets are a
+          # configuration bug — fail loudly.
+          echo "has_secrets=false" >> $GITHUB_OUTPUT
+          if [[ "$IS_FORK" == "true" ]]; then
+            echo "::notice::Skipping e2e-real-llm: secrets unavailable on fork PR. Missing: ${missing[*]}"
+            exit 0
           else
-            echo "has_secrets=false" >> $GITHUB_OUTPUT
-            echo "::notice::Skipping e2e-real-llm: secrets unavailable (likely a fork PR)."
+            echo "::error::Internal PR missing required e2e secrets: ${missing[*]}. Fix repo secrets configuration."
+            exit 1
           fi
 
   pytest-matrix:

--- a/.github/workflows/e2e-real-llm.yml
+++ b/.github/workflows/e2e-real-llm.yml
@@ -1,0 +1,132 @@
+name: E2E (real LLM)
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+# Cancel in-flight runs on the same PR when a new commit lands.
+concurrency:
+  group: e2e-real-llm-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Check secrets availability
+    runs-on: ubuntu-latest
+    outputs:
+      has_secrets: ${{ steps.check.outputs.has_secrets }}
+    steps:
+      - id: check
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          if [[ -n "$OPENAI_API_KEY" && ( -n "$GOOGLE_API_KEY" || -n "$GEMINI_API_KEY" ) ]]; then
+            echo "has_secrets=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_secrets=false" >> $GITHUB_OUTPUT
+            echo "::notice::Skipping e2e-real-llm: secrets unavailable (likely a fork PR)."
+          fi
+
+  pytest-matrix:
+    name: pytest e2e — ${{ matrix.pair }}
+    needs: preflight
+    if: needs.preflight.outputs.has_secrets == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pair:
+          - lg-openai
+          - lg-gemini
+          - adk-gemini
+    env:
+      E2E_PAIR: ${{ matrix.pair }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GUARDRAILS_API_KEY: ${{ secrets.GUARDRAILS_API_KEY }}
+      IDUN_TELEMETRY_ENABLED: "false"
+      # Force AI Studio auth (bypasses any host Vertex env that might
+      # leak through — defense in depth; CI runner shouldn't have it,
+      # but matches the conftest's explicit override).
+      GOOGLE_GENAI_USE_VERTEXAI: "false"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install workspace dependencies
+        run: uv sync --group dev
+
+      - name: Run pytest e2e for matrix pair
+        run: uv run pytest tests/e2e/ -v --pair=${{ matrix.pair }} --maxfail=3
+
+  playwright:
+    name: Playwright e2e (real LLM)
+    needs: preflight
+    if: needs.preflight.outputs.has_secrets == 'true'
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      LLM_PROVIDER: openai
+      LLM_MODEL: gpt-5.4-mini
+      IDUN_TELEMETRY_ENABLED: "false"
+      GOOGLE_GENAI_USE_VERTEXAI: "false"
+      # Admin REST guardrail-add scenario also needs Guardrails Hub.
+      GUARDRAILS_API_KEY: ${{ secrets.GUARDRAILS_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install workspace dependencies
+        run: uv sync --group dev
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install UI dependencies
+        working-directory: services/idun_agent_standalone_ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        working-directory: services/idun_agent_standalone_ui
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright real-LLM specs
+        working-directory: services/idun_agent_standalone_ui
+        run: pnpm exec playwright test e2e/chat-real-llm.spec.ts e2e/admin-edit-and-reload.spec.ts
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-${{ github.run_id }}
+          path: services/idun_agent_standalone_ui/test-results/
+          retention-days: 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,18 @@ The repo includes per-package `CLAUDE.md` files that orient contributors (and AI
 
 Reviewers reject PRs where scope-changing code is not accompanied by a CLAUDE.md update.
 
+## End-to-end test coverage for LLM-driven UI features
+
+Any new UI feature that triggers an LLM-driven flow must:
+
+1. **Add a Playwright spec** under `services/idun_agent_standalone_ui/e2e/` that exercises the feature end-to-end, with assertions tolerant of real-LLM output drift (substring or shape checks, never exact strings).
+2. **Wire the spec into `.github/workflows/e2e-real-llm.yml`** if it needs a new agent fixture (under `tests/e2e/fixtures/agents/`) or YAML template (under `tests/e2e/fixtures/configs/`). For specs that only consume an existing fixture, no workflow change is needed — `playwright test` runs every spec in the directory.
+3. **Run on the existing required-check pair (LG+OpenAI)** at minimum. Extend to other pairs (`lg-gemini`, `adk-gemini`) only when the feature has provider-specific behavior worth covering.
+
+The pytest layer at `tests/e2e/` covers the engine-side surface; the Playwright layer covers the UI-streaming + real-browser path. Both must stay green to merge to `main` or `develop`.
+
+See `tests/e2e/README.md` for the run-book and scenario-authoring guide.
+
 ## Code of Conduct
 
 By contributing to this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/services/idun_agent_standalone_ui/e2e/admin-edit-and-reload.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/admin-edit-and-reload.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+
+const SENTINEL = "qwertanu";
+
+test("admin guardrail addition triggers reload — chat with sentinel blocked", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/");
+  // baseURL is configured by playwright.config.ts; we infer from page.url().
+  const baseURL = new URL(page.url() || "/", page.url() || "http://127.0.0.1").origin;
+
+  // Pre-reload: send the sentinel-bearing prompt directly via the engine
+  // API. Should succeed (no guardrail registered yet).
+  const preRun = await request.post(`${baseURL}/agent/run`, {
+    headers: { Accept: "text/event-stream" },
+    data: {
+      threadId: "pre-reload",
+      runId: "pre-reload",
+      messages: [{ id: "m1", role: "user", content: `hello (${SENTINEL})` }],
+      tools: [],
+      context: [],
+      state: {},
+      forwardedProps: {},
+    },
+  });
+  expect(preRun.status()).toBe(200);
+
+  // Add a BAN_LIST input guard. Field shape is the same as pytest scenario 7
+  // (verified against StandaloneGuardrailCreate + ManagerBanListConfig
+  // schemas during Task 2.6 implementation):
+  //   - top-level: name, position, enabled, guardrail
+  //   - inner guardrail: snake_case (config_id, banned_words)
+  //   - reload status enum value: "reloaded" (lowercase)
+  const create = await request.post(`${baseURL}/admin/api/v1/guardrails`, {
+    data: {
+      name: "e2e-ui-ban-sentinel",
+      position: "input",
+      enabled: true,
+      guardrail: {
+        config_id: "ban_list",
+        banned_words: [SENTINEL],
+      },
+    },
+  });
+  expect([200, 201]).toContain(create.status());
+  const createBody = await create.json();
+  expect(createBody.reload?.status).toBe("reloaded");
+
+  // Reload the admin page and verify the new guardrail row is visible.
+  await page.goto("/admin/guardrails");
+  await expect(page.getByText("e2e-ui-ban-sentinel")).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Post-reload: same chat is now blocked.
+  const postRun = await request.post(`${baseURL}/agent/run`, {
+    headers: { Accept: "text/event-stream" },
+    data: {
+      threadId: "post-reload",
+      runId: "post-reload",
+      messages: [{ id: "m2", role: "user", content: `hello (${SENTINEL})` }],
+      tools: [],
+      context: [],
+      state: {},
+      forwardedProps: {},
+    },
+  });
+  expect(postRun.status()).toBe(429);
+});

--- a/services/idun_agent_standalone_ui/e2e/admin-edit-and-reload.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/admin-edit-and-reload.spec.ts
@@ -2,6 +2,18 @@ import { expect, test } from "@playwright/test";
 
 const SENTINEL = "qwertanu";
 
+// This spec exercises the admin REST → commit_with_reload → engine pickup
+// pipeline by adding a BAN_LIST guardrail. The engine's guardrail
+// converter requires GUARDRAILS_API_KEY to inject into the api_key field;
+// the new e2e-real-llm.yml workflow forwards it, but the existing
+// standalone-ci.yml Playwright job doesn't (and shouldn't — its boot
+// uses an inline echo agent without guardrails). Skip cleanly when the
+// key isn't present so this spec only fires from the real-LLM workflow.
+test.skip(
+  !process.env.GUARDRAILS_API_KEY,
+  "admin-edit-and-reload requires GUARDRAILS_API_KEY (real-LLM workflow only)",
+);
+
 test("admin guardrail addition triggers reload — chat with sentinel blocked", async ({
   page,
   request,

--- a/services/idun_agent_standalone_ui/e2e/boot-standalone.sh
+++ b/services/idun_agent_standalone_ui/e2e/boot-standalone.sh
@@ -15,6 +15,21 @@
 # command no longer accepts flags (simplified in the post-rework branch).
 set -euo pipefail
 
+# Real-LLM e2e: select provider + model. Defaults preserve the existing
+# echo-agent path when these vars aren't set. The spawned standalone
+# subprocess reads E2E_PROVIDER / E2E_MODEL via the agent fixtures.
+LLM_PROVIDER="${LLM_PROVIDER:-}"
+LLM_MODEL="${LLM_MODEL:-}"
+if [[ -n "$LLM_PROVIDER" ]]; then
+  export E2E_PROVIDER="$LLM_PROVIDER"
+  export E2E_MODEL="$LLM_MODEL"
+fi
+
+# Force AI Studio (GEMINI_API_KEY / GOOGLE_API_KEY) auth — host
+# .env files that export GOOGLE_GENAI_USE_VERTEXAI=TRUE would
+# otherwise route ChatGoogleGenerativeAI through Vertex ADC.
+export GOOGLE_GENAI_USE_VERTEXAI=false
+
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 PORT="${E2E_PORT:-8001}"
 TMPDIR_E2E="$(mktemp -d -t idun-e2e-XXXXXX)"

--- a/services/idun_agent_standalone_ui/e2e/chat-real-llm.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/chat-real-llm.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+// Selectors mirror chat.spec.ts. The chat surface has no data-testid —
+// we use placeholder + role idioms.
+
+test("chat happy path with real LLM streams a non-empty assistant reply", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const input = page.locator('textarea[placeholder^="Message"]');
+  await expect(input).toBeVisible({ timeout: 30_000 });
+
+  const prompt = "Say hello in one short sentence.";
+  await input.fill(prompt);
+  await page.getByRole("button", { name: /send message/i }).click();
+
+  // User bubble appears immediately.
+  await expect(page.locator(`text=${prompt}`).first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Wait for assistant reply. The chat doesn't tag assistant bubbles
+  // with a stable testid; we poll the page for any post-user text that
+  // is at least 20 chars (filtering out the prompt itself + the
+  // composer placeholder).
+  await expect
+    .poll(
+      async () => {
+        const all = await page.locator("body").innerText();
+        const trimmed = all
+          .replace(prompt, "")
+          .replace(/Message[^\n]*/g, "")
+          .trim();
+        return trimmed.length;
+      },
+      { timeout: 60_000, intervals: [500, 1_000, 2_000] },
+    )
+    .toBeGreaterThan(20);
+});

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -28,7 +28,7 @@ If neither `OPENAI_API_KEY` nor a Gemini key is set, the entire suite skips at s
 
 ## Layout
 
-```
+```text
 tests/e2e/
 ├── conftest.py                       # session + per-scenario fixtures
 ├── helpers/

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,111 @@
+# tests/e2e — real-agents real-LLM end-to-end suite
+
+This directory exercises the standalone end-to-end with real OpenAI and Gemini API keys. It is **not** part of the default `make test` / `make ci` runs; it is gated behind `OPENAI_API_KEY` plus `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) being set in the environment.
+
+The suite spawns a real `idun init --no-browser` subprocess per scenario, hits `/agent/run` and `/admin/api/v1/*` over HTTP, parses the AG-UI SSE wire format, and asserts loose contracts (event-shape, response-substring, JSON-schema parse) — never exact-string LLM output.
+
+## Run locally
+
+```bash
+# Required env vars
+export OPENAI_API_KEY=...
+export GEMINI_API_KEY=...        # AI Studio's modern naming; GOOGLE_API_KEY also accepted
+export GUARDRAILS_API_KEY=...    # for the reload-pipeline scenario
+
+# Run a single pair shard (~25-50s wall-clock)
+uv run pytest tests/e2e/ -v --pair=lg-openai
+uv run pytest tests/e2e/ -v --pair=lg-gemini
+uv run pytest tests/e2e/ -v --pair=adk-gemini
+
+# Run a single scenario
+uv run pytest tests/e2e/scenarios/test_tool_call.py --pair=lg-openai -v
+
+# Run the helper unit tests (no LLM, fast)
+uv run pytest tests/e2e/helpers/ -v
+```
+
+If neither `OPENAI_API_KEY` nor a Gemini key is set, the entire suite skips at session start.
+
+## Layout
+
+```
+tests/e2e/
+├── conftest.py                       # session + per-scenario fixtures
+├── helpers/
+│   ├── aguievents.py                 # SSE parser + loose-assertion vocab
+│   ├── judge.py                      # binary YES/NO LLM judge (gpt-5.4-mini)
+│   └── test_*.py                     # offline unit tests
+├── fixtures/
+│   ├── agents/                       # provider-agnostic agent modules
+│   └── configs/                      # Jinja2 YAML templates
+└── scenarios/
+    └── test_*.py                     # one file per scenario
+```
+
+## Pairs (SPEC §5.1)
+
+| Pair | Adapter | Provider | Model |
+|------|---------|----------|-------|
+| `lg-openai` | LangGraph | OpenAI | `gpt-5.4-mini` |
+| `lg-gemini` | LangGraph | Google AI Studio | `gemini-3-flash-preview` |
+| `adk-gemini` | Google ADK | Google AI Studio | `gemini-3-flash-preview` |
+
+Pair selection is via `--pair=<name>` (CLI) or `E2E_PAIR=<name>` (env). Default behavior (no flag, no env) is "all pairs" — but every scenario uses `@pytest.mark.pair(...)` markers to opt into specific pairs, so the conftest filters down at collection time.
+
+## Scenarios (SPEC §5)
+
+| # | Scenario | LG+OpenAI | LG+Gemini | ADK+Gemini |
+|---|---|:---:|:---:|:---:|
+| 1 | chat happy path | ✅ | ✅ | ✅ |
+| 2 | streaming SSE shape | ✅ | ✅ | ✅ |
+| 3 | tool call (calculator) | ✅ | ✅ | ✅ * |
+| 4 | multi-turn (judge-asserted) | ✅ | ✅ | ✅ |
+| 5 | guardrail block (boot-time YAML) | DEFERRED | — | — |
+| 6 | MCP roundtrip | DEFERRED | — | DEFERRED |
+| 7 | reload pipeline (admin REST) | ✅ | — | — |
+| 8 | structured output | ✅ | ✅ | — |
+| 9 | prompt templating | ✅ | ✅ | — |
+
+\* ADK+Gemini correctly issues the tool call but doesn't synthesize a follow-up text — tested via `_assert_result_visible` accepting either `TEXT_MESSAGE_CONTENT` or `TOOL_CALL_RESULT.content`.
+
+**Deferred scenarios** (5, 6, ADK MCP) are blocked on a standalone seeder gap tracked as T1 priority in `tasks/idun-rework-roadmap-08-05-2026/TODO.md`. The seeder currently materializes only `StandaloneAgentRow` and `StandaloneMemoryRow` from YAML; `guardrails:` and `mcp_servers:` blocks are silently dropped. Once that's fixed, un-defer SPEC §5 rows 5 + 6.
+
+## Adding a scenario
+
+1. **Decide pair scope.** Use `@pytest.mark.pair("lg-openai", ...)` to opt into pairs.
+2. **Reuse fixtures.** Most scenarios consume `agent_lg_chat.py` (LangGraph chat, no tools) or `agent_adk_chat.py` (ADK minimal). New fixtures only when the scenario needs novel agent shape (e.g. tool variants, MCP, guardrails).
+3. **Loose assertions only.** Reach for `assert_envelope_complete`, `assert_event_sequence`, `assert_response_contains`, `assert_tool_called_once`, `assert_json_schema_valid`. Reach for the `judge` helper only when no loose assertion can catch the regression (current usage: scenario 4 only).
+4. **Match the conftest's idioms.** `pair`, `render_config`, `standalone_with_config` are the three fixtures every scenario uses. `tmp_path` is implicit in pytest.
+5. **If the scenario requires UI-driven coverage**, also add a Playwright spec under `services/idun_agent_standalone_ui/e2e/` (per CONTRIBUTING.md).
+
+## Adding a fixture
+
+- Python agent modules go in `fixtures/agents/`. They must NOT use `from __future__ import annotations` — the engine's `importlib.util.spec_from_file_location` loader can't resolve PEP-563 deferred refs in TypedDict-shaped state schemas. Eager annotations work.
+- YAML templates go in `fixtures/configs/`. Use Jinja2 with `StrictUndefined` (the conftest's `render_config` enforces this — undeclared template vars fail loudly).
+- Provider-agnostic Python code reads `E2E_PROVIDER` / `E2E_MODEL` from env. The conftest's `_spawn_idun` exports those based on the active pair.
+
+## Debugging a hung subprocess
+
+The `standalone_with_config` fixture pipes the subprocess's stdout, drains it in a background thread (bounded `deque(maxlen=2000)`), and dumps the last ~4000 chars on failure. If a test hangs without surfacing output:
+
+1. Check the standalone is binding the port: `lsof -iTCP -sTCP:LISTEN -n -P | grep <port>`.
+2. Increase the health-poll timeout in `conftest.py::_wait_for_health` if your machine is slow (default 45s).
+3. Re-run with `-s` to stream stdout live: `uv run pytest tests/e2e/scenarios/<file>.py --pair=<pair> -v -s`.
+4. The conftest forces `GOOGLE_GENAI_USE_VERTEXAI=false` in the subprocess env. If you're seeing Vertex ADC errors, your host `.env` may be exporting `GOOGLE_GENAI_USE_VERTEXAI=TRUE` and `uv run` is auto-loading it — but the conftest override should win.
+5. `idun init` boots in ~5-10s on a warm cache, ~15-30s cold. If boot consistently exceeds 30s in CI, file an issue — the 45s health timeout has margin but not infinite.
+
+## Cost (SPEC §7.4)
+
+Projected at ~80 PR runs/month × 17 LLM-driven invocations × ~500 tokens × cheapest tier (`gpt-5.4-mini` + `gemini-3-flash-preview`): **< $1/month**. No cost circuit breaker in v1.
+
+## CI
+
+`.github/workflows/e2e-real-llm.yml` runs the full pytest matrix (3 pairs in parallel) plus the 2 Playwright specs on every PR to `main`/`develop`. Auto-skips on fork PRs (secrets gate).
+
+## References
+
+- SPEC: `tasks/e2e-real-agents-08-05-2026/SPEC.md` (in `Idun-Group/idun-dev`)
+- PLAN: `tasks/e2e-real-agents-08-05-2026/PLAN.md` (in `Idun-Group/idun-dev`)
+- Roadmap: `tasks/idun-rework-roadmap-08-05-2026/TODO.md` (in `Idun-Group/idun-dev`)
+- Engine adapters: `libs/idun_agent_engine/CLAUDE.md`
+- Standalone CLI: `libs/idun_agent_standalone/src/idun_agent_standalone/cli.py`

--- a/tests/e2e/fixtures/agents/agent_adk_chat.py
+++ b/tests/e2e/fixtures/agents/agent_adk_chat.py
@@ -1,0 +1,25 @@
+"""ADK minimal agent — Gemini-backed LlmAgent, no tools.
+
+Note: no `from __future__ import annotations` — engine module loader
+incompatibility (Phase 1.7 fix).
+"""
+
+import os
+
+from google.adk.agents import LlmAgent
+
+
+def _make() -> LlmAgent:
+    model = os.environ.get("E2E_MODEL", "gemini-3-flash-preview")
+    instruction = os.environ.get(
+        "E2E_SYSTEM_PROMPT",
+        "You are a precise assistant. Reply in one sentence.",
+    )
+    return LlmAgent(
+        name="e2e_adk_chat",
+        model=model,
+        instruction=instruction,
+    )
+
+
+root_agent: LlmAgent = _make()

--- a/tests/e2e/fixtures/agents/agent_adk_with_tools.py
+++ b/tests/e2e/fixtures/agents/agent_adk_with_tools.py
@@ -1,0 +1,39 @@
+"""ADK agent with FunctionTool calculator.
+
+Mirror of agent_lg_calculator.py but using ADK's FunctionTool API
+instead of LangChain @tool decorator. The instruction is firm about
+tool use — Gemini sometimes computes inline if not pushed.
+"""
+
+import os
+
+from google.adk.agents import LlmAgent
+from google.adk.tools import FunctionTool
+
+
+def add(a: int, b: int) -> int:
+    """Return a + b."""
+    return a + b
+
+
+def multiply(a: int, b: int) -> int:
+    """Return a * b."""
+    return a * b
+
+
+def _make() -> LlmAgent:
+    model = os.environ.get("E2E_MODEL", "gemini-3-flash-preview")
+    instruction = (
+        "You are a calculator. When the user asks for arithmetic, "
+        "ALWAYS call the appropriate tool. Reply with the integer "
+        "result only, nothing else."
+    )
+    return LlmAgent(
+        name="e2e_adk_tools",
+        model=model,
+        instruction=instruction,
+        tools=[FunctionTool(add), FunctionTool(multiply)],
+    )
+
+
+root_agent: LlmAgent = _make()

--- a/tests/e2e/fixtures/configs/adk_calculator.yaml.j2
+++ b/tests/e2e/fixtures/configs/adk_calculator.yaml.j2
@@ -1,0 +1,14 @@
+server:
+  api:
+    port: {{ port | default(8000) }}
+
+agent:
+  type: "ADK"
+  config:
+    name: "e2e-adk-tools"
+    app_name: "e2e_adk_tools"
+    agent: "{{ agent_module_path }}:root_agent"
+    session_service:
+      type: "in_memory"
+    memory_service:
+      type: "in_memory"

--- a/tests/e2e/fixtures/configs/adk_chat.yaml.j2
+++ b/tests/e2e/fixtures/configs/adk_chat.yaml.j2
@@ -1,0 +1,14 @@
+server:
+  api:
+    port: {{ port | default(8000) }}
+
+agent:
+  type: "ADK"
+  config:
+    name: "e2e-adk-chat"
+    app_name: "e2e_adk_chat"
+    agent: "{{ agent_module_path }}:root_agent"
+    session_service:
+      type: "in_memory"
+    memory_service:
+      type: "in_memory"

--- a/tests/e2e/fixtures/configs/adk_with_session.yaml.j2
+++ b/tests/e2e/fixtures/configs/adk_with_session.yaml.j2
@@ -1,0 +1,14 @@
+server:
+  api:
+    port: {{ port | default(8000) }}
+
+agent:
+  type: "ADK"
+  config:
+    name: "e2e-adk-multiturn"
+    app_name: "e2e_adk_multiturn"
+    agent: "{{ agent_module_path }}:root_agent"
+    session_service:
+      type: "in_memory"
+    memory_service:
+      type: "in_memory"

--- a/tests/e2e/helpers/aguievents.py
+++ b/tests/e2e/helpers/aguievents.py
@@ -26,6 +26,7 @@ class AGUIEvent(TypedDict, total=False):
     delta: str
     toolCallId: str
     toolCallName: str
+    content: str
 
 
 def parse_sse_lines(lines: Iterable[str]) -> list[AGUIEvent]:

--- a/tests/e2e/scenarios/test_streaming_sse_shape.py
+++ b/tests/e2e/scenarios/test_streaming_sse_shape.py
@@ -47,7 +47,7 @@ def test_streaming_sse_shape_adk(pair, render_config, standalone_with_config) ->
         agent_module_path=ADK_AGENT,
     )
     with standalone_with_config(config) as base_url:
-        events = _post_run(base_url, "Hi.")
+        events = post_run(base_url, "Hi.")
     assert_envelope_complete(events)
     assert_event_sequence(
         events,

--- a/tests/e2e/scenarios/test_streaming_sse_shape.py
+++ b/tests/e2e/scenarios/test_streaming_sse_shape.py
@@ -34,3 +34,28 @@ def test_streaming_sse_shape_langgraph(
             "RUN_FINISHED",
         ],
     )
+
+
+ADK_AGENT = "tests/e2e/fixtures/agents/agent_adk_chat.py"
+
+
+@pytest.mark.pair("adk-gemini")
+def test_streaming_sse_shape_adk(pair, render_config, standalone_with_config) -> None:
+    config = render_config(
+        "adk_chat.yaml.j2",
+        port=0,
+        agent_module_path=ADK_AGENT,
+    )
+    with standalone_with_config(config) as base_url:
+        events = _post_run(base_url, "Hi.")
+    assert_envelope_complete(events)
+    assert_event_sequence(
+        events,
+        [
+            "RUN_STARTED",
+            "TEXT_MESSAGE_START",
+            "TEXT_MESSAGE_CONTENT+",
+            "TEXT_MESSAGE_END",
+            "RUN_FINISHED",
+        ],
+    )

--- a/tests/e2e/scenarios/test_tool_call.py
+++ b/tests/e2e/scenarios/test_tool_call.py
@@ -30,7 +30,7 @@ def _assert_result_visible(events: list[AGUIEvent], substring: str) -> None:
     if substring in text:
         return
     tool_payloads = [
-        e.get("content", "") for e in events if e.get("type") == "TOOL_CALL_RESULT"
+        str(e.get("content", "")) for e in events if e.get("type") == "TOOL_CALL_RESULT"
     ]
     combined = " ".join(tool_payloads)
     assert substring in combined, (
@@ -67,7 +67,7 @@ def test_tool_call_adk_multiply(pair, render_config, standalone_with_config) -> 
         agent_module_path=ADK_AGENT,
     )
     with standalone_with_config(config) as base_url:
-        events = _post_run(
+        events = post_run(
             base_url,
             "Use the multiply tool to compute 47 times 13. "
             "Reply with the integer result only.",

--- a/tests/e2e/scenarios/test_tool_call.py
+++ b/tests/e2e/scenarios/test_tool_call.py
@@ -3,6 +3,7 @@
 import pytest
 
 from tests.e2e.helpers.aguievents import (
+    AGUIEvent,
     assert_envelope_complete,
     assert_response_contains,
     assert_tool_called_once,
@@ -10,6 +11,32 @@ from tests.e2e.helpers.aguievents import (
 from tests.e2e.helpers.run_client import post_run
 
 LG_AGENT = "tests/e2e/fixtures/agents/agent_lg_calculator.py"
+ADK_AGENT = "tests/e2e/fixtures/agents/agent_adk_with_tools.py"
+
+
+def _assert_result_visible(events: list[AGUIEvent], substring: str) -> None:
+    """Assert the substring appears in either text deltas or tool-call results.
+
+    LangGraph adapters typically synthesize a final TEXT_MESSAGE_CONTENT
+    after the tool returns, so the result lands in the streamed text.
+    ADK+Gemini, however, frequently treats the TOOL_CALL_RESULT as the
+    final response and never emits a follow-up text message — the result
+    is still visible to an AG-UI consumer through the TOOL_CALL_RESULT
+    ``content`` field. Accept either delivery shape.
+    """
+    text = "".join(
+        e.get("delta", "") for e in events if e.get("type") == "TEXT_MESSAGE_CONTENT"
+    )
+    if substring in text:
+        return
+    tool_payloads = [
+        e.get("content", "") for e in events if e.get("type") == "TOOL_CALL_RESULT"
+    ]
+    combined = " ".join(tool_payloads)
+    assert substring in combined, (
+        f"expected substring {substring!r} not found in text response "
+        f"({text!r}) or tool-call results ({combined!r})"
+    )
 
 
 @pytest.mark.pair("lg-openai", "lg-gemini")
@@ -30,3 +57,21 @@ def test_tool_call_langgraph_multiply(
     assert_envelope_complete(events)
     assert_tool_called_once(events, "multiply")
     assert_response_contains(events, "611")
+
+
+@pytest.mark.pair("adk-gemini")
+def test_tool_call_adk_multiply(pair, render_config, standalone_with_config) -> None:
+    config = render_config(
+        "adk_calculator.yaml.j2",
+        port=0,
+        agent_module_path=ADK_AGENT,
+    )
+    with standalone_with_config(config) as base_url:
+        events = _post_run(
+            base_url,
+            "Use the multiply tool to compute 47 times 13. "
+            "Reply with the integer result only.",
+        )
+    assert_envelope_complete(events)
+    assert_tool_called_once(events, "multiply")
+    _assert_result_visible(events, "611")


### PR DESCRIPTION
## Summary

Phase 6 of the real-LLM e2e suite: documentation. Closes the suite's docs surface — anyone who lands a UI-LLM feature now has a clear contract, and any new contributor can run + extend the suite locally.

**PR 5 of 5** in the stacked series. Base = `feat/e2e-real-agents-phase-5-ci` (PR #581).

## What ships

- **`CONTRIBUTING.md`** — appended a section: "End-to-end test coverage for LLM-driven UI features." The rule: any new UI feature that triggers an LLM-driven flow must add a Playwright spec under `services/idun_agent_standalone_ui/e2e/`, wire it into the CI workflow if it needs new agent fixtures, and run on the LG+OpenAI required-check pair at minimum.
- **`tests/e2e/README.md`** — local run-book + scenario-authoring guide. Covers env vars, pair filtering, scenario layout, fixture conventions, debugging hung subprocesses, cost projection, and references back to the SPEC + PLAN + roadmap in `Idun-Group/idun-dev`.

## Test plan

- [ ] CodeRabbit review.
- [ ] Reviewer skim of the README to catch any guidance that's already stale.

## Notes for reviewers

- Stack: this is the last PR in the series. Once Phases 0-5 merge to develop, this branch will rebase cleanly onto develop.
- Both files are docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with requirements for end-to-end test coverage of LLM-driven UI features, including Playwright test specifications
  * Added comprehensive documentation for the end-to-end test suite covering local execution, supported model pairings, scenario authoring, and debugging guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->