### PR TITLE
feat(standalone/seed): persist all top-level YAML config blocks (T1: seeder gap)

### DIFF
--- a/libs/idun_agent_schema/src/idun_agent_schema/manager/guardrail_configs.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/manager/guardrail_configs.py
@@ -1,5 +1,5 @@
 import os
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 from pydantic import BaseModel, Field
 
@@ -32,7 +32,9 @@ class SimpleNSFWTextConfig(BaseModel):
 
 
 class SimpleToxicLanguageConfig(BaseModel):
-    config_id: Literal[GuardrailConfigId.TOXIC_LANGUAGE] = GuardrailConfigId.TOXIC_LANGUAGE
+    config_id: Literal[GuardrailConfigId.TOXIC_LANGUAGE] = (
+        GuardrailConfigId.TOXIC_LANGUAGE
+    )
     api_key: str = ""
     reject_message: str = ""
     threshold: float = Field(
@@ -41,7 +43,9 @@ class SimpleToxicLanguageConfig(BaseModel):
 
 
 class SimpleGibberishTextConfig(BaseModel):
-    config_id: Literal[GuardrailConfigId.GIBBERISH_TEXT] = GuardrailConfigId.GIBBERISH_TEXT
+    config_id: Literal[GuardrailConfigId.GIBBERISH_TEXT] = (
+        GuardrailConfigId.GIBBERISH_TEXT
+    )
     api_key: str = ""
     reject_message: str = ""
     threshold: float = Field(
@@ -59,7 +63,9 @@ class SimpleBiasCheckConfig(BaseModel):
 
 
 class SimpleCompetitionCheckConfig(BaseModel):
-    config_id: Literal[GuardrailConfigId.COMPETITION_CHECK] = GuardrailConfigId.COMPETITION_CHECK
+    config_id: Literal[GuardrailConfigId.COMPETITION_CHECK] = (
+        GuardrailConfigId.COMPETITION_CHECK
+    )
     api_key: str = ""
     reject_message: str = ""
     competitors: list[str] = Field(
@@ -68,7 +74,9 @@ class SimpleCompetitionCheckConfig(BaseModel):
 
 
 class SimpleCorrectLanguageConfig(BaseModel):
-    config_id: Literal[GuardrailConfigId.CORRECT_LANGUAGE] = GuardrailConfigId.CORRECT_LANGUAGE
+    config_id: Literal[GuardrailConfigId.CORRECT_LANGUAGE] = (
+        GuardrailConfigId.CORRECT_LANGUAGE
+    )
     api_key: str = ""
     reject_message: str = ""
     expected_languages: list[str] = Field(
@@ -77,7 +85,9 @@ class SimpleCorrectLanguageConfig(BaseModel):
 
 
 class SimpleRestrictToTopicConfig(BaseModel):
-    config_id: Literal[GuardrailConfigId.RESTRICT_TO_TOPIC] = GuardrailConfigId.RESTRICT_TO_TOPIC
+    config_id: Literal[GuardrailConfigId.RESTRICT_TO_TOPIC] = (
+        GuardrailConfigId.RESTRICT_TO_TOPIC
+    )
     api_key: str = ""
     reject_message: str = ""
     valid_topics: list[str] = Field(
@@ -99,6 +109,7 @@ ManagerGuardrailConfig = Union[
     SimpleCorrectLanguageConfig,
     SimpleRestrictToTopicConfig,
 ]
+
 
 def convert_guardrail(guardrails_data: dict) -> dict:
     if not guardrails_data:
@@ -135,13 +146,15 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                     else:
                         banned_words.append(word.strip())
 
-                converted[position].append({
-                    "config_id": "ban_list",
-                    "api_key": api_key,
-                    "reject_message": _reject_message(guardrail, "ban!!"),
-                    "guard_url": "hub://guardrails/ban_list",
-                    "guard_params": {"banned_words": banned_words},
-                })
+                converted[position].append(
+                    {
+                        "config_id": "ban_list",
+                        "api_key": api_key,
+                        "reject_message": _reject_message(guardrail, "ban!!"),
+                        "guard_url": "hub://guardrails/ban_list",
+                        "guard_params": {"banned_words": banned_words},
+                    }
+                )
 
             elif (
                 config_id == "detect_pii"
@@ -159,82 +172,190 @@ def convert_guardrail(guardrails_data: dict) -> dict:
                     pii_entity_map.get(entity, entity)
                     for entity in guardrail["pii_entities"]
                 ]
-                converted[position].append({
-                    "config_id": "detect_pii",
-                    "api_key": api_key,
-                    "reject_message": _reject_message(guardrail, "PII detected"),
-                    "guard_url": "hub://guardrails/detect_pii",
-                    "guard_params": {
-                        "pii_entities": mapped_entities,
-                        "on_fail": "exception",
-                    },
-                })
+                converted[position].append(
+                    {
+                        "config_id": "detect_pii",
+                        "api_key": api_key,
+                        "reject_message": _reject_message(guardrail, "PII detected"),
+                        "guard_url": "hub://guardrails/detect_pii",
+                        "guard_params": {
+                            "pii_entities": mapped_entities,
+                            "on_fail": "exception",
+                        },
+                    }
+                )
 
             elif config_id == "nsfw_text" and "api_key" not in guardrail:
-                converted[position].append({
-                    "config_id": "nsfw_text",
-                    "api_key": api_key,
-                    "reject_message": _reject_message(guardrail, "NSFW content detected"),
-                    "guard_url": "hub://guardrails/nsfw_text",
-                    "threshold": guardrail["threshold"],
-                })
+                converted[position].append(
+                    {
+                        "config_id": "nsfw_text",
+                        "api_key": api_key,
+                        "reject_message": _reject_message(
+                            guardrail, "NSFW content detected"
+                        ),
+                        "guard_url": "hub://guardrails/nsfw_text",
+                        "threshold": guardrail["threshold"],
+                    }
+                )
 
             elif config_id == "toxic_language" and "api_key" not in guardrail:
-                converted[position].append({
-                    "config_id": "toxic_language",
-                    "api_key": api_key,
-                    "reject_message": _reject_message(guardrail, "Toxic language detected"),
-                    "guard_url": "hub://guardrails/toxic_language",
-                    "threshold": guardrail["threshold"],
-                })
+                converted[position].append(
+                    {
+                        "config_id": "toxic_language",
+                        "api_key": api_key,
+                        "reject_message": _reject_message(
+                            guardrail, "Toxic language detected"
+                        ),
+                        "guard_url": "hub://guardrails/toxic_language",
+                        "threshold": guardrail["threshold"],
+                    }
+                )
 
             elif config_id == "gibberish_text" and "api_key" not in guardrail:
-                converted[position].append({
-                    "config_id": "gibberish_text",
-                    "api_key": api_key,
-                    "reject_message": _reject_message(guardrail, "Gibberish text detected"),
-                    "guard_url": "hub://guardrails/gibberish_text",
-                    "threshold": guardrail["threshold"],
-                })
+                converted[position].append(
+                    {
+                        "config_id": "gibberish_text",
+                        "api_key": api_key,
+                        "reject_message": _reject_message(
+                            guardrail, "Gibberish text detected"
+                        ),
+                        "guard_url": "hub://guardrails/gibberish_text",
+                        "threshold": guardrail["threshold"],
+                    }
+                )
 
             elif config_id == "bias_check" and "api_key" not in guardrail:
-                converted[position].append({
-                    "config_id": "bias_check",
-                    "api_key": api_key,
-                    "reject_message": _reject_message(guardrail, "Bias detected"),
-                    "guard_url": "hub://guardrails/bias_check",
-                    "threshold": guardrail["threshold"],
-                })
+                converted[position].append(
+                    {
+                        "config_id": "bias_check",
+                        "api_key": api_key,
+                        "reject_message": _reject_message(guardrail, "Bias detected"),
+                        "guard_url": "hub://guardrails/bias_check",
+                        "threshold": guardrail["threshold"],
+                    }
+                )
 
             elif config_id == "competition_check" and "api_key" not in guardrail:
-                converted[position].append({
-                    "config_id": "competition_check",
-                    "api_key": api_key,
-                    "reject_message": _reject_message(guardrail, "Competitor mentioned"),
-                    "guard_url": "hub://guardrails/competitor_check",
-                    "competitors": guardrail["competitors"],
-                })
+                converted[position].append(
+                    {
+                        "config_id": "competition_check",
+                        "api_key": api_key,
+                        "reject_message": _reject_message(
+                            guardrail, "Competitor mentioned"
+                        ),
+                        "guard_url": "hub://guardrails/competitor_check",
+                        "competitors": guardrail["competitors"],
+                    }
+                )
 
             elif config_id == "correct_language" and "api_key" not in guardrail:
-                converted[position].append({
-                    "config_id": "correct_language",
-                    "api_key": api_key,
-                    "reject_message": _reject_message(guardrail, "Incorrect language detected"),
-                    "guard_url": "hub://scb-10x/correct_language",
-                    "expected_languages": guardrail["expected_languages"],
-                })
+                converted[position].append(
+                    {
+                        "config_id": "correct_language",
+                        "api_key": api_key,
+                        "reject_message": _reject_message(
+                            guardrail, "Incorrect language detected"
+                        ),
+                        "guard_url": "hub://scb-10x/correct_language",
+                        "expected_languages": guardrail["expected_languages"],
+                    }
+                )
 
             elif config_id == "restrict_to_topic" and "api_key" not in guardrail:
-                converted[position].append({
-                    "config_id": "restrict_to_topic",
-                    "api_key": api_key,
-                    "reject_message": _reject_message(guardrail, "Off-topic content detected"),
-                    "guard_url": "hub://tryolabs/restricttotopic",
-                    "valid_topics": guardrail.get("valid_topics", []),
-                    "invalid_topics": guardrail.get("invalid_topics", []),
-                })
+                converted[position].append(
+                    {
+                        "config_id": "restrict_to_topic",
+                        "api_key": api_key,
+                        "reject_message": _reject_message(
+                            guardrail, "Off-topic content detected"
+                        ),
+                        "guard_url": "hub://tryolabs/restricttotopic",
+                        "valid_topics": guardrail.get("valid_topics", []),
+                        "invalid_topics": guardrail.get("invalid_topics", []),
+                    }
+                )
 
             else:
                 converted[position].append(guardrail)
 
     return converted
+
+
+# Engine-shape fields that have no place in the manager-shape models.
+# Stripped by ``to_manager_shape`` before producing the manager dict.
+# ``api_key`` is stripped because the assembly path
+# (``services/engine_config._layer_guardrails``) injects it from the
+# ``GUARDRAILS_API_KEY`` env var; storing the engine's empty default in
+# the DB would force the assembly layer to special case it. ``guard_url``
+# is hardcoded per guard inside ``convert_guardrail`` so storing it would
+# duplicate that knowledge in two places.
+_ENGINE_ONLY_FIELDS: frozenset[str] = frozenset({"api_key", "guard_url"})
+
+# Engine guard ``config_id`` values that have a corresponding
+# ``Simple*Config`` manager model and are therefore round-trippable
+# through ``convert_guardrail``. The manager namespace covers a
+# deliberate subset of the engine's GuardrailConfigId enum (the guards
+# the legacy manager service ever shipped). Engine-only ids
+# (``detect_jailbreak``, ``prompt_injection``, ``rag_hallucination``,
+# ``code_scanner``, ``model_armor``, ``custom_llm``) fall through to the
+# passthrough branch in ``convert_guardrail`` and are likewise stored
+# verbatim by ``to_manager_shape`` minus the engine-only fields.
+_MANAGER_SUPPORTED_IDS: frozenset[str] = frozenset(
+    {
+        GuardrailConfigId.BAN_LIST.value,
+        GuardrailConfigId.DETECT_PII.value,
+        GuardrailConfigId.NSFW_TEXT.value,
+        GuardrailConfigId.TOXIC_LANGUAGE.value,
+        GuardrailConfigId.GIBBERISH_TEXT.value,
+        GuardrailConfigId.BIAS_CHECK.value,
+        GuardrailConfigId.COMPETITION_CHECK.value,
+        GuardrailConfigId.CORRECT_LANGUAGE.value,
+        GuardrailConfigId.RESTRICT_TO_TOPIC.value,
+    }
+)
+
+
+def to_manager_shape(engine_guard: Any) -> dict[str, Any]:
+    """Convert one engine-shape guardrail into the manager-shape dict.
+
+    The inverse of one iteration of ``convert_guardrail``. Used by the
+    standalone seeder to materialize the engine YAML's typed
+    ``GuardrailsV2`` configs into the manager-shape JSON column the
+    standalone DB stores.
+
+    The round trip
+    ``engine → to_manager_shape → manager → convert_guardrail → engine``
+    is lossless modulo two engine-only fields:
+
+    - ``api_key``: re-injected at assembly time from the
+      ``GUARDRAILS_API_KEY`` env var (see
+      ``services/engine_config._layer_guardrails``). Storing the
+      engine's empty default in the DB would force the assembly to
+      special case it.
+    - ``guard_url``: hardcoded per guard inside ``convert_guardrail``.
+
+    For unrecognized ``config_id`` values (engine guards that never had
+    a manager equivalent) we still strip the engine-only fields and
+    return the remaining payload verbatim — this matches
+    ``convert_guardrail``'s passthrough branch on the way back.
+
+    Accepts a Pydantic model instance (typed ``GuardrailConfig`` from
+    ``GuardrailsV2.input``/``.output``) or an already-dumped dict so
+    callers can use whichever shape is convenient.
+    """
+    if hasattr(engine_guard, "model_dump"):
+        engine_dict = engine_guard.model_dump(mode="json", exclude_none=True)
+    else:
+        engine_dict = dict(engine_guard)
+
+    # Normalize the config_id to its string value so downstream lookups
+    # against the manager union are stable regardless of whether the
+    # caller passed a Pydantic model (enum value) or a raw dict.
+    raw_id = engine_dict.get("config_id")
+    if hasattr(raw_id, "value"):
+        engine_dict["config_id"] = raw_id.value
+
+    manager_dict: dict[str, Any] = {
+        k: v for k, v in engine_dict.items() if k not in _ENGINE_ONLY_FIELDS
+    }
+    return manager_dict

--- a/libs/idun_agent_schema/tests/manager/__init__.py
+++ b/libs/idun_agent_schema/tests/manager/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the idun_agent_schema.manager namespace."""

--- a/libs/idun_agent_schema/tests/manager/test_guardrail_configs.py
+++ b/libs/idun_agent_schema/tests/manager/test_guardrail_configs.py
@@ -1,0 +1,135 @@
+"""Tests for ``idun_agent_schema.manager.guardrail_configs``.
+
+Pins the round-trip contract used by the standalone seeder and the
+``services/engine_config._layer_guardrails`` assembly path:
+
+    engine → to_manager_shape → manager → convert_guardrail → engine
+
+is lossless modulo two engine-only fields (``api_key`` re-injected from
+the ``GUARDRAILS_API_KEY`` env var, ``guard_url`` hardcoded inside
+``convert_guardrail``).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from idun_agent_schema.engine.guardrails_v2 import (
+    BanListConfig,
+    DetectPIIConfig,
+    GuardrailsV2,
+    ToxicLanguageConfig,
+)
+from idun_agent_schema.manager.guardrail_configs import (
+    convert_guardrail,
+    to_manager_shape,
+)
+
+
+@pytest.fixture(autouse=True)
+def _set_guardrails_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``convert_guardrail`` raises if GUARDRAILS_API_KEY is unset."""
+    monkeypatch.setenv("GUARDRAILS_API_KEY", "test-key")
+
+
+def _round_trip(engine_guard: object, position: str = "input") -> object:
+    """engine → to_manager_shape → manager dict → convert_guardrail → engine."""
+    manager_dict = to_manager_shape(engine_guard)
+    converted = convert_guardrail({position: [manager_dict]})
+    return GuardrailsV2.model_validate(converted)
+
+
+def test_to_manager_shape_strips_engine_only_fields() -> None:
+    """``api_key`` and ``guard_url`` are stripped on the way down to manager shape."""
+    engine_guard = BanListConfig(
+        api_key="secret",
+        guard_url="hub://guardrails/ban_list",
+        banned_words=["alpha", "beta"],
+    )
+    manager_dict = to_manager_shape(engine_guard)
+
+    assert "api_key" not in manager_dict
+    assert "guard_url" not in manager_dict
+    # Manager-shape fields preserved.
+    assert manager_dict["config_id"] == "ban_list"
+    assert manager_dict["banned_words"] == ["alpha", "beta"]
+
+
+def test_round_trip_ban_list() -> None:
+    """BAN_LIST round-trips: banned_words preserved, api_key re-injected."""
+    original = BanListConfig(
+        api_key="secret",
+        banned_words=["alpha", "beta"],
+        reject_message="ban!!",
+    )
+
+    rebuilt = _round_trip(original, position="input")
+
+    assert isinstance(rebuilt, GuardrailsV2)
+    assert len(rebuilt.input) == 1
+    assert len(rebuilt.output) == 0
+    rebuilt_guard = rebuilt.input[0]
+    assert isinstance(rebuilt_guard, BanListConfig)
+    assert rebuilt_guard.banned_words == original.banned_words
+    assert rebuilt_guard.reject_message == original.reject_message
+    # api_key is re-injected from env (the fixture). guard_url is the hardcoded default.
+    assert rebuilt_guard.api_key == os.environ["GUARDRAILS_API_KEY"]
+    assert rebuilt_guard.guard_url == "hub://guardrails/ban_list"
+
+
+def test_round_trip_detect_pii() -> None:
+    """DETECT_PII round-trips: pii_entities preserved, on_fail injected by convert."""
+    original = DetectPIIConfig(
+        api_key="secret",
+        pii_entities=["EMAIL_ADDRESS", "PHONE_NUMBER"],
+    )
+
+    rebuilt = _round_trip(original, position="output")
+
+    assert len(rebuilt.output) == 1
+    rebuilt_guard = rebuilt.output[0]
+    assert isinstance(rebuilt_guard, DetectPIIConfig)
+    assert rebuilt_guard.pii_entities == original.pii_entities
+    # convert_guardrail unconditionally sets on_fail="exception" inside
+    # guard_params; the engine model validator flattens it back.
+    assert rebuilt_guard.on_fail == "exception"
+
+
+def test_round_trip_toxic_language_threshold_preserved() -> None:
+    """Threshold-style guards (TOXIC_LANGUAGE) round-trip the float verbatim."""
+    original = ToxicLanguageConfig(
+        api_key="secret",
+        threshold=0.42,
+        reject_message="No.",
+    )
+
+    rebuilt = _round_trip(original, position="input")
+
+    assert len(rebuilt.input) == 1
+    rebuilt_guard = rebuilt.input[0]
+    assert isinstance(rebuilt_guard, ToxicLanguageConfig)
+    assert rebuilt_guard.threshold == pytest.approx(0.42)
+    assert rebuilt_guard.reject_message == "No."
+
+
+def test_to_manager_shape_accepts_dict_input() -> None:
+    """The helper accepts an already-dumped dict, not just Pydantic models.
+
+    The seeder iterates typed configs; downstream callers in tests and
+    future tools may pass a dict directly. Both forms must work.
+    """
+    engine_dict = {
+        "config_id": "ban_list",
+        "api_key": "secret",
+        "guard_url": "hub://guardrails/ban_list",
+        "banned_words": ["x"],
+        "reject_message": "ban!!",
+    }
+    manager_dict = to_manager_shape(engine_dict)
+    assert manager_dict == {
+        "config_id": "ban_list",
+        "banned_words": ["x"],
+        "reject_message": "ban!!",
+    }

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
@@ -27,6 +27,7 @@ from idun_agent_standalone.infrastructure.db.models.observability import (
     StandaloneObservabilityRow,
 )
 from idun_agent_standalone.infrastructure.db.models.prompt import StandalonePromptRow
+from idun_agent_standalone.infrastructure.db.models.sso import StandaloneSsoRow
 
 logger = get_logger(__name__)
 
@@ -173,6 +174,36 @@ async def _seed_observability_if_empty(
     return 1
 
 
+async def _seed_sso_if_empty(session: AsyncSession, engine_config: EngineConfig) -> int:
+    """Seed the singleton ``StandaloneSsoRow`` from YAML.
+
+    ``engine_config.sso`` is a single ``SSOConfig`` (not a list);
+    standalone stores it as a singleton row keyed by ``id="singleton"``.
+    The assembly layer (``services/engine_config._layer_sso``) reads the
+    row back and layers it onto ``EngineConfig.sso`` at runtime.
+
+    No-op if the singleton row already exists or the YAML omits the
+    ``sso:`` block. Absence means SSO is not configured and agent routes
+    are unprotected — that is a valid configuration, not an error.
+    """
+    if engine_config.sso is None:
+        return 0
+
+    existing = await session.get(StandaloneSsoRow, "singleton")
+    if existing is not None:
+        logger.info("sso singleton exists; skipping seed")
+        return 0
+
+    session.add(
+        StandaloneSsoRow(
+            id="singleton",
+            sso_config=engine_config.sso.model_dump(mode="json"),
+        )
+    )
+    await session.commit()
+    return 1
+
+
 async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> None:
     """Seed each resource row from YAML if the DB is empty.
 
@@ -203,6 +234,7 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         "memory": 0,
         "prompts": 0,
         "observability": 0,
+        "sso": 0,
     }
 
     async with sm() as session:
@@ -231,11 +263,18 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         except Exception:
             logger.exception("Failed to seed observability row from %s", config_path)
 
+    async with sm() as session:
+        try:
+            seeded["sso"] = await _seed_sso_if_empty(session, engine_config)
+        except Exception:
+            logger.exception("Failed to seed sso row from %s", config_path)
+
     logger.info(
-        "seed complete from %s: agent=%d memory=%d prompts=%d observability=%d",
+        "seed complete from %s: agent=%d memory=%d prompts=%d observability=%d sso=%d",
         config_path,
         seeded["agent"],
         seeded["memory"],
         seeded["prompts"],
         seeded["observability"],
+        seeded["sso"],
     )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
@@ -3,6 +3,12 @@
 Seeds the singleton agent plus the optional memory row from
 ``IDUN_CONFIG_PATH`` if the DB is empty. Schema creation is handled
 by Alembic via ``db.migrate.upgrade_head`` before this runs.
+
+The seeder is split into one ``_seed_<resource>_if_empty`` helper per
+resource, called by the ``seed_from_yaml_if_empty`` orchestrator. Each
+helper runs under its own try/except so a future per-resource seeder
+(observability, guardrails, ...) cannot kill the agent boot if it
+explodes — the operator still gets a working agent and a logged error.
 """
 
 from __future__ import annotations
@@ -10,8 +16,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from idun_agent_engine.core.config_builder import ConfigBuilder
+from idun_agent_engine.core.engine_config import EngineConfig
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
@@ -20,68 +27,125 @@ from idun_agent_standalone.infrastructure.db.models.memory import StandaloneMemo
 logger = get_logger(__name__)
 
 
-async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> None:
-    """Seed the agent (and optional memory) row if the DB has no agent."""
-    async with sm() as session:
-        existing = (
-            await session.execute(select(StandaloneAgentRow))
-        ).scalar_one_or_none()
-        if existing is not None:
-            return
+async def _seed_agent_if_empty(
+    session: AsyncSession, engine_config: EngineConfig
+) -> int:
+    """Seed the singleton agent row from ``engine_config`` if absent.
 
-        if not config_path.exists():
+    Returns the number of rows added (0 or 1) so the orchestrator can
+    log a coverage summary at the end of the seed pass.
+    """
+    existing = (await session.execute(select(StandaloneAgentRow))).scalar_one_or_none()
+    if existing is not None:
+        return 0
+
+    agent_config = engine_config.agent.config
+    framework = engine_config.agent.type.value
+
+    # Memory lives on its own row. Pull it off the agent config so
+    # base_engine_config holds only server + agent fields.
+    inner_dict = agent_config.model_dump(exclude_none=True)
+    inner_dict.pop("checkpointer", None)
+    inner_dict.pop("session_service", None)
+
+    base_engine_config = {
+        "server": engine_config.server.model_dump(),
+        "agent": {"type": framework, "config": inner_dict},
+    }
+
+    session.add(
+        StandaloneAgentRow(
+            name=agent_config.name,
+            base_engine_config=base_engine_config,
+            status="draft",
+        )
+    )
+    await session.commit()
+    return 1
+
+
+async def _seed_memory_if_empty(
+    session: AsyncSession, engine_config: EngineConfig
+) -> int:
+    """Seed the singleton memory row if the YAML declared one.
+
+    LangGraph configs put the persistence handle under ``checkpointer``;
+    ADK configs put it under ``session_service``. Either is mapped onto
+    the standalone memory row's ``memory_config`` JSON column. Absence
+    means the agent runs on the engine's in-memory default — that is a
+    valid configuration, not an error.
+    """
+    existing = (await session.execute(select(StandaloneMemoryRow))).scalar_one_or_none()
+    if existing is not None:
+        return 0
+
+    agent_config = engine_config.agent.config
+    framework = engine_config.agent.type.value
+
+    checkpointer = getattr(agent_config, "checkpointer", None)
+    session_service = getattr(agent_config, "session_service", None)
+    memory_payload: dict | None = None
+    if checkpointer is not None:
+        memory_payload = checkpointer.model_dump()
+    elif session_service is not None:
+        memory_payload = session_service.model_dump()
+
+    if memory_payload is None:
+        return 0
+
+    session.add(
+        StandaloneMemoryRow(
+            id="singleton",
+            agent_framework=framework,
+            memory_config=memory_payload,
+        )
+    )
+    await session.commit()
+    return 1
+
+
+async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> None:
+    """Seed each resource row from YAML if the DB is empty.
+
+    Each per-resource helper runs under its own try/except so an
+    isolated failure (e.g. a future observability seeder choking on a
+    malformed env var) does not prevent the agent from booting. The
+    operator gets a working agent plus a logged error pointing at the
+    failed resource.
+    """
+    if not config_path.exists():
+        # Nothing to seed; the operator may be running in fully
+        # config-less mode and will use the wizard.
+        async with sm() as session:
+            existing = (
+                await session.execute(select(StandaloneAgentRow))
+            ).scalar_one_or_none()
+        if existing is None:
             logger.info(
                 "No agent row and no config.yaml at %s. Standalone is unconfigured.",
                 config_path,
             )
-            return
+        return
 
-        config = ConfigBuilder.load_from_file(str(config_path))
+    engine_config = ConfigBuilder.load_from_file(str(config_path))
 
-        agent_config = config.agent.config
-        framework = config.agent.type.value
+    seeded: dict[str, int] = {"agent": 0, "memory": 0}
 
-        # Memory lives on its own row. Pull it off the agent config so
-        # base_engine_config holds only server + agent fields.
-        checkpointer = getattr(agent_config, "checkpointer", None)
-        session_service = getattr(agent_config, "session_service", None)
-        memory_payload: dict | None = None
-        if checkpointer is not None:
-            memory_payload = checkpointer.model_dump()
-        elif session_service is not None:
-            memory_payload = session_service.model_dump()
+    async with sm() as session:
+        try:
+            seeded["agent"] = await _seed_agent_if_empty(session, engine_config)
+        except Exception:
+            logger.exception("Failed to seed agent row from %s", config_path)
 
-        inner_dict = agent_config.model_dump(exclude_none=True)
-        inner_dict.pop("checkpointer", None)
-        inner_dict.pop("session_service", None)
+    async with sm() as session:
+        try:
+            seeded["memory"] = await _seed_memory_if_empty(session, engine_config)
+        except Exception:
+            logger.exception("Failed to seed memory row from %s", config_path)
 
-        base_engine_config = {
-            "server": config.server.model_dump(),
-            "agent": {"type": framework, "config": inner_dict},
-        }
-
-        session.add(
-            StandaloneAgentRow(
-                name=agent_config.name,
-                base_engine_config=base_engine_config,
-                status="draft",
-            )
-        )
-
-        if memory_payload is not None:
-            session.add(
-                StandaloneMemoryRow(
-                    id="singleton",
-                    agent_framework=framework,
-                    memory_config=memory_payload,
-                )
-            )
-
-        await session.commit()
-        logger.info(
-            "Seeded standalone DB from %s (name=%s, framework=%s, memory=%s)",
-            config_path,
-            agent_config.name,
-            framework,
-            "configured" if memory_payload else "default",
-        )
+    logger.info(
+        "seed complete from %s: agent=%d memory=%d",
+        config_path,
+        seeded["agent"],
+        seeded["memory"],
+    )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
@@ -17,11 +17,15 @@ from pathlib import Path
 
 from idun_agent_engine.core.config_builder import ConfigBuilder
 from idun_agent_engine.core.engine_config import EngineConfig
+from idun_agent_schema.manager.guardrail_configs import to_manager_shape
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.infrastructure.db.models.guardrail import (
+    StandaloneGuardrailRow,
+)
 from idun_agent_standalone.infrastructure.db.models.integration import (
     StandaloneIntegrationRow,
 )
@@ -336,6 +340,87 @@ async def _seed_integrations_if_empty(
     return seeded
 
 
+async def _seed_guardrails_if_empty(
+    session: AsyncSession, engine_config: EngineConfig
+) -> int:
+    """Seed ``StandaloneGuardrailRow`` rows from ``engine_config.guardrails``.
+
+    No-op if the YAML omits the ``guardrails:`` block (or both
+    ``input`` and ``output`` are empty), or if the
+    ``standalone_guardrail`` table already has at least one row
+    (per-resource seed-if-empty semantics from SPEC §3). Returns the
+    number of rows written.
+
+    Each engine-shape typed guard (``BanListConfig``, ``DetectPIIConfig``,
+    ...) is converted to manager-shape via ``to_manager_shape`` before
+    being stored in the JSON column, because the assembly layer
+    (``services/engine_config._layer_guardrails``) reads rows back as
+    manager-shape and re-runs ``convert_guardrail`` on the way out. The
+    DB therefore canonically holds manager-shape and the seeder must
+    invert the engine YAML before writing.
+
+    ``position`` is mirrored from the YAML's ``input``/``output`` split.
+    ``sort_order`` is the per-position list index (resets to 0 between
+    buckets) so the assembly layer's ORDER BY (position, sort_order)
+    preserves the operator's YAML ordering. All rows are seeded as
+    ``enabled=True`` because the engine ``GuardrailsV2`` schema has no
+    per-guard enabled flag — the row-level toggle is added by the admin
+    layer for runtime pause/resume.
+
+    We ``await session.flush()`` after each insert so successive calls
+    to ``ensure_unique_slug`` see the rows we have already added in
+    this loop — otherwise duplicate config ids in the same YAML batch
+    (two ``ban_list`` input guards) would all collapse onto the bare
+    slug and violate the unique constraint at commit time.
+    """
+    guardrails = engine_config.guardrails
+    if not guardrails or (not guardrails.input and not guardrails.output):
+        return 0
+
+    existing_count = await session.scalar(
+        select(func.count()).select_from(StandaloneGuardrailRow)
+    )
+    if existing_count and existing_count > 0:
+        logger.info(
+            "guardrails table non-empty (count=%d); skipping seed",
+            existing_count,
+        )
+        return 0
+
+    seeded = 0
+    for position, bucket in (
+        ("input", guardrails.input or []),
+        ("output", guardrails.output or []),
+    ):
+        for sort_order, engine_guard in enumerate(bucket):
+            manager_dict = to_manager_shape(engine_guard)
+            config_id = manager_dict.get("config_id", "guardrail")
+            candidate = normalize_slug(f"{config_id}-{position}")
+            slug = await ensure_unique_slug(
+                session,
+                StandaloneGuardrailRow,
+                StandaloneGuardrailRow.slug,
+                candidate,
+            )
+            session.add(
+                StandaloneGuardrailRow(
+                    slug=slug,
+                    name=slug,
+                    enabled=True,
+                    position=position,
+                    sort_order=sort_order,
+                    guardrail_config=manager_dict,
+                )
+            )
+            # Flush so ensure_unique_slug on the next iteration sees this
+            # row when checking the "is this slug taken" query.
+            await session.flush()
+            seeded += 1
+
+    await session.commit()
+    return seeded
+
+
 async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> None:
     """Seed each resource row from YAML if the DB is empty.
 
@@ -369,6 +454,7 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         "sso": 0,
         "mcp_servers": 0,
         "integrations": 0,
+        "guardrails": 0,
     }
 
     async with sm() as session:
@@ -419,9 +505,17 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         except Exception:
             logger.exception("Failed to seed integration rows from %s", config_path)
 
+    async with sm() as session:
+        try:
+            seeded["guardrails"] = await _seed_guardrails_if_empty(
+                session, engine_config
+            )
+        except Exception:
+            logger.exception("Failed to seed guardrail rows from %s", config_path)
+
     logger.info(
         "seed complete from %s: agent=%d memory=%d prompts=%d observability=%d "
-        "sso=%d mcp_servers=%d integrations=%d",
+        "sso=%d mcp_servers=%d integrations=%d guardrails=%d",
         config_path,
         seeded["agent"],
         seeded["memory"],
@@ -430,4 +524,5 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         seeded["sso"],
         seeded["mcp_servers"],
         seeded["integrations"],
+        seeded["guardrails"],
     )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
@@ -17,12 +17,13 @@ from pathlib import Path
 
 from idun_agent_engine.core.config_builder import ConfigBuilder
 from idun_agent_engine.core.engine_config import EngineConfig
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
 from idun_agent_standalone.infrastructure.db.models.memory import StandaloneMemoryRow
+from idun_agent_standalone.infrastructure.db.models.prompt import StandalonePromptRow
 
 logger = get_logger(__name__)
 
@@ -104,6 +105,38 @@ async def _seed_memory_if_empty(
     return 1
 
 
+async def _seed_prompts_if_empty(
+    session: AsyncSession, engine_config: EngineConfig
+) -> int:
+    """Seed ``StandalonePromptRow`` rows from ``engine_config.prompts``.
+
+    No-op if the YAML omits the ``prompts:`` block or if the prompts
+    table already has at least one row (per-resource seed-if-empty
+    semantics from SPEC §3). Returns the number of rows written.
+    """
+    if not engine_config.prompts:
+        return 0
+
+    existing_count = await session.scalar(
+        select(func.count()).select_from(StandalonePromptRow)
+    )
+    if existing_count and existing_count > 0:
+        logger.info("prompts table non-empty (count=%d); skipping seed", existing_count)
+        return 0
+
+    for prompt in engine_config.prompts:
+        session.add(
+            StandalonePromptRow(
+                prompt_id=prompt.prompt_id,
+                content=prompt.content,
+                version=prompt.version,
+                tags=list(prompt.tags or []),
+            )
+        )
+    await session.commit()
+    return len(engine_config.prompts)
+
+
 async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> None:
     """Seed each resource row from YAML if the DB is empty.
 
@@ -129,7 +162,7 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
 
     engine_config = ConfigBuilder.load_from_file(str(config_path))
 
-    seeded: dict[str, int] = {"agent": 0, "memory": 0}
+    seeded: dict[str, int] = {"agent": 0, "memory": 0, "prompts": 0}
 
     async with sm() as session:
         try:
@@ -143,9 +176,16 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         except Exception:
             logger.exception("Failed to seed memory row from %s", config_path)
 
+    async with sm() as session:
+        try:
+            seeded["prompts"] = await _seed_prompts_if_empty(session, engine_config)
+        except Exception:
+            logger.exception("Failed to seed prompt rows from %s", config_path)
+
     logger.info(
-        "seed complete from %s: agent=%d memory=%d",
+        "seed complete from %s: agent=%d memory=%d prompts=%d",
         config_path,
         seeded["agent"],
         seeded["memory"],
+        seeded["prompts"],
     )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
@@ -23,6 +23,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
 from idun_agent_standalone.infrastructure.db.models.memory import StandaloneMemoryRow
+from idun_agent_standalone.infrastructure.db.models.observability import (
+    StandaloneObservabilityRow,
+)
 from idun_agent_standalone.infrastructure.db.models.prompt import StandalonePromptRow
 
 logger = get_logger(__name__)
@@ -137,6 +140,39 @@ async def _seed_prompts_if_empty(
     return len(engine_config.prompts)
 
 
+async def _seed_observability_if_empty(
+    session: AsyncSession, engine_config: EngineConfig
+) -> int:
+    """Seed the singleton ``StandaloneObservabilityRow`` from YAML.
+
+    ``engine_config.observability`` is a ``list[ObservabilityConfig]``;
+    standalone is single-tenant and stores at most one provider, so we
+    take the first element. The assembly layer
+    (``services/engine_config._layer_observability``) wraps it back into
+    a one-element list when materializing ``EngineConfig`` at runtime.
+
+    No-op if the singleton row already exists or the YAML omits the
+    ``observability:`` block.
+    """
+    if not engine_config.observability:
+        return 0
+
+    existing = await session.get(StandaloneObservabilityRow, "singleton")
+    if existing is not None:
+        logger.info("observability singleton exists; skipping seed")
+        return 0
+
+    first = engine_config.observability[0]
+    session.add(
+        StandaloneObservabilityRow(
+            id="singleton",
+            observability_config=first.model_dump(mode="json"),
+        )
+    )
+    await session.commit()
+    return 1
+
+
 async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> None:
     """Seed each resource row from YAML if the DB is empty.
 
@@ -162,7 +198,12 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
 
     engine_config = ConfigBuilder.load_from_file(str(config_path))
 
-    seeded: dict[str, int] = {"agent": 0, "memory": 0, "prompts": 0}
+    seeded: dict[str, int] = {
+        "agent": 0,
+        "memory": 0,
+        "prompts": 0,
+        "observability": 0,
+    }
 
     async with sm() as session:
         try:
@@ -182,10 +223,19 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         except Exception:
             logger.exception("Failed to seed prompt rows from %s", config_path)
 
+    async with sm() as session:
+        try:
+            seeded["observability"] = await _seed_observability_if_empty(
+                session, engine_config
+            )
+        except Exception:
+            logger.exception("Failed to seed observability row from %s", config_path)
+
     logger.info(
-        "seed complete from %s: agent=%d memory=%d prompts=%d",
+        "seed complete from %s: agent=%d memory=%d prompts=%d observability=%d",
         config_path,
         seeded["agent"],
         seeded["memory"],
         seeded["prompts"],
+        seeded["observability"],
     )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
@@ -22,12 +22,16 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.infrastructure.db.models.mcp_server import (
+    StandaloneMCPServerRow,
+)
 from idun_agent_standalone.infrastructure.db.models.memory import StandaloneMemoryRow
 from idun_agent_standalone.infrastructure.db.models.observability import (
     StandaloneObservabilityRow,
 )
 from idun_agent_standalone.infrastructure.db.models.prompt import StandalonePromptRow
 from idun_agent_standalone.infrastructure.db.models.sso import StandaloneSsoRow
+from idun_agent_standalone.services.slugs import ensure_unique_slug, normalize_slug
 
 logger = get_logger(__name__)
 
@@ -204,6 +208,63 @@ async def _seed_sso_if_empty(session: AsyncSession, engine_config: EngineConfig)
     return 1
 
 
+async def _seed_mcp_servers_if_empty(
+    session: AsyncSession, engine_config: EngineConfig
+) -> int:
+    """Seed ``StandaloneMCPServerRow`` rows from ``engine_config.mcp_servers``.
+
+    No-op if the YAML omits the ``mcp_servers:`` block or if the
+    ``standalone_mcp_server`` table already has at least one row
+    (per-resource seed-if-empty semantics from SPEC §3). Returns the
+    number of rows written.
+
+    Each row gets a slug derived from the MCP server's ``name`` via
+    ``ensure_unique_slug``. We ``await session.flush()`` after each
+    insert so successive calls to ``ensure_unique_slug`` see the rows
+    we have already added in this loop — otherwise duplicate names in
+    the same YAML batch would all collapse onto the bare slug and
+    violate the unique constraint at commit time.
+    """
+    mcp_servers = engine_config.mcp_servers
+    if not mcp_servers:
+        return 0
+
+    existing_count = await session.scalar(
+        select(func.count()).select_from(StandaloneMCPServerRow)
+    )
+    if existing_count and existing_count > 0:
+        logger.info(
+            "mcp_servers table non-empty (count=%d); skipping seed",
+            existing_count,
+        )
+        return 0
+
+    seeded = 0
+    for mcp in mcp_servers:
+        candidate = normalize_slug(mcp.name)
+        slug = await ensure_unique_slug(
+            session,
+            StandaloneMCPServerRow,
+            StandaloneMCPServerRow.slug,
+            candidate,
+        )
+        session.add(
+            StandaloneMCPServerRow(
+                name=mcp.name,
+                slug=slug,
+                enabled=True,
+                mcp_server_config=mcp.model_dump(mode="json", exclude_none=True),
+            )
+        )
+        # Flush so ensure_unique_slug on the next iteration sees this
+        # row when checking the "is this slug taken" query.
+        await session.flush()
+        seeded += 1
+
+    await session.commit()
+    return seeded
+
+
 async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> None:
     """Seed each resource row from YAML if the DB is empty.
 
@@ -235,6 +296,7 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         "prompts": 0,
         "observability": 0,
         "sso": 0,
+        "mcp_servers": 0,
     }
 
     async with sm() as session:
@@ -269,12 +331,22 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         except Exception:
             logger.exception("Failed to seed sso row from %s", config_path)
 
+    async with sm() as session:
+        try:
+            seeded["mcp_servers"] = await _seed_mcp_servers_if_empty(
+                session, engine_config
+            )
+        except Exception:
+            logger.exception("Failed to seed mcp_server rows from %s", config_path)
+
     logger.info(
-        "seed complete from %s: agent=%d memory=%d prompts=%d observability=%d sso=%d",
+        "seed complete from %s: agent=%d memory=%d prompts=%d observability=%d "
+        "sso=%d mcp_servers=%d",
         config_path,
         seeded["agent"],
         seeded["memory"],
         seeded["prompts"],
         seeded["observability"],
         seeded["sso"],
+        seeded["mcp_servers"],
     )

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/scripts/seed.py
@@ -22,6 +22,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.infrastructure.db.models.integration import (
+    StandaloneIntegrationRow,
+)
 from idun_agent_standalone.infrastructure.db.models.mcp_server import (
     StandaloneMCPServerRow,
 )
@@ -265,6 +268,74 @@ async def _seed_mcp_servers_if_empty(
     return seeded
 
 
+async def _seed_integrations_if_empty(
+    session: AsyncSession, engine_config: EngineConfig
+) -> int:
+    """Seed ``StandaloneIntegrationRow`` rows from ``engine_config.integrations``.
+
+    No-op if the YAML omits the ``integrations:`` block or if the
+    ``standalone_integration`` table already has at least one row
+    (per-resource seed-if-empty semantics from SPEC §3). Returns the
+    number of rows written.
+
+    Each row gets a slug derived from the integration's ``provider``
+    enum value (e.g. ``WHATSAPP`` → ``whatsapp``) via
+    ``ensure_unique_slug``; the row's ``name`` mirrors that slug since
+    ``IntegrationConfig`` carries no display name field of its own. The
+    row level ``enabled`` flag is preserved verbatim from the YAML —
+    unlike the mcp_server seeder, integrations carry an explicit
+    ``enabled`` field at the engine config layer and the operator may
+    have intentionally seeded one as ``false``.
+
+    We ``await session.flush()`` after each insert so successive calls
+    to ``ensure_unique_slug`` see the rows we have already added in
+    this loop — otherwise duplicate providers in the same YAML batch
+    would all collapse onto the bare slug and violate the unique
+    constraint at commit time.
+    """
+    integrations = engine_config.integrations
+    if not integrations:
+        return 0
+
+    existing_count = await session.scalar(
+        select(func.count()).select_from(StandaloneIntegrationRow)
+    )
+    if existing_count and existing_count > 0:
+        logger.info(
+            "integrations table non-empty (count=%d); skipping seed",
+            existing_count,
+        )
+        return 0
+
+    seeded = 0
+    for integration in integrations:
+        provider_str = str(integration.provider.value).lower()
+        candidate = normalize_slug(provider_str)
+        slug = await ensure_unique_slug(
+            session,
+            StandaloneIntegrationRow,
+            StandaloneIntegrationRow.slug,
+            candidate,
+        )
+        session.add(
+            StandaloneIntegrationRow(
+                slug=slug,
+                name=slug,
+                enabled=integration.enabled,
+                integration_config=integration.model_dump(
+                    mode="json", exclude_none=True
+                ),
+            )
+        )
+        # Flush so ensure_unique_slug on the next iteration sees this
+        # row when checking the "is this slug taken" query.
+        await session.flush()
+        seeded += 1
+
+    await session.commit()
+    return seeded
+
+
 async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> None:
     """Seed each resource row from YAML if the DB is empty.
 
@@ -297,6 +368,7 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         "observability": 0,
         "sso": 0,
         "mcp_servers": 0,
+        "integrations": 0,
     }
 
     async with sm() as session:
@@ -339,9 +411,17 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         except Exception:
             logger.exception("Failed to seed mcp_server rows from %s", config_path)
 
+    async with sm() as session:
+        try:
+            seeded["integrations"] = await _seed_integrations_if_empty(
+                session, engine_config
+            )
+        except Exception:
+            logger.exception("Failed to seed integration rows from %s", config_path)
+
     logger.info(
         "seed complete from %s: agent=%d memory=%d prompts=%d observability=%d "
-        "sso=%d mcp_servers=%d",
+        "sso=%d mcp_servers=%d integrations=%d",
         config_path,
         seeded["agent"],
         seeded["memory"],
@@ -349,4 +429,5 @@ async def seed_from_yaml_if_empty(sm: async_sessionmaker, config_path: Path) -> 
         seeded["observability"],
         seeded["sso"],
         seeded["mcp_servers"],
+        seeded["integrations"],
     )

--- a/libs/idun_agent_standalone/tests/fixtures/configs/maximal.yaml
+++ b/libs/idun_agent_standalone/tests/fixtures/configs/maximal.yaml
@@ -1,0 +1,86 @@
+server:
+  api:
+    port: 8000
+
+agent:
+  type: LANGGRAPH
+  config:
+    name: Seeded Ada
+    graph_definition: ./agent.py:graph
+    checkpointer:
+      type: sqlite
+      db_url: sqlite:///checkpoint.db
+
+prompts:
+  - prompt_id: system-prompt
+    version: 2
+    content: "You are a helpful assistant for {{ domain }}."
+    tags:
+      - latest
+      - production
+  - prompt_id: rag-context
+    version: 1
+    content: "Use this context: {{ context }}"
+    tags:
+      - rag
+
+observability:
+  - provider: LANGFUSE
+    enabled: true
+    config:
+      host: https://cloud.langfuse.com
+      public_key: pk-test
+      secret_key: sk-test
+
+sso:
+  enabled: true
+  issuer: https://accounts.google.com
+  client_id: 123456.apps.googleusercontent.com
+  allowed_domains:
+    - example.com
+
+mcp_servers:
+  - name: time
+    transport: stdio
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-time"
+  - name: filesystem
+    transport: stdio
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-filesystem"
+      - "/tmp"
+
+integrations:
+  - provider: WHATSAPP
+    enabled: true
+    config:
+      access_token: test-token
+      phone_number_id: "123456"
+      verify_token: test-verify
+  - provider: DISCORD
+    enabled: false
+    config:
+      bot_token: test-bot-token
+      application_id: "987654"
+      public_key: abcdef
+
+guardrails:
+  input:
+    - config_id: ban_list
+      banned_words:
+        - secret-word
+        - another-banned
+      api_key: test-key
+    - config_id: detect_pii
+      pii_entities:
+        - EMAIL_ADDRESS
+        - PHONE_NUMBER
+      api_key: test-key
+  output:
+    - config_id: toxic_language
+      threshold: 0.5
+      api_key: test-key

--- a/libs/idun_agent_standalone/tests/integration/test_seed_round_trip.py
+++ b/libs/idun_agent_standalone/tests/integration/test_seed_round_trip.py
@@ -33,7 +33,7 @@ _MAXIMAL_YAML_PATH = (
 @pytest.fixture
 async def sessionmaker_factory() -> AsyncIterator[async_sessionmaker]:
     """Async sessionmaker bound to an in-memory SQLite with all ORMs created."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     factory = async_sessionmaker(engine, expire_on_commit=False)

--- a/libs/idun_agent_standalone/tests/integration/test_seed_round_trip.py
+++ b/libs/idun_agent_standalone/tests/integration/test_seed_round_trip.py
@@ -1,0 +1,148 @@
+"""End-to-end: maximal YAML → seed → assemble_engine_config → semantic match.
+
+This is the cross-cutting proof that all 7 per-resource seeders
+(agent, memory, prompts, observability, sso, mcp_servers,
+integrations, guardrails) and the assembly layer agree on shapes.
+Per-resource isolation tests live in tests/unit/scripts/test_seed.py;
+this integration test catches subtle interaction bugs (slug
+collisions across resources, sort_order regressions, manager↔engine
+shape round-trip drift) that the per-resource tests can't surface
+individually.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from idun_agent_schema.engine.agent_framework import AgentFramework
+from idun_agent_schema.engine.guardrails_v2 import GuardrailConfigId
+from idun_agent_schema.engine.integrations.base import IntegrationProvider
+from idun_agent_schema.engine.observability_v2 import ObservabilityProvider
+from idun_agent_standalone.infrastructure.db.session import Base
+from idun_agent_standalone.infrastructure.scripts.seed import seed_from_yaml_if_empty
+from idun_agent_standalone.services.engine_config import assemble_engine_config
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_MAXIMAL_YAML_PATH = (
+    Path(__file__).parent.parent / "fixtures" / "configs" / "maximal.yaml"
+)
+
+
+@pytest.fixture
+async def sessionmaker_factory() -> AsyncIterator[async_sessionmaker]:
+    """Async sessionmaker bound to an in-memory SQLite with all ORMs created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def maximal_yaml_path() -> Path:
+    """Absolute path to the maximal YAML fixture (all 8 resource blocks)."""
+    assert (
+        _MAXIMAL_YAML_PATH.exists()
+    ), f"maximal YAML fixture missing at {_MAXIMAL_YAML_PATH}"
+    return _MAXIMAL_YAML_PATH
+
+
+async def test_maximal_yaml_seed_round_trip(
+    sessionmaker_factory: async_sessionmaker, maximal_yaml_path: Path
+) -> None:
+    """Seed every resource from the maximal YAML and assemble a matching EngineConfig.
+
+    Pins the contract that the seeder + assembly form a faithful
+    round-trip across every resource block. Any new field added to a
+    seeder that the assembly layer does not surface (or vice versa)
+    will surface here as a missing/extra section on the assembled
+    EngineConfig.
+    """
+    await seed_from_yaml_if_empty(sessionmaker_factory, maximal_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        engine_config = await assemble_engine_config(session)
+
+    # ---- Agent + memory (memory is layered onto agent.config.checkpointer) ----
+    assert engine_config.agent.type == AgentFramework.LANGGRAPH
+    assert engine_config.agent.config.name == "Seeded Ada"
+    checkpointer = engine_config.agent.config.checkpointer
+    assert checkpointer is not None, "memory row not layered onto agent.config"
+    assert checkpointer.type == "sqlite"
+    assert checkpointer.db_url == "sqlite:///checkpoint.db"
+
+    # ---- Prompts: 2 entries, fields preserved ----
+    assert engine_config.prompts is not None
+    assert len(engine_config.prompts) == 2
+    by_id = {p.prompt_id: p for p in engine_config.prompts}
+    assert set(by_id) == {"system-prompt", "rag-context"}
+    assert by_id["system-prompt"].version == 2
+    assert by_id["system-prompt"].content == (
+        "You are a helpful assistant for {{ domain }}."
+    )
+    assert by_id["system-prompt"].tags == ["latest", "production"]
+    assert by_id["rag-context"].version == 1
+
+    # ---- Observability: singleton wrapped back into a 1-elem list ----
+    assert engine_config.observability is not None
+    assert len(engine_config.observability) == 1
+    obs = engine_config.observability[0]
+    assert obs.provider == ObservabilityProvider.LANGFUSE
+    assert obs.enabled is True
+    assert obs.config.host == "https://cloud.langfuse.com"
+    assert obs.config.public_key == "pk-test"
+    assert obs.config.secret_key == "sk-test"
+
+    # ---- SSO: present, enabled, fields preserved ----
+    assert engine_config.sso is not None
+    assert engine_config.sso.enabled is True
+    assert engine_config.sso.issuer == "https://accounts.google.com"
+    assert engine_config.sso.client_id == "123456.apps.googleusercontent.com"
+    assert engine_config.sso.allowed_domains == ["example.com"]
+
+    # ---- MCP servers: 2, both enabled ----
+    assert engine_config.mcp_servers is not None
+    assert len(engine_config.mcp_servers) == 2
+    mcp_names = {m.name for m in engine_config.mcp_servers}
+    assert mcp_names == {"time", "filesystem"}
+    time_mcp = next(m for m in engine_config.mcp_servers if m.name == "time")
+    assert time_mcp.transport == "stdio"
+    assert time_mcp.command == "npx"
+    assert time_mcp.args == ["-y", "@modelcontextprotocol/server-time"]
+
+    # ---- Integrations: only the enabled WhatsApp row surfaces; Discord is filtered. ----
+    # _layer_integrations drops disabled rows so the engine never tries to
+    # register a webhook for an integration the operator has paused.
+    assert engine_config.integrations is not None
+    assert len(engine_config.integrations) == 1
+    whatsapp = engine_config.integrations[0]
+    assert whatsapp.provider == IntegrationProvider.WHATSAPP
+    assert whatsapp.enabled is True
+    assert whatsapp.config.access_token == "test-token"
+    assert whatsapp.config.phone_number_id == "123456"
+    assert whatsapp.config.verify_token == "test-verify"
+
+    # ---- Guardrails: 2 input + 1 output, ordering preserved by sort_order ----
+    assert engine_config.guardrails is not None
+    assert len(engine_config.guardrails.input) == 2
+    assert len(engine_config.guardrails.output) == 1
+
+    input_ids = [g.config_id for g in engine_config.guardrails.input]
+    assert input_ids == [
+        GuardrailConfigId.BAN_LIST,
+        GuardrailConfigId.DETECT_PII,
+    ]
+    output_ids = [g.config_id for g in engine_config.guardrails.output]
+    assert output_ids == [GuardrailConfigId.TOXIC_LANGUAGE]
+
+    ban_guard = engine_config.guardrails.input[0]
+    assert ban_guard.banned_words == ["secret-word", "another-banned"]
+    pii_guard = engine_config.guardrails.input[1]
+    assert pii_guard.pii_entities == ["EMAIL_ADDRESS", "PHONE_NUMBER"]
+    toxic_guard = engine_config.guardrails.output[0]
+    assert toxic_guard.threshold == 0.5

--- a/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
+++ b/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
@@ -16,6 +16,9 @@ from typing import Any
 import pytest
 import yaml
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.infrastructure.db.models.mcp_server import (
+    StandaloneMCPServerRow,
+)
 from idun_agent_standalone.infrastructure.db.models.memory import StandaloneMemoryRow
 from idun_agent_standalone.infrastructure.db.models.observability import (
     StandaloneObservabilityRow,
@@ -146,6 +149,37 @@ def sso_yaml_path(tmp_path: Path) -> Path:
     config_path = tmp_path / "config-with-sso.yaml"
     with open(config_path, "w") as f:
         yaml.dump(_SSO_YAML, f)
+    return config_path
+
+
+# YAML with a top-level `mcp_servers:` block — exercises the mcp_servers
+# seeder. Collection resource: each entry becomes its own row with a
+# unique slug derived from the MCP server's name.
+_MCP_SERVERS_YAML: dict[str, Any] = {
+    **_AGENT_YAML,
+    "mcp_servers": [
+        {
+            "name": "time",
+            "transport": "stdio",
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-time"],
+        },
+        {
+            "name": "filesystem",
+            "transport": "stdio",
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        },
+    ],
+}
+
+
+@pytest.fixture
+def mcp_servers_yaml_path(tmp_path: Path) -> Path:
+    """Write a YAML config with an `mcp_servers:` block and return its path."""
+    config_path = tmp_path / "config-with-mcp-servers.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(_MCP_SERVERS_YAML, f)
     return config_path
 
 
@@ -438,5 +472,82 @@ async def test_seed_sso_no_op_on_yaml_without_block(
 
     async with sessionmaker_factory() as session:
         count = await session.scalar(select(func.count()).select_from(StandaloneSsoRow))
+
+    assert count == 0
+
+
+async def test_seed_mcp_servers_inserts_rows_when_empty(
+    sessionmaker_factory: async_sessionmaker, mcp_servers_yaml_path: Path
+) -> None:
+    """YAML with 2 MCP servers → 2 StandaloneMCPServerRow records with unique slugs."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, mcp_servers_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        rows = (await session.scalars(select(StandaloneMCPServerRow))).all()
+
+    assert len(rows) == 2
+    names = {r.name for r in rows}
+    assert names == {"time", "filesystem"}
+    # All rows enabled by default.
+    assert all(r.enabled for r in rows)
+    # Slugs are unique across the seeded batch.
+    slugs = [r.slug for r in rows]
+    assert len(set(slugs)) == 2
+    # Config dict preserved (transport/command/args round-trip).
+    time_row = next(r for r in rows if r.name == "time")
+    assert time_row.mcp_server_config["transport"] == "stdio"
+    assert time_row.mcp_server_config["command"] == "npx"
+    assert time_row.mcp_server_config["args"] == [
+        "-y",
+        "@modelcontextprotocol/server-time",
+    ]
+
+
+async def test_seed_mcp_servers_skips_when_table_nonempty(
+    sessionmaker_factory: async_sessionmaker, mcp_servers_yaml_path: Path
+) -> None:
+    """If the mcp_servers table has any row, the mcp_servers seeder is a no-op."""
+    async with sessionmaker_factory() as session:
+        session.add(
+            StandaloneMCPServerRow(
+                name="pre-existing",
+                slug="pre-existing",
+                enabled=True,
+                mcp_server_config={
+                    "transport": "stdio",
+                    "command": "echo",
+                    "args": ["hi"],
+                },
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker_factory() as session:
+        pre_count = await session.scalar(
+            select(func.count()).select_from(StandaloneMCPServerRow)
+        )
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, mcp_servers_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        post_count = await session.scalar(
+            select(func.count()).select_from(StandaloneMCPServerRow)
+        )
+        rows = (await session.scalars(select(StandaloneMCPServerRow))).all()
+
+    assert post_count == pre_count, "mcp_servers re-seeded despite non-empty table"
+    assert {r.name for r in rows} == {"pre-existing"}
+
+
+async def test_seed_mcp_servers_no_op_on_yaml_without_block(
+    sessionmaker_factory: async_sessionmaker, yaml_config_path: Path
+) -> None:
+    """YAML without an `mcp_servers:` block → no rows, no error."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(StandaloneMCPServerRow)
+        )
 
     assert count == 0

--- a/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
+++ b/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
@@ -17,6 +17,9 @@ import pytest
 import yaml
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
 from idun_agent_standalone.infrastructure.db.models.memory import StandaloneMemoryRow
+from idun_agent_standalone.infrastructure.db.models.observability import (
+    StandaloneObservabilityRow,
+)
 from idun_agent_standalone.infrastructure.db.models.prompt import StandalonePromptRow
 from idun_agent_standalone.infrastructure.db.session import Base
 from idun_agent_standalone.infrastructure.scripts import seed as seed_module
@@ -91,6 +94,34 @@ def prompts_yaml_path(tmp_path: Path) -> Path:
     config_path = tmp_path / "config-with-prompts.yaml"
     with open(config_path, "w") as f:
         yaml.dump(_PROMPTS_YAML, f)
+    return config_path
+
+
+# YAML with a top-level `observability:` block — exercises the
+# observability seeder (singleton resource: only the first provider
+# from the list is persisted, mirroring the assembly layer's wrap).
+_OBSERVABILITY_YAML: dict[str, Any] = {
+    **_AGENT_YAML,
+    "observability": [
+        {
+            "provider": "LANGFUSE",
+            "enabled": True,
+            "config": {
+                "host": "https://cloud.langfuse.com",
+                "public_key": "pk-test",
+                "secret_key": "sk-test",
+            },
+        },
+    ],
+}
+
+
+@pytest.fixture
+def observability_yaml_path(tmp_path: Path) -> Path:
+    """Write a YAML config with an `observability:` block and return its path."""
+    config_path = tmp_path / "config-with-observability.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(_OBSERVABILITY_YAML, f)
     return config_path
 
 
@@ -263,6 +294,66 @@ async def test_seed_prompts_no_op_on_yaml_without_prompts_block(
     async with sessionmaker_factory() as session:
         count = await session.scalar(
             select(func.count()).select_from(StandalonePromptRow)
+        )
+
+    assert count == 0
+
+
+async def test_seed_observability_inserts_singleton_when_empty(
+    sessionmaker_factory: async_sessionmaker, observability_yaml_path: Path
+) -> None:
+    """YAML with observability provider → 1 StandaloneObservabilityRow (singleton)."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, observability_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        rows = (await session.scalars(select(StandaloneObservabilityRow))).all()
+
+    assert len(rows) == 1
+    row = rows[0]
+    # Singleton PK + config dict preserved from the first provider in YAML.
+    assert row.id == "singleton"
+    config = row.observability_config
+    assert config["provider"] == "LANGFUSE"
+    assert config["enabled"] is True
+    assert "config" in config
+
+
+async def test_seed_observability_skips_when_singleton_exists(
+    sessionmaker_factory: async_sessionmaker, observability_yaml_path: Path
+) -> None:
+    """If singleton row exists, no re-seed (existing config preserved)."""
+    async with sessionmaker_factory() as session:
+        session.add(
+            StandaloneObservabilityRow(
+                id="singleton",
+                observability_config={
+                    "provider": "PHOENIX",
+                    "enabled": False,
+                    "config": {},
+                },
+            )
+        )
+        await session.commit()
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, observability_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        rows = (await session.scalars(select(StandaloneObservabilityRow))).all()
+
+    assert len(rows) == 1
+    # The pre-existing PHOENIX row was NOT overwritten with LANGFUSE.
+    assert rows[0].observability_config["provider"] == "PHOENIX"
+
+
+async def test_seed_observability_no_op_on_yaml_without_block(
+    sessionmaker_factory: async_sessionmaker, yaml_config_path: Path
+) -> None:
+    """YAML without observability block → no row, no error."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(StandaloneObservabilityRow)
         )
 
     assert count == 0

--- a/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
+++ b/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
@@ -16,6 +16,9 @@ from typing import Any
 import pytest
 import yaml
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.infrastructure.db.models.integration import (
+    StandaloneIntegrationRow,
+)
 from idun_agent_standalone.infrastructure.db.models.mcp_server import (
     StandaloneMCPServerRow,
 )
@@ -548,6 +551,115 @@ async def test_seed_mcp_servers_no_op_on_yaml_without_block(
     async with sessionmaker_factory() as session:
         count = await session.scalar(
             select(func.count()).select_from(StandaloneMCPServerRow)
+        )
+
+    assert count == 0
+
+
+# YAML with a top-level `integrations:` block — exercises the integrations
+# seeder. Collection resource: each entry becomes its own row with a slug
+# derived from the provider, and the row level ``enabled`` flag preserved
+# from the YAML (NOT default-True like mcp_servers).
+_INTEGRATIONS_YAML: dict[str, Any] = {
+    **_AGENT_YAML,
+    "integrations": [
+        {
+            "provider": "WHATSAPP",
+            "enabled": True,
+            "config": {
+                "access_token": "test-token",
+                "phone_number_id": "123456",
+                "verify_token": "test-verify",
+            },
+        },
+        {
+            "provider": "DISCORD",
+            "enabled": False,
+            "config": {
+                "bot_token": "test-bot-token",
+                "application_id": "987654",
+                "public_key": "abcdef",
+            },
+        },
+    ],
+}
+
+
+@pytest.fixture
+def integrations_yaml_path(tmp_path: Path) -> Path:
+    """Write a YAML config with an `integrations:` block and return its path."""
+    config_path = tmp_path / "config-with-integrations.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(_INTEGRATIONS_YAML, f)
+    return config_path
+
+
+async def test_seed_integrations_inserts_rows_when_empty(
+    sessionmaker_factory: async_sessionmaker, integrations_yaml_path: Path
+) -> None:
+    """YAML with 2 integrations → 2 rows with unique slugs, enabled flags preserved."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, integrations_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        rows = (await session.scalars(select(StandaloneIntegrationRow))).all()
+
+    assert len(rows) == 2
+    # Both providers are present in the seeded payloads.
+    providers = {r.integration_config["provider"] for r in rows}
+    assert providers == {"WHATSAPP", "DISCORD"}
+    # Enabled flag preserved from YAML (WhatsApp=true, Discord=false). The
+    # row level enabled is the single source of truth at assembly; the
+    # seeder must NOT default it to True like mcp_servers does.
+    by_provider = {r.integration_config["provider"]: r for r in rows}
+    assert by_provider["WHATSAPP"].enabled is True
+    assert by_provider["DISCORD"].enabled is False
+    # Slugs are unique across the seeded batch.
+    slugs = [r.slug for r in rows]
+    assert len(set(slugs)) == 2
+
+
+async def test_seed_integrations_skips_when_table_nonempty(
+    sessionmaker_factory: async_sessionmaker, integrations_yaml_path: Path
+) -> None:
+    """If the integrations table has any row, the seeder is a no-op."""
+    async with sessionmaker_factory() as session:
+        existing = StandaloneIntegrationRow(
+            slug="pre-existing",
+            name="pre-existing",
+            enabled=True,
+            integration_config={
+                "provider": "SLACK",
+                "enabled": True,
+                "config": {
+                    "bot_token": "xoxb-pre",
+                    "signing_secret": "shh",
+                },
+            },
+        )
+        session.add(existing)
+        await session.commit()
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, integrations_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(StandaloneIntegrationRow)
+        )
+        rows = (await session.scalars(select(StandaloneIntegrationRow))).all()
+
+    assert count == 1
+    assert {r.integration_config["provider"] for r in rows} == {"SLACK"}
+
+
+async def test_seed_integrations_no_op_on_yaml_without_block(
+    sessionmaker_factory: async_sessionmaker, yaml_config_path: Path
+) -> None:
+    """YAML without an `integrations:` block → no rows, no error."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(StandaloneIntegrationRow)
         )
 
     assert count == 0

--- a/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
+++ b/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
@@ -16,6 +16,9 @@ from typing import Any
 import pytest
 import yaml
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.infrastructure.db.models.guardrail import (
+    StandaloneGuardrailRow,
+)
 from idun_agent_standalone.infrastructure.db.models.integration import (
     StandaloneIntegrationRow,
 )
@@ -660,6 +663,142 @@ async def test_seed_integrations_no_op_on_yaml_without_block(
     async with sessionmaker_factory() as session:
         count = await session.scalar(
             select(func.count()).select_from(StandaloneIntegrationRow)
+        )
+
+    assert count == 0
+
+
+# YAML with a top-level `guardrails:` block — exercises the guardrails
+# seeder. Mixed input (2) and output (1) so positions and sort_order
+# branches both fire. Engine YAML uses the engine-shape ``GuardrailsV2``
+# typed configs; the seeder converts each to manager-shape via
+# ``to_manager_shape`` before storing in the JSON column.
+_GUARDRAILS_YAML: dict[str, Any] = {
+    **_AGENT_YAML,
+    "guardrails": {
+        "input": [
+            {
+                "config_id": "ban_list",
+                "banned_words": ["secret-word", "another-banned"],
+                "api_key": "test-key",
+            },
+            {
+                "config_id": "detect_pii",
+                "pii_entities": ["EMAIL_ADDRESS", "PHONE_NUMBER"],
+                "api_key": "test-key",
+            },
+        ],
+        "output": [
+            {
+                "config_id": "toxic_language",
+                "threshold": 0.5,
+                "api_key": "test-key",
+            },
+        ],
+    },
+}
+
+
+@pytest.fixture
+def guardrails_yaml_path(tmp_path: Path) -> Path:
+    """Write a YAML config with a `guardrails:` block and return its path."""
+    config_path = tmp_path / "config-with-guardrails.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(_GUARDRAILS_YAML, f)
+    return config_path
+
+
+async def test_seed_guardrails_inserts_input_and_output_rows(
+    sessionmaker_factory: async_sessionmaker, guardrails_yaml_path: Path
+) -> None:
+    """YAML with 2 input + 1 output guards → 3 StandaloneGuardrailRow records.
+
+    Exercises the position split (``input``/``output``), the per-position
+    ``sort_order`` counter, and the manager-shape conversion: the JSON
+    column must hold the manager-shape (``config_id`` + guard-specific
+    fields, no engine-only ``guard_url``).
+    """
+    await seed_from_yaml_if_empty(sessionmaker_factory, guardrails_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        rows = (
+            await session.scalars(
+                select(StandaloneGuardrailRow).order_by(
+                    StandaloneGuardrailRow.position,
+                    StandaloneGuardrailRow.sort_order,
+                )
+            )
+        ).all()
+
+    assert len(rows) == 3
+    inputs = [r for r in rows if r.position == "input"]
+    outputs = [r for r in rows if r.position == "output"]
+    assert len(inputs) == 2
+    assert len(outputs) == 1
+    # Sort order is monotonic and starts at 0 within each position bucket
+    # so the assembly layer's ORDER BY (position, sort_order) preserves
+    # the operator's YAML ordering.
+    assert [r.sort_order for r in inputs] == [0, 1]
+    assert outputs[0].sort_order == 0
+    # All enabled by default — engine GuardrailsV2 has no per-guard
+    # ``enabled`` flag so the seeder marks every row enabled.
+    assert all(r.enabled for r in rows)
+    # Slugs are unique across the seeded batch.
+    slugs = [r.slug for r in rows]
+    assert len(set(slugs)) == 3
+    # Manager-shape stored: each row holds a ``config_id`` and the
+    # guard-specific fields (no engine-only ``guard_url``).
+    config_ids = [r.guardrail_config["config_id"] for r in rows]
+    assert set(config_ids) == {"ban_list", "detect_pii", "toxic_language"}
+    for row in rows:
+        assert "guard_url" not in row.guardrail_config
+    ban_row = next(r for r in inputs if r.guardrail_config["config_id"] == "ban_list")
+    assert ban_row.guardrail_config["banned_words"] == [
+        "secret-word",
+        "another-banned",
+    ]
+
+
+async def test_seed_guardrails_skips_when_table_nonempty(
+    sessionmaker_factory: async_sessionmaker, guardrails_yaml_path: Path
+) -> None:
+    """If the guardrails table has any row, the seeder is a no-op."""
+    async with sessionmaker_factory() as session:
+        existing = StandaloneGuardrailRow(
+            slug="pre-existing",
+            name="pre-existing",
+            position="input",
+            sort_order=0,
+            enabled=True,
+            guardrail_config={
+                "config_id": "detect_pii",
+                "pii_entities": ["EMAIL_ADDRESS"],
+            },
+        )
+        session.add(existing)
+        await session.commit()
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, guardrails_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(StandaloneGuardrailRow)
+        )
+        rows = (await session.scalars(select(StandaloneGuardrailRow))).all()
+
+    assert count == 1
+    assert rows[0].slug == "pre-existing"
+
+
+async def test_seed_guardrails_no_op_on_yaml_without_block(
+    sessionmaker_factory: async_sessionmaker, yaml_config_path: Path
+) -> None:
+    """YAML without a `guardrails:` block → no rows, no error."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(StandaloneGuardrailRow)
         )
 
     assert count == 0

--- a/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
+++ b/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
@@ -59,7 +59,7 @@ _AGENT_YAML: dict[str, Any] = {
 @pytest.fixture
 async def sessionmaker_factory() -> AsyncIterator[async_sessionmaker]:
     """Async sessionmaker bound to an in-memory SQLite with all ORMs created."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     factory = async_sessionmaker(engine, expire_on_commit=False)

--- a/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
+++ b/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
@@ -17,10 +17,11 @@ import pytest
 import yaml
 from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
 from idun_agent_standalone.infrastructure.db.models.memory import StandaloneMemoryRow
+from idun_agent_standalone.infrastructure.db.models.prompt import StandalonePromptRow
 from idun_agent_standalone.infrastructure.db.session import Base
 from idun_agent_standalone.infrastructure.scripts import seed as seed_module
 from idun_agent_standalone.infrastructure.scripts.seed import seed_from_yaml_if_empty
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 # A minimal LangGraph YAML the engine's ConfigBuilder can validate
@@ -61,6 +62,35 @@ def yaml_config_path(tmp_path: Path) -> Path:
     config_path = tmp_path / "config.yaml"
     with open(config_path, "w") as f:
         yaml.dump(_AGENT_YAML, f)
+    return config_path
+
+
+# YAML with a top-level `prompts:` block — exercises the prompts seeder.
+_PROMPTS_YAML: dict[str, Any] = {
+    **_AGENT_YAML,
+    "prompts": [
+        {
+            "prompt_id": "system-prompt",
+            "version": 2,
+            "content": "You are a helpful assistant for {{ domain }}.",
+            "tags": ["latest", "production"],
+        },
+        {
+            "prompt_id": "rag-context",
+            "version": 1,
+            "content": "Use this context: {{ context }}",
+            "tags": ["rag"],
+        },
+    ],
+}
+
+
+@pytest.fixture
+def prompts_yaml_path(tmp_path: Path) -> Path:
+    """Write a YAML config with a `prompts:` block and return its path."""
+    config_path = tmp_path / "config-with-prompts.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(_PROMPTS_YAML, f)
     return config_path
 
 
@@ -173,3 +203,66 @@ async def test_agent_failure_does_not_block_memory_seed(
     assert agents == []
     assert len(memories) == 1
     assert memories[0].agent_framework == "LANGGRAPH"
+
+
+async def test_seed_prompts_inserts_rows_when_empty(
+    sessionmaker_factory: async_sessionmaker, prompts_yaml_path: Path
+) -> None:
+    """YAML with 2 prompts → 2 StandalonePromptRow records, fields preserved."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, prompts_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        rows = (await session.scalars(select(StandalonePromptRow))).all()
+
+    assert len(rows) == 2
+    assert {r.prompt_id for r in rows} == {"system-prompt", "rag-context"}
+    sys_row = next(r for r in rows if r.prompt_id == "system-prompt")
+    assert sys_row.version == 2
+    assert sys_row.content == "You are a helpful assistant for {{ domain }}."
+    assert sys_row.tags == ["latest", "production"]
+
+
+async def test_seed_prompts_skips_when_table_nonempty(
+    sessionmaker_factory: async_sessionmaker, prompts_yaml_path: Path
+) -> None:
+    """If the prompts table already has rows, the prompts seeder is a no-op."""
+    async with sessionmaker_factory() as session:
+        session.add(
+            StandalonePromptRow(
+                prompt_id="pre-existing",
+                version=1,
+                content="already here",
+                tags=[],
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker_factory() as session:
+        pre_count = await session.scalar(
+            select(func.count()).select_from(StandalonePromptRow)
+        )
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, prompts_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        post_count = await session.scalar(
+            select(func.count()).select_from(StandalonePromptRow)
+        )
+        rows = (await session.scalars(select(StandalonePromptRow))).all()
+
+    assert post_count == pre_count, "prompts re-seeded despite non-empty table"
+    assert {r.prompt_id for r in rows} == {"pre-existing"}
+
+
+async def test_seed_prompts_no_op_on_yaml_without_prompts_block(
+    sessionmaker_factory: async_sessionmaker, yaml_config_path: Path
+) -> None:
+    """YAML without a `prompts:` block → no rows, no error."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        count = await session.scalar(
+            select(func.count()).select_from(StandalonePromptRow)
+        )
+
+    assert count == 0

--- a/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
+++ b/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
@@ -1,0 +1,175 @@
+"""Unit tests for the per-resource seed pipeline.
+
+The seeder is split into one function per resource so a failure
+materializing one resource (e.g. observability rows in a future
+extension) cannot prevent the agent from booting. This module pins
+that contract: the orchestrator must catch + log per-resource
+exceptions and keep going.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.infrastructure.db.models.memory import StandaloneMemoryRow
+from idun_agent_standalone.infrastructure.db.session import Base
+from idun_agent_standalone.infrastructure.scripts import seed as seed_module
+from idun_agent_standalone.infrastructure.scripts.seed import seed_from_yaml_if_empty
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+# A minimal LangGraph YAML the engine's ConfigBuilder can validate
+# without importing a real graph module. We intentionally include
+# a checkpointer so the memory seed branch fires.
+_AGENT_YAML: dict[str, Any] = {
+    "server": {"api": {"port": 8000}},
+    "agent": {
+        "type": "LANGGRAPH",
+        "config": {
+            "name": "Seeded Ada",
+            "graph_definition": "./agent.py:graph",
+            "checkpointer": {
+                "type": "sqlite",
+                "db_url": "sqlite:///checkpoint.db",
+            },
+        },
+    },
+}
+
+
+@pytest.fixture
+async def sessionmaker_factory() -> AsyncIterator[async_sessionmaker]:
+    """Async sessionmaker bound to an in-memory SQLite with all ORMs created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def yaml_config_path(tmp_path: Path) -> Path:
+    """Write the minimal LangGraph YAML to disk and return its path."""
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(_AGENT_YAML, f)
+    return config_path
+
+
+async def test_seed_from_yaml_writes_agent_and_memory_rows(
+    sessionmaker_factory: async_sessionmaker, yaml_config_path: Path
+) -> None:
+    """Happy path: both per-resource functions run and persist rows."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        agent = (await session.execute(select(StandaloneAgentRow))).scalar_one()
+        memory = (await session.execute(select(StandaloneMemoryRow))).scalar_one()
+
+    assert agent.name == "Seeded Ada"
+    assert agent.status == "draft"
+    assert agent.base_engine_config["agent"]["type"] == "LANGGRAPH"
+    # The checkpointer is moved off the agent body and lives on the memory row.
+    assert "checkpointer" not in agent.base_engine_config["agent"]["config"]
+    assert memory.agent_framework == "LANGGRAPH"
+    assert memory.memory_config["type"] == "sqlite"
+
+
+async def test_seed_skips_when_db_already_has_agent(
+    sessionmaker_factory: async_sessionmaker, yaml_config_path: Path
+) -> None:
+    """If the agent row exists, the seeder is a no-op (no second insert)."""
+    async with sessionmaker_factory() as session:
+        session.add(
+            StandaloneAgentRow(
+                name="Existing",
+                base_engine_config={"server": {}, "agent": {"type": "LANGGRAPH"}},
+            )
+        )
+        await session.commit()
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        agents = (await session.execute(select(StandaloneAgentRow))).scalars().all()
+
+    assert len(agents) == 1
+    assert agents[0].name == "Existing"
+
+
+async def test_seed_no_config_path_is_noop(
+    sessionmaker_factory: async_sessionmaker, tmp_path: Path
+) -> None:
+    """No YAML on disk → no rows, no exception."""
+    missing = tmp_path / "does-not-exist.yaml"
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, missing)
+
+    async with sessionmaker_factory() as session:
+        agents = (await session.execute(select(StandaloneAgentRow))).scalars().all()
+        memories = (await session.execute(select(StandaloneMemoryRow))).scalars().all()
+
+    assert agents == []
+    assert memories == []
+
+
+async def test_memory_failure_does_not_block_agent_seed(
+    sessionmaker_factory: async_sessionmaker,
+    yaml_config_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `_seed_memory_if_empty` raises, the agent row must still be persisted.
+
+    This pins SPEC decision #8: per-resource try/except in the
+    orchestrator. Observability/memory failures cannot kill agent boot.
+    """
+
+    async def boom(session: Any, engine_config: Any) -> None:
+        raise RuntimeError("simulated memory seeder explosion")
+
+    monkeypatch.setattr(seed_module, "_seed_memory_if_empty", boom)
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        agents = (await session.execute(select(StandaloneAgentRow))).scalars().all()
+        memories = (await session.execute(select(StandaloneMemoryRow))).scalars().all()
+
+    assert len(agents) == 1
+    assert agents[0].name == "Seeded Ada"
+    assert memories == []
+
+
+async def test_agent_failure_does_not_block_memory_seed(
+    sessionmaker_factory: async_sessionmaker,
+    yaml_config_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `_seed_agent_if_empty` raises, the memory seeder still gets a chance.
+
+    Pins symmetric per-resource isolation — neither helper monopolizes
+    the boot path.
+    """
+
+    async def boom(session: Any, engine_config: Any) -> None:
+        raise RuntimeError("simulated agent seeder explosion")
+
+    monkeypatch.setattr(seed_module, "_seed_agent_if_empty", boom)
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        agents = (await session.execute(select(StandaloneAgentRow))).scalars().all()
+        memories = (await session.execute(select(StandaloneMemoryRow))).scalars().all()
+
+    assert agents == []
+    assert len(memories) == 1
+    assert memories[0].agent_framework == "LANGGRAPH"

--- a/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
+++ b/libs/idun_agent_standalone/tests/unit/scripts/test_seed.py
@@ -21,6 +21,7 @@ from idun_agent_standalone.infrastructure.db.models.observability import (
     StandaloneObservabilityRow,
 )
 from idun_agent_standalone.infrastructure.db.models.prompt import StandalonePromptRow
+from idun_agent_standalone.infrastructure.db.models.sso import StandaloneSsoRow
 from idun_agent_standalone.infrastructure.db.session import Base
 from idun_agent_standalone.infrastructure.scripts import seed as seed_module
 from idun_agent_standalone.infrastructure.scripts.seed import seed_from_yaml_if_empty
@@ -122,6 +123,29 @@ def observability_yaml_path(tmp_path: Path) -> Path:
     config_path = tmp_path / "config-with-observability.yaml"
     with open(config_path, "w") as f:
         yaml.dump(_OBSERVABILITY_YAML, f)
+    return config_path
+
+
+# YAML with a top-level `sso:` block — exercises the SSO seeder. SSO is
+# a singleton in the engine schema (a single SSOConfig, not a list), so
+# the seeder writes one row keyed by id="singleton".
+_SSO_YAML: dict[str, Any] = {
+    **_AGENT_YAML,
+    "sso": {
+        "enabled": True,
+        "issuer": "https://accounts.google.com",
+        "client_id": "123456.apps.googleusercontent.com",
+        "allowed_domains": ["example.com"],
+    },
+}
+
+
+@pytest.fixture
+def sso_yaml_path(tmp_path: Path) -> Path:
+    """Write a YAML config with an `sso:` block and return its path."""
+    config_path = tmp_path / "config-with-sso.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(_SSO_YAML, f)
     return config_path
 
 
@@ -355,5 +379,64 @@ async def test_seed_observability_no_op_on_yaml_without_block(
         count = await session.scalar(
             select(func.count()).select_from(StandaloneObservabilityRow)
         )
+
+    assert count == 0
+
+
+async def test_seed_sso_inserts_singleton_when_empty(
+    sessionmaker_factory: async_sessionmaker, sso_yaml_path: Path
+) -> None:
+    """YAML with sso block → 1 StandaloneSsoRow (singleton, fields preserved)."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, sso_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        rows = (await session.scalars(select(StandaloneSsoRow))).all()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == "singleton"
+    config = row.sso_config
+    assert config["enabled"] is True
+    assert config["issuer"] == "https://accounts.google.com"
+    assert config["client_id"] == "123456.apps.googleusercontent.com"
+    assert config["allowed_domains"] == ["example.com"]
+
+
+async def test_seed_sso_skips_when_singleton_exists(
+    sessionmaker_factory: async_sessionmaker, sso_yaml_path: Path
+) -> None:
+    """If singleton row exists, no re-seed (existing config preserved)."""
+    async with sessionmaker_factory() as session:
+        session.add(
+            StandaloneSsoRow(
+                id="singleton",
+                sso_config={
+                    "enabled": False,
+                    "issuer": "https://other.idp",
+                    "client_id": "other-client",
+                },
+            )
+        )
+        await session.commit()
+
+    await seed_from_yaml_if_empty(sessionmaker_factory, sso_yaml_path)
+
+    async with sessionmaker_factory() as session:
+        rows = (await session.scalars(select(StandaloneSsoRow))).all()
+
+    assert len(rows) == 1
+    # The pre-existing row was NOT overwritten with the YAML values.
+    assert rows[0].sso_config["issuer"] == "https://other.idp"
+    assert rows[0].sso_config["enabled"] is False
+
+
+async def test_seed_sso_no_op_on_yaml_without_block(
+    sessionmaker_factory: async_sessionmaker, yaml_config_path: Path
+) -> None:
+    """YAML without sso block → no row, no error."""
+    await seed_from_yaml_if_empty(sessionmaker_factory, yaml_config_path)
+
+    async with sessionmaker_factory() as session:
+        count = await session.scalar(select(func.count()).select_from(StandaloneSsoRow))
 
     assert count == 0


### PR DESCRIPTION
## Summary

Closes the T1 standalone seeder gap surfaced by `tasks/e2e-real-agents-08-05-2026/`. The seeder at `infrastructure/scripts/seed.py::seed_from_yaml_if_empty` previously persisted only `StandaloneAgentRow` and `StandaloneMemoryRow` from YAML; six other top-level blocks (`prompts`, `observability`, `sso`, `mcp_servers`, `integrations`, `guardrails`) were silently dropped on first boot.

This PR ships the per-resource seeders, restoring boot-time YAML config for every admin resource type and **un-blocking 3 deferred e2e scenarios** (Tasks 2.4 boot-time guardrail, 2.5 LG MCP, 3.4 ADK MCP — re-enabled in idun-dev SPEC §5 via parallel docs commit).

Tracks `tasks/standalone-seeder-yaml-09-05-2026/` (SPEC + PLAN in idun-dev).

## What ships

**9 commits** on `feat/standalone-seeder-yaml-full`:

| # | Task | Commit | Adds |
|---|---|---|---|
| 1 | Refactor seeder to per-resource pattern | `7e4ef487` | `_seed_agent_if_empty()` + `_seed_memory_if_empty()` + 5 isolation tests |
| 2 | Prompts | `11ee976c` | `_seed_prompts_if_empty()` + 3 tests |
| 3 | Observability (singleton) | `636a53fb` | `_seed_observability_if_empty()` + 3 tests |
| 4 | SSO (singleton) | `a7036942` | `_seed_sso_if_empty()` + 3 tests |
| 5 | MCP servers (collection + slug) | `2b6452e2` | `_seed_mcp_servers_if_empty()` + 3 tests |
| 6 | Integrations (collection + slug) | `95d8277a` | `_seed_integrations_if_empty()` + 3 tests |
| 7a | Schema: `to_manager_shape` (engine→manager inverse) | `8e4104cb` | helper + 5 round-trip tests |
| 7b | Guardrails (input + output, position + sort_order) | `613348cb` | `_seed_guardrails_if_empty()` + 3 tests |
| 8 | End-to-end round-trip | `71371de6` | maximal YAML → seed → assemble → semantic equality |

## Test coverage

- **`idun_agent_standalone`**: 394 → 414 (+20 new tests; 1 unrelated pre-existing skip preserved)
  - 18 new in `tests/unit/scripts/test_seed.py` (per-resource isolation)
  - 1 new in `tests/integration/test_seed_round_trip.py` (cross-cutting)
  - 1 from Task 1 refactor isolation
- **`idun_agent_schema`**: 77 → 82 (+5 round-trip tests for `to_manager_shape`)
- All formatters/linters clean (ruff/black/mypy on both libs).

## Architecture decisions (per SPEC §3)

1. **Per-resource emptiness check** — each resource seeds independently if its table is empty. No bundled "DB is empty" check.
2. **Singletons** (`memory`, `observability`, `sso`) — PK = `"singleton"`; row-existence guard before insert.
3. **Collections** (`prompts`, `mcp_servers`, `integrations`, `guardrails`) — `count() == 0` guard; `await session.flush()` between iterations so `ensure_unique_slug` sees pending rows.
4. **Per-resource try/except** in the orchestrator — a malformed observability block doesn't block agent boot. Partial seeding is acceptable per SPEC §3.2.
5. **Shape conversion** — `mode="json"` Pydantic dumps for JSON columns. Guardrails specifically use the new `to_manager_shape` helper to invert `convert_guardrail` (DB stores manager shape, assembly converts back to engine shape on the way out).
6. **INFO summary log** at end of orchestration: `seed complete from <path>: agent=N memory=N prompts=N observability=N sso=N mcp_servers=N integrations=N guardrails=N`.

## Subtle details caught during implementation

- **`StandaloneIntegrationRow.name` is NOT-NULL** but `IntegrationConfig` has no `name` field → seeder synthesizes `name=slug` (mirrors admin POST behavior).
- **Slug uniqueness within one YAML** requires `await session.flush()` between successive `ensure_unique_slug` calls — without it, two YAML entries with the same name both pick the bare slug.
- **PII guardrail `on_fail`** survives the manager↔engine round-trip only because `convert_guardrail` hardcodes `on_fail="exception"` for PII. Locked by `test_round_trip_detect_pii`.
- **Observability uses `session.get(Row, "singleton")`** instead of `scalar_one_or_none()` — slight stylistic difference from memory seeder; both are correct for typed-PK lookups.

## Test plan

- [ ] CodeRabbit review.
- [ ] Reviewer eyes on the new `to_manager_shape` schema helper (round-trip tests pin the contract; reviewer should sanity-check that the manager-shape dicts are what the assembly layer expects).
- [ ] Maintainer skim of the per-resource pattern (the orchestrator's per-resource try/except is intentional — partial seed is by design).

## Follow-ups (parallel docs commit on idun-dev `1400231`)

Same commit re-enables the 3 deferred e2e scenarios in idun-dev:
- SPEC §5 rows 5 (guardrail block) + 6 (MCP roundtrip) restored from DEFERRED to active.
- PLAN Tasks 2.4 + 2.5 + 3.4 bodies restored from commit `d4c6298d`.
- Roadmap T1 seeder entry checked off `[x] DONE 2026-05-09`.

The actual e2e test re-implementation lands in a separate follow-up PR — this seeder PR is intentionally focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved guardrail configuration handling with engine↔manager conversion and manager-shaped export.
  * Expanded YAML-driven seeding to initialize prompts, observability, SSO, MCP servers, integrations, and guardrails on first boot.

* **Tests**
  * Added unit and integration tests covering guardrail round-trips and per-resource seeding isolation and ordering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/589)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->