### PR TITLE
test(engine): silence third-party warnings + fix lifespan mock leak

### DIFF
--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -219,6 +219,16 @@ pythonpath = ["src", "tests"]
 filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::PendingDeprecationWarning",
+    # Third-party noise we can't fix at our level:
+    # - google-adk / ag-ui-adk emit "[EXPERIMENTAL]" UserWarnings for stable APIs we depend on
+    "ignore:\\[EXPERIMENTAL\\]:UserWarning",
+    # - pydantic UnsupportedFieldAttributeWarning fires from downstream models
+    #   (ag-ui / copilotkit) using Field(alias=...) on Annotated type aliases / union members
+    "ignore::pydantic.warnings.UnsupportedFieldAttributeWarning",
+    # - langgraph emits LangChainPendingDeprecationWarning at import time about
+    #   `allowed_objects`; the import-time site bypasses the generic
+    #   PendingDeprecationWarning filter above
+    "ignore::langchain_core._api.deprecation.LangChainPendingDeprecationWarning",
 ]
 markers = [
     "unit: Unit tests (fast, no external dependencies)",

--- a/libs/idun_agent_engine/tests/unit/server/test_lifespan.py
+++ b/libs/idun_agent_engine/tests/unit/server/test_lifespan.py
@@ -35,8 +35,9 @@ class TestLifespan:
         app = MagicMock()
         app.state.engine_config = engine_config
 
-        mock_agent = AsyncMock()
+        mock_agent = MagicMock()
         mock_agent.name = "Lifecycle Agent"
+        mock_agent.close = AsyncMock()
 
         with patch(
             "idun_agent_engine.core.config_builder.ConfigBuilder.initialize_agent_from_config"

--- a/libs/idun_agent_engine/tests/unit/server/test_lifespan.py
+++ b/libs/idun_agent_engine/tests/unit/server/test_lifespan.py
@@ -52,5 +52,8 @@ class TestLifespan:
                 call_args = mock_init.call_args
                 assert call_args[0][0] is engine_config
 
-            # After lifespan exits, agent should be closed
-            mock_agent.close.assert_called_once()
+            # After lifespan exits, agent should be closed AND awaited.
+            # assert_awaited_once also catches the regression where the
+            # coroutine is called but not awaited — exactly the bug class
+            # the AsyncMock-vs-MagicMock split in this fixture guards against.
+            mock_agent.close.assert_awaited_once()


### PR DESCRIPTION
## Summary

Engine CI was surfacing 92 warnings; only one was ours. This PR fixes that one and filters the third-party noise so future regressions stand out.

- **`tests/unit/server/test_lifespan.py`** — switch the agent fixture from `AsyncMock` to `MagicMock` with `close = AsyncMock()`. With `AsyncMock`, `agent.discover_capabilities()` returned a coroutine that the sync caller in `lifespan.configure_app` never awaited, leaking a `RuntimeWarning` via the `except` branch.
- **`pyproject.toml` filterwarnings** — ignore three categories that originate outside our code:
  - `[EXPERIMENTAL]` `UserWarning`s from `google-adk` / `ag-ui-adk` (~64 warnings)
  - `pydantic.warnings.UnsupportedFieldAttributeWarning` from downstream ag-ui / copilotkit models using `Field(alias=…)` on `Annotated` type aliases / union members (~24 warnings)
  - `langchain_core._api.deprecation.LangChainPendingDeprecationWarning` from langgraph's import-time `allowed_objects` notice — the existing `PendingDeprecationWarning` filter doesn't catch it because it fires before pytest's filter applies (1 warning)

After this PR: engine `pytest` reports `0 warnings` instead of 92.

## Test plan

- [x] `uv run pytest libs/idun_agent_engine/tests/unit/server/test_lifespan.py libs/idun_agent_engine/tests/integration/server/test_agent_run_observers.py` — 2 passed, 0 warnings
- [x] `uv run pytest libs/idun_agent_engine/tests/unit -q` — all unit tests pass, no regressions
- [ ] CI `Test engine (Py3.12)` job shows clean warning summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended test configuration to suppress additional third-party warnings for cleaner test runs.
  * Improved lifespan test mock to ensure the agent close operation is awaited, preventing a regression.

* **Chores**
  * Enhanced test filtering for clearer, less noisy test output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/590)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->