### PR TITLE
feat(guidelines): seed project-specific rules + first generated outputs + advisory CI drift check

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,57 @@
+---
+name: code-reviewer
+description: Idun coding-guideline review against the active rule set.
+model: opus
+tools: Read, Grep, Bash
+---
+
+# Code Reviewer
+
+You review a Python / TypeScript diff against the Idun coding-guideline rule set.
+Run `git diff origin/develop...HEAD` (or use the diff supplied to you) to see the changes.
+
+## Rule set (read-only inputs — never modify these)
+
+| ID | Severity | Layer | Title | Detection | Description |
+| --- | --- | --- | --- | --- | --- |
+| CMP-001 | advise | pre-commit | Cyclomatic complexity ≤ 10 (advisory) | ruff: `C901` | Functions with cyclomatic complexity above 10 are hard to test, hard to review, and tend to attract bugs. The cap is advisory — exceeding it is a prompt to ref… |
+| ASYNC-001 | warn | pre-commit, pr-review-agent | No sync I/O on async paths | ruff: `ASYNC` | Sync HTTP / DB / file I/O inside an async function blocks the event loop and starves every other coroutine on it. In a FastAPI/LangGraph hot path this silently… |
+| ASYNC-002 | warn | pre-commit, pr-review-agent | Track `asyncio.create_task` references (no fire-and-forget) | ruff: `RUF006` | A bare `asyncio.create_task(...)` whose return value is discarded can be garbage-collected mid-flight, swallowing exceptions and silently dropping work. Long-l… |
+| ERR-001 | warn | pre-commit, pr-review-agent | No `except Exception:` without re-raise + logger.exception | ruff: `BLE001` | A blind `except Exception:` that quietly continues hides bugs and turns unexpected failures into silent data corruption. The default policy is to log the trace… |
+| LOG-001 | warn | pre-commit, pr-review-agent | Use `logger.exception` for unexpected; never bare `except` | ruff: `BLE001` | Unexpected exceptions must be logged with the traceback so on-call can diagnose them. `logger.error("...")` inside an `except` clause hides the stack; bare `ex… |
+| LOG-003 | warn | pr-review-agent | Redact secrets/PII from log args | regex: `(secret|password|token|api[_-]?key)\s*=` | Logs are shipped to Langfuse, OTel collectors, and stdout — anything logged in plaintext leaks into long-term retention. Credentials and PII must be redacted (… |
+| MIGRATION-001 | warn | pr-review-agent | SQLAlchemy model change requires Alembic revision in same PR | manual: `diff sniffer — touches services/idun_agent_manager/src/app/infrastructure/db/models/ AND no new file under services/idun_agent_manager/alembic/versions/` | Any change to a SQLAlchemy ORM model must be accompanied by an Alembic revision in the same PR. Otherwise the dev/prod migration breaks at deploy. |
+| RES-001 | warn | pre-commit, pr-review-agent | Use `async with` for HTTP/DB/files; no manual `.close()` | ruff: `SIM117` | Manual `.close()` calls leak resources whenever the path between open and close raises. Context managers guarantee cleanup on every exit and compose with `asyn… |
+| SCHEMA-001 | warn | pr-review-agent | Schema changes ship in idun_agent_schema before consumers | manual: `cross-package diff sniffer in PR-review subagent` | Pydantic models in idun_agent_schema must change before any consumer (idun_agent_engine, idun_agent_standalone, services/idun_agent_standalone_ui) references t… |
+| SQL-001 | warn | pre-commit, pr-review-agent | Parametrized queries only; no f-string SQL | ruff: `S608` | String-interpolated SQL is a SQL-injection vector and breaks the driver's prepared-statement cache. All values must travel as bound parameters via SQLAlchemy t… |
+| TIME-001 | warn | pre-commit, pr-review-agent | Always tz-aware UTC datetimes; ban `datetime.utcnow()` | ruff: `DTZ` | `datetime.utcnow()` returns a naive datetime that compares wrongly against tz-aware values and is deprecated in Python 3.12+. All timestamps that cross a proce… |
+| TYPE-001 | warn | pre-commit | No `Any` outside FFI/JSON boundaries | mypy: `disallow-any-explicit` | Explicit `Any` defeats the type checker and propagates through every call site that touches it. It is acceptable at FFI / raw-JSON boundaries where the shape i… |
+
+## How to evaluate
+
+1. Read every changed file in the diff (use `Read` for full context).
+2. For each rule, decide whether the diff introduces a violation. Use `Bash` to run the rule's detection spec where possible (e.g., `ruff check --select ASYNC <file>`).
+3. Report only **new** violations introduced by this diff; do not list pre-existing issues unless the diff touches the same file region.
+4. Emit findings grouped by severity (warn, advise) then file. Include `<id>:<line>` and the rule's `fix_hint`.
+
+## Output format
+
+```markdown
+## Findings
+
+### Severity: warn
+
+#### path/to/file.py
+- **ASYNC-001** (line 142): sync `requests.get` inside `async def`.
+  Fix: use httpx.AsyncClient inside `async with`.
+
+### Severity: advise
+...
+
+## Summary
+- N warn findings across M files
+- N advise findings across M files
+- 0 block findings
+```
+
+Never apply fixes. Never modify files. Output the report and stop.

--- a/.claude/guidelines/rules/MIGRATION-001.yaml
+++ b/.claude/guidelines/rules/MIGRATION-001.yaml
@@ -1,0 +1,22 @@
+id: MIGRATION-001
+title: SQLAlchemy model change requires Alembic revision in same PR
+category: schema
+severity: warn
+layer: [pr-review-agent]
+detection:
+  type: manual
+  spec: diff sniffer — touches services/idun_agent_manager/src/app/infrastructure/db/models/ AND no new file under services/idun_agent_manager/alembic/versions/
+owner: manager-team
+description: |
+  Any change to a SQLAlchemy ORM model must be accompanied by an Alembic
+  revision in the same PR. Otherwise the dev/prod migration breaks at deploy.
+fix_hint: |
+  Run `cd services/idun_agent_manager && alembic revision --autogenerate -m "<msg>"`
+  and commit the new file under alembic/versions/.
+graduation:
+  promote_to_block_when: "3 consecutive weeks zero violations"
+  default_block_target: pr-review-agent
+  current_phase: advisory
+state: active
+since: 2026-05-09
+last_updated: 2026-05-09

--- a/.claude/guidelines/rules/SCHEMA-001.yaml
+++ b/.claude/guidelines/rules/SCHEMA-001.yaml
@@ -1,0 +1,24 @@
+id: SCHEMA-001
+title: Schema changes ship in idun_agent_schema before consumers
+category: schema
+severity: warn
+layer: [pr-review-agent]
+detection:
+  type: manual
+  spec: cross-package diff sniffer in PR-review subagent
+owner: schema-team
+description: |
+  Pydantic models in idun_agent_schema must change before any consumer
+  (idun_agent_engine, idun_agent_standalone, services/idun_agent_standalone_ui)
+  references the new field. A PR that updates a consumer without first updating
+  the schema breaks the schema-flows-first invariant from CLAUDE.md.
+fix_hint: |
+  Split the change: (1) add the field to idun_agent_schema, ship that PR;
+  (2) consume it in engine/standalone/UI in a follow-up PR.
+graduation:
+  promote_to_block_when: "false-positive rate <5% over 4 weeks"
+  default_block_target: pr-review-agent
+  current_phase: advisory
+state: active
+since: 2026-05-09
+last_updated: 2026-05-09

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,52 @@ jobs:
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
         run: |
           uv run pytest libs/idun_agent_engine/tests -m "not requires_langfuse and not requires_phoenix and not requires_postgres"
+
+  guidelines-check:
+    name: Coding guidelines drift check (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone idun-dev plugin
+        env:
+          IDUN_DEV_TOKEN: ${{ secrets.IDUN_DEV_READ_TOKEN }}
+        run: |
+          if [ -z "$IDUN_DEV_TOKEN" ]; then
+            echo "IDUN_DEV_READ_TOKEN secret not set — cannot clone idun-dev plugin."
+            echo "Add the secret to repo settings or skip the guidelines-check job."
+            exit 1
+          fi
+          git clone --depth 1 \
+            https://x-access-token:$IDUN_DEV_TOKEN@github.com/Idun-Group/idun-dev.git \
+            $RUNNER_TEMP/idun-dev
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Install renderer deps
+        run: |
+          cd $RUNNER_TEMP/idun-dev/.claude/scripts
+          uv sync --all-groups
+
+      - name: Drift check
+        id: drift
+        run: |
+          cd $RUNNER_TEMP/idun-dev/.claude/scripts
+          uv run python render_guidelines.py \
+            --target-repo $GITHUB_WORKSPACE --check
+        continue-on-error: true
+
+      - name: Comment on PR if drift
+        if: steps.drift.outcome == 'failure' && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: guidelines-drift
+          message: |
+            Coding-guideline outputs have drifted from the YAML source of truth.
+            Run `/render-guidelines` locally and commit the resulting changes.
+
+            (This check is **advisory** in v1 — it will not block merge.)

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # Superpowers brainstorming artifacts
 .superpowers/
 
+# Coding-guidelines renderer runtime log
+.claude/guidelines/render.log
+
 # Standalone UI build output gets baked into the wheel by the Makefile
 # (`make build-standalone-ui`); the static/ directory is otherwise empty.
 libs/idun_agent_standalone/src/idun_agent_standalone/static/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,3 +148,24 @@ Plus any of these domain blocks that genuinely apply, in this order: Config flow
 - Branch naming: `feat/*`, `fix/*`, `docs/*`, `chore/*`, `misc/*`.
 - Python line length: 88. Async throughout. Ruff + Black + Mypy.
 - Schema changes land in `idun_agent_schema` first, then engine and standalone consumers. Frontend types regenerate from the standalone OpenAPI spec.
+
+<!-- BEGIN: generated-by render_guidelines -->
+## Coding Guidelines — Severity Matrix (auto-generated)
+
+| ID | Title | Severity | Layer |
+| --- | --- | --- | --- |
+| ASYNC-001 | No sync I/O on async paths | warn | pre-commit, pr-review-agent |
+| ASYNC-002 | Track `asyncio.create_task` references (no fire-and-forget) | warn | pre-commit, pr-review-agent |
+| CMP-001 | Cyclomatic complexity ≤ 10 (advisory) | advise | pre-commit |
+| ERR-001 | No `except Exception:` without re-raise + logger.exception | warn | pre-commit, pr-review-agent |
+| LOG-001 | Use `logger.exception` for unexpected; never bare `except` | warn | pre-commit, pr-review-agent |
+| LOG-003 | Redact secrets/PII from log args | warn | pr-review-agent |
+| MIGRATION-001 | SQLAlchemy model change requires Alembic revision in same PR | warn | pr-review-agent |
+| RES-001 | Use `async with` for HTTP/DB/files; no manual `.close()` | warn | pre-commit, pr-review-agent |
+| SCHEMA-001 | Schema changes ship in idun_agent_schema before consumers | warn | pr-review-agent |
+| SQL-001 | Parametrized queries only; no f-string SQL | warn | pre-commit, pr-review-agent |
+| TIME-001 | Always tz-aware UTC datetimes; ban `datetime.utcnow()` | warn | pre-commit, pr-review-agent |
+| TYPE-001 | No `Any` outside FFI/JSON boundaries | warn | pre-commit |
+
+Full rule book: `docs/team/CODING-GUIDELINES.md`.
+<!-- END: generated-by render_guidelines -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,3 +115,13 @@ By contributing to this project, you agree to abide by our [Code of Conduct](COD
 ## Questions?
 
 If you have any questions, feel free to ask by opening an issue.
+
+<!-- BEGIN: generated-by render_guidelines -->
+## Coding Guidelines (auto-generated)
+
+This repository follows the Idun coding-guideline rule set (12 rules: 0 block / 11 warn / 1 advise).
+
+Full reference: [`docs/team/CODING-GUIDELINES.md`](docs/team/CODING-GUIDELINES.md).
+
+Active rule ids: ASYNC-001, ASYNC-002, CMP-001, ERR-001, LOG-001, LOG-003, MIGRATION-001, RES-001, SCHEMA-001, SQL-001, TIME-001, TYPE-001.
+<!-- END: generated-by render_guidelines -->

--- a/docs/team/CODING-GUIDELINES.md
+++ b/docs/team/CODING-GUIDELINES.md
@@ -1,0 +1,228 @@
+# Coding Guidelines
+
+_Generated from `.claude/guidelines/rules/*.yaml` — do not edit by hand._
+
+## async-lifecycle
+
+### ASYNC-001 — No sync I/O on async paths
+
+**Severity:** warn
+**Layer:** pre-commit, pr-review-agent
+**Owner:** engine-team
+
+Sync HTTP / DB / file I/O inside an async function blocks the event loop and
+starves every other coroutine on it. In a FastAPI/LangGraph hot path this
+silently destroys throughput and tail latency.
+
+**Fix:** Replace `requests.get(...)` with `async with httpx.AsyncClient() as c:` and
+switch sync DB / file calls to their async equivalents (asyncpg, aiofiles).
+
+Good:
+```
+async with httpx.AsyncClient() as client:
+    resp = await client.get(url)
+```
+
+Bad:
+```
+async def fetch(url):
+    return requests.get(url).json()
+```
+
+### ASYNC-002 — Track `asyncio.create_task` references (no fire-and-forget)
+
+**Severity:** warn
+**Layer:** pre-commit, pr-review-agent
+**Owner:** engine-team
+
+A bare `asyncio.create_task(...)` whose return value is discarded can be
+garbage-collected mid-flight, swallowing exceptions and silently dropping
+work. Long-lived background tasks must keep a strong reference.
+
+**Fix:** Assign the task to a module/instance variable or a tracking set, and
+`await` or `cancel()` it during shutdown.
+
+## logging
+
+### LOG-001 — Use `logger.exception` for unexpected; never bare `except`
+
+**Severity:** warn
+**Layer:** pre-commit, pr-review-agent
+**Owner:** platform-team
+
+Unexpected exceptions must be logged with the traceback so on-call can
+diagnose them. `logger.error("...")` inside an `except` clause hides the
+stack; bare `except:` swallows `KeyboardInterrupt` and `SystemExit`.
+
+**Fix:** Use `except Exception:` with `logger.exception("context")`, or a narrower
+exception type when you intend to handle the error locally.
+
+Good:
+```
+try:
+    result = await call_external()
+except httpx.HTTPError:
+    logger.exception("external call failed")
+    raise
+```
+
+Bad:
+```
+try:
+    result = await call_external()
+except:
+    logger.error("call failed")
+```
+
+### LOG-003 — Redact secrets/PII from log args
+
+**Severity:** warn
+**Layer:** pr-review-agent
+**Owner:** platform-team
+
+Logs are shipped to Langfuse, OTel collectors, and stdout — anything logged
+in plaintext leaks into long-term retention. Credentials and PII must be
+redacted (or never logged) at the call site, not at the sink.
+
+**Fix:** Replace secret values with a placeholder like `"***"` before logging, or
+log the field name only (`logger.info("token rotated")` not the token).
+
+## error-handling
+
+### ERR-001 — No `except Exception:` without re-raise + logger.exception
+
+**Severity:** warn
+**Layer:** pre-commit, pr-review-agent
+**Owner:** platform-team
+
+A blind `except Exception:` that quietly continues hides bugs and turns
+unexpected failures into silent data corruption. The default policy is to
+log the traceback and re-raise; deliberate suppression must be justified.
+
+**Fix:** Either narrow the exception class or call `logger.exception(...)` then
+`raise` — only swallow exceptions when you have a documented reason.
+
+## types
+
+### TYPE-001 — No `Any` outside FFI/JSON boundaries
+
+**Severity:** warn
+**Layer:** pre-commit
+**Owner:** platform-team
+
+Explicit `Any` defeats the type checker and propagates through every call
+site that touches it. It is acceptable at FFI / raw-JSON boundaries where
+the shape is genuinely unknown, but never inside our domain code.
+
+**Fix:** Replace `Any` with a concrete type, `TypedDict`, dataclass, or Pydantic
+model — read the source to find the real type before reaching for `Any`.
+
+## time
+
+### TIME-001 — Always tz-aware UTC datetimes; ban `datetime.utcnow()`
+
+**Severity:** warn
+**Layer:** pre-commit, pr-review-agent
+**Owner:** platform-team
+
+`datetime.utcnow()` returns a naive datetime that compares wrongly against
+tz-aware values and is deprecated in Python 3.12+. All timestamps that
+cross a process boundary (DB, API, logs) must be tz-aware UTC.
+
+**Fix:** Use `datetime.now(timezone.utc)` (or `datetime.now(UTC)` on 3.11+) and
+store/transmit the value with its tzinfo intact.
+
+Good:
+```
+from datetime import datetime, timezone
+now = datetime.now(timezone.utc)
+```
+
+Bad:
+```
+from datetime import datetime
+now = datetime.utcnow()
+```
+
+## resource
+
+### RES-001 — Use `async with` for HTTP/DB/files; no manual `.close()`
+
+**Severity:** warn
+**Layer:** pre-commit, pr-review-agent
+**Owner:** engine-team
+
+Manual `.close()` calls leak resources whenever the path between open and
+close raises. Context managers guarantee cleanup on every exit and compose
+with `async with` for httpx, asyncpg, aiofiles, etc.
+
+**Fix:** Wrap the resource in `with` / `async with`; collapse nested context
+managers into a single comma-separated form.
+
+## sql
+
+### SQL-001 — Parametrized queries only; no f-string SQL
+
+**Severity:** warn
+**Layer:** pre-commit, pr-review-agent
+**Owner:** manager-team
+
+String-interpolated SQL is a SQL-injection vector and breaks the driver's
+prepared-statement cache. All values must travel as bound parameters via
+SQLAlchemy text() bindings or the driver's parameter API.
+
+**Fix:** Replace f-string SQL with a parametrized query — `text("...:id")` plus
+`.params(id=value)`, or the asyncpg `$1`/`$2` form.
+
+Good:
+```
+await session.execute(text("SELECT * FROM agents WHERE id = :id"), {"id": agent_id})
+```
+
+Bad:
+```
+await session.execute(text(f"SELECT * FROM agents WHERE id = '{agent_id}'"))
+```
+
+## complexity
+
+### CMP-001 — Cyclomatic complexity ≤ 10 (advisory)
+
+**Severity:** advise
+**Layer:** pre-commit
+**Owner:** platform-team
+
+Functions with cyclomatic complexity above 10 are hard to test, hard to
+review, and tend to attract bugs. The cap is advisory — exceeding it is a
+prompt to refactor into smaller helpers, not an automatic failure.
+
+**Fix:** Extract guard clauses, dispatch tables, or helper functions to bring the
+branching count down; aim for one responsibility per function.
+
+## schema
+
+### MIGRATION-001 — SQLAlchemy model change requires Alembic revision in same PR
+
+**Severity:** warn
+**Layer:** pr-review-agent
+**Owner:** manager-team
+
+Any change to a SQLAlchemy ORM model must be accompanied by an Alembic
+revision in the same PR. Otherwise the dev/prod migration breaks at deploy.
+
+**Fix:** Run `cd services/idun_agent_manager && alembic revision --autogenerate -m "<msg>"`
+and commit the new file under alembic/versions/.
+
+### SCHEMA-001 — Schema changes ship in idun_agent_schema before consumers
+
+**Severity:** warn
+**Layer:** pr-review-agent
+**Owner:** schema-team
+
+Pydantic models in idun_agent_schema must change before any consumer
+(idun_agent_engine, idun_agent_standalone, services/idun_agent_standalone_ui)
+references the new field. A PR that updates a consumer without first updating
+the schema breaks the schema-flows-first invariant from CLAUDE.md.
+
+**Fix:** Split the change: (1) add the field to idun_agent_schema, ship that PR;
+(2) consume it in engine/standalone/UI in a follow-up PR.


### PR DESCRIPTION
## Summary

Companion PR to `Idun-Group/idun-dev#16` (merged). Lands the platform-side artifacts of PLAN-1 from the coding-guideline rollout.

### What's added

- **2 project-specific rule YAMLs** at `.claude/guidelines/rules/`:
  - `SCHEMA-001` — Schema changes ship in `idun_agent_schema` before consumers (warn, pr-review-agent, manual detection).
  - `MIGRATION-001` — SQLAlchemy model change requires Alembic revision in same PR (warn, pr-review-agent, manual detection).
- **First generated outputs** (auto-rendered from the merged plugin's renderer + 10 generic rules + these 2 project-specific rules — 12 total):
  - `docs/team/CODING-GUIDELINES.md` — full rule book grouped by category.
  - `CONTRIBUTING.md` — auto-generated fragment between `<!-- BEGIN/END: generated-by render_guidelines -->` markers (existing prose preserved outside markers).
  - `CLAUDE.md` — severity-matrix fragment between the same markers (existing content preserved).
  - `.claude/agents/code-reviewer.md` — code-reviewer subagent prompt with the full rule table embedded.
- **`.gitignore`** — ignores `.claude/guidelines/render.log` (renderer runtime output, not source).
- **CI advisory drift check** — new `guidelines-check` job in `.github/workflows/ci.yml`:
  - Runs `render_guidelines.py --check` against the PR.
  - Posts a sticky PR comment if drift is detected.
  - `continue-on-error: true` at the job level — workflow status stays green even if the job fails.
  - **Required secret:** `IDUN_DEV_READ_TOKEN` (PAT or fine-grained token with read access to `Idun-Group/idun-dev`). Until the secret is added in repo Settings → Secrets and variables → Actions, the job will fail at the clone step but won't block the workflow. **Action item for repo admin: add the secret before merging if you want the drift check to run.**

### Severity breakdown of merged 12 rules

- **Block:** 0 (advisory rollout — Phase 1 of the planned graduate-to-blocking)
- **Warn:** 11 (ASYNC-001/002, LOG-001/003, ERR-001, TYPE-001, TIME-001, RES-001, SQL-001, SCHEMA-001, MIGRATION-001)
- **Advise:** 1 (CMP-001 — cyclomatic complexity ≤ 10)

### Spec & plan

Authoritative sources in `idun-dev/tasks/coding-guidelines-09-05-2026/`:
- `SPEC.md` — full design (10 sections, 30 rules total in the inventory; 12 active in v1)
- `PLAN-1.md` — 14-task plan executed across both repos (this PR is the platform-side artifact set)
- `PLAN-2.md`, `PLAN-3.md` — follow-up rollouts (PR-review subagent + remaining rules + hooks + headless-Claude CI; setup tasks like Black removal, ESLint+Prettier, commitlint, ADRs, /onboarding-check)

### Test plan for review

- [ ] `/idun-team:audit-guidelines` reports `No drift.` against this branch
- [ ] `cat docs/team/CODING-GUIDELINES.md | grep -c "^### "` reports 12 rules
- [ ] `grep -A5 "Severity Matrix" CLAUDE.md` shows the auto-generated table
- [ ] `grep "ASYNC-001" CONTRIBUTING.md` finds the rule in the auto-generated fragment
- [ ] After admin adds `IDUN_DEV_READ_TOKEN` secret, the `guidelines-check` CI job runs without the clone error
- [ ] No existing CI status changes; engine-tests + pre-commit gates unchanged

Marked draft for human review of the rule severities, the CI workflow change, and the secret-admin step before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)