### PR TITLE
test(e2e): Phase 4.5 — boot-standalone.sh real-LLM agent swap

### DIFF
--- a/services/idun_agent_standalone_ui/e2e/boot-standalone.sh
+++ b/services/idun_agent_standalone_ui/e2e/boot-standalone.sh
@@ -55,11 +55,22 @@ echo "[boot] building UI -> $UIDIR" >&2
 mkdir -p "$UIDIR"
 cp -R "$ROOT/services/idun_agent_standalone_ui/out/." "$UIDIR/"
 
-# Inline echo-agent module. A trivial LangGraph that echoes the last
-# user message back. Lives in the temp dir so the engine resolves the
-# absolute path via importlib.util.spec_from_file_location — no PYTHONPATH
-# games, no permanent test fixture in the package.
-cat > "$AGENT_FILE" <<'PY'
+# Agent module: real LLM if LLM_PROVIDER is set, otherwise inline echo.
+# Both live in the temp dir so the engine resolves the absolute path via
+# importlib.util.spec_from_file_location — no PYTHONPATH games, no
+# permanent test fixture in the package.
+if [[ -n "$LLM_PROVIDER" ]]; then
+  # Reuse the canonical real-LLM fixture used by the pytest e2e matrix.
+  # That module reads E2E_PROVIDER / E2E_MODEL at import time (already
+  # exported above) and exposes the same `graph` symbol the YAML below
+  # references. Without this swap the chat-real-llm spec would pass
+  # against echo and the UI gate against real-LLM streaming would be
+  # vacuous (CodeRabbit flagged this on PR #580).
+  echo "[boot] real-LLM mode (provider=$LLM_PROVIDER model=$LLM_MODEL)" >&2
+  cp "$ROOT/tests/e2e/fixtures/agents/agent_lg_chat.py" "$AGENT_FILE"
+else
+  echo "[boot] echo-agent mode (no LLM_PROVIDER set)" >&2
+  cat > "$AGENT_FILE" <<'PY'
 """Minimal LangGraph echo agent for E2E tests.
 
 Uses LangChain message types + `add_messages` reducer so the engine's
@@ -92,6 +103,7 @@ _builder.set_entry_point("echo")
 _builder.add_edge("echo", END)
 graph = _builder.compile()
 PY
+fi
 
 # Inline config — points at the temp-dir agent file. The engine's
 # LangGraph adapter resolves "/abs/path/to/file.py:varname" via

--- a/services/idun_agent_standalone_ui/e2e/chat-real-llm.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/chat-real-llm.spec.ts
@@ -24,6 +24,7 @@ test("chat happy path with real LLM streams a non-empty assistant reply", async 
   // with a stable testid; we poll the page for any post-user text that
   // is at least 20 chars (filtering out the prompt itself + the
   // composer placeholder).
+  let lastReply = "";
   await expect
     .poll(
       async () => {
@@ -32,9 +33,16 @@ test("chat happy path with real LLM streams a non-empty assistant reply", async 
           .replace(prompt, "")
           .replace(/Message[^\n]*/g, "")
           .trim();
+        lastReply = trimmed;
         return trimmed.length;
       },
       { timeout: 60_000, intervals: [500, 1_000, 2_000] },
     )
     .toBeGreaterThan(20);
+
+  // Guard against silent fallback to the echo agent. boot-standalone.sh
+  // swaps the agent module when LLM_PROVIDER is set; if that swap ever
+  // regresses, length alone would still pass — assert the echo prefix
+  // is absent so the gate stays meaningful.
+  expect(lastReply.toLowerCase()).not.toContain("echo:");
 });

--- a/services/idun_agent_standalone_ui/e2e/chat-real-llm.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/chat-real-llm.spec.ts
@@ -11,6 +11,13 @@ test("chat happy path with real LLM streams a non-empty assistant reply", async 
   const input = page.locator('textarea[placeholder^="Message"]');
   await expect(input).toBeVisible({ timeout: 30_000 });
 
+  // Baseline of static page text BEFORE sending the prompt — used to
+  // compute the post-send delta so static UI strings (greeting,
+  // starter prompts, sidebar) can't satisfy the length predicate.
+  const baseline = (await page.locator("body").innerText())
+    .replace(/Message[^\n]*/g, "")
+    .trim();
+
   const prompt = "Say hello in one short sentence.";
   await input.fill(prompt);
   await page.getByRole("button", { name: /send message/i }).click();
@@ -21,20 +28,18 @@ test("chat happy path with real LLM streams a non-empty assistant reply", async 
   });
 
   // Wait for assistant reply. The chat doesn't tag assistant bubbles
-  // with a stable testid; we poll the page for any post-user text that
-  // is at least 20 chars (filtering out the prompt itself + the
-  // composer placeholder).
+  // with a stable testid; we poll the page for the post-send delta
+  // (everything that isn't already in the baseline + the prompt) and
+  // assert the new content exceeds 20 chars.
   let lastReply = "";
   await expect
     .poll(
       async () => {
         const all = await page.locator("body").innerText();
-        const trimmed = all
-          .replace(prompt, "")
-          .replace(/Message[^\n]*/g, "")
-          .trim();
-        lastReply = trimmed;
-        return trimmed.length;
+        const transcript = all.replace(/Message[^\n]*/g, "").trim();
+        const delta = transcript.replace(baseline, "").replace(prompt, "").trim();
+        lastReply = delta;
+        return delta.length;
       },
       { timeout: 60_000, intervals: [500, 1_000, 2_000] },
     )

--- a/services/idun_agent_standalone_ui/e2e/chat-real-llm.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/chat-real-llm.spec.ts
@@ -3,6 +3,17 @@ import { expect, test } from "@playwright/test";
 // Selectors mirror chat.spec.ts. The chat surface has no data-testid —
 // we use placeholder + role idioms.
 
+// Skip cleanly when the standalone wasn't booted with a real-LLM agent
+// (boot-standalone.sh swaps the agent module only when LLM_PROVIDER is
+// set). Without this skip the standalone-ci.yml Playwright job, which
+// boots the echo agent, would run this spec against echo and fail the
+// not-toContain("echo:") gate. Real-LLM job in e2e-real-llm.yml exports
+// LLM_PROVIDER=openai so the spec runs there.
+test.skip(
+  !process.env.LLM_PROVIDER,
+  "chat-real-llm requires LLM_PROVIDER set so boot-standalone.sh swaps in the real-LLM agent fixture; runs from the e2e-real-llm.yml workflow.",
+);
+
 test("chat happy path with real LLM streams a non-empty assistant reply", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

Closes the chat-real-llm UI coverage gap surfaced during the e2e-real-agents work (CodeRabbit on PR #580). The Playwright job already sets `LLM_PROVIDER=openai` + `LLM_MODEL=gpt-5.4-mini`, but the boot script wrote an inline echo-agent regardless — so `chat-real-llm.spec.ts` was passing trivially against echo, never actually exercising real-LLM streaming through the bundled UI.

## Changes

- **`boot-standalone.sh`** — when `LLM_PROVIDER` is non-empty, copy `tests/e2e/fixtures/agents/agent_lg_chat.py` into the temp dir (the canonical fixture used by the pytest matrix) instead of writing the inline echo block. The agent reads `E2E_PROVIDER` / `E2E_MODEL` at import time, which the script already exports from `LLM_PROVIDER` / `LLM_MODEL`.
- **`chat-real-llm.spec.ts`** — assert `lastReply` does NOT contain `"echo:"` so a future regression that silently falls back to the echo path can't pass the length check vacuously.

When `LLM_PROVIDER` is unset (local dev / CI without secrets) the echo path is unchanged.

## Test plan

- [x] Bash syntax: `bash -n boot-standalone.sh` — clean
- [x] TypeScript: `pnpm typecheck` — clean
- [x] Local Playwright run with real LLM: `LLM_PROVIDER=openai LLM_MODEL=gpt-5.4-mini pnpm exec playwright test e2e/chat-real-llm.spec.ts` → **1 passed (26.4s)**
- [ ] CI: 4 required real-LLM checks all pass (matrix unchanged; this only affects the Playwright job's behavior under `LLM_PROVIDER=openai`)
- [ ] CodeRabbit review — likely clean (no new types, small surface)

## Roadmap impact

Closes T1 entry `Phase 4.5 — boot-standalone.sh real-LLM agent swap` in `tasks/idun-rework-roadmap-08-05-2026/TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced e2e test to skip when no real LLM is configured, capture a baseline snapshot, derive assistant reply deltas during polling, assert non-empty responses, and verify replies do not contain an unintended "echo:" prefix (case-insensitive).

* **Chores**
  * Boot flow now conditionally generates the temporary agent module to support real-LLM vs fallback agent modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/593)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->