### PR TITLE
fix(engine,standalone): surface guardrail install failures to reload pipeline

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -156,17 +156,17 @@ async def configure_app(app: FastAPI, engine_config):
     if not hasattr(app.state, "post_configure_callbacks"):
         app.state.post_configure_callbacks = []
 
+    # Per-guard init failures are caught and collected inside
+    # _parse_guardrails (returns the failure list). Anything that escapes
+    # _parse_guardrails is a parser bug, not an expected install error,
+    # and must propagate so the reload pipeline can roll back the DB
+    # write — silently swallowing it would re-introduce the very
+    # silent-passthrough behavior this surface was added to fix.
     guardrails_obj = engine_config.guardrails
-    failed_guardrails: list[FailedGuardrail] = []
-    try:
-        guardrails, failed_guardrails = (
-            _parse_guardrails(guardrails_obj) if guardrails_obj else ([], [])
-        )
-        logger.debug(f"Guardrails: {guardrails}")
-    except Exception as e:
-        logger.exception(f"Failed to parse guardrails: {e}, continuing without them")
-        guardrails = []
-        failed_guardrails = []
+    guardrails, failed_guardrails = (
+        _parse_guardrails(guardrails_obj) if guardrails_obj else ([], [])
+    )
+    logger.debug(f"Guardrails: {guardrails}")
     # Mirror the failed_mcp_servers pattern — surface install failures
     # so embedders (e.g. the standalone reload pipeline) can roll back
     # the DB write instead of letting the request flow through with

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -2,10 +2,12 @@
 
 Initializes the agent at startup and cleans up resources on shutdown.
 """
+
 import inspect
 import logging
 from collections.abc import Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 
 from fastapi import FastAPI
 from idun_agent_schema.engine.guardrails import Guardrails
@@ -22,30 +24,69 @@ logger = logging.getLogger(__name__)
 PostConfigureCallback = Callable[[FastAPI], Awaitable[None]]
 
 
-def _parse_guardrails(guardrails_obj: Guardrails) -> Sequence[BaseGuardrail]:
-    """Build guard instances; one failure does not drop the rest."""
+@dataclass(frozen=True)
+class FailedGuardrail:
+    """A guardrail that failed to initialize.
+
+    Surfaced via ``app.state.failed_guardrails`` — same pattern the
+    engine already uses for ``failed_mcp_servers``. Embedders (e.g.
+    the standalone reload pipeline) inspect this list to detect
+    silent install failures and surface them as a non-success reload
+    outcome, instead of letting the request flow through with the
+    guardrail inactive.
+    """
+
+    config_id: str
+    position: str
+    error: str
+
+
+def _parse_guardrails(
+    guardrails_obj: Guardrails,
+) -> tuple[Sequence[BaseGuardrail], list[FailedGuardrail]]:
+    """Build guard instances; collect rather than swallow failures.
+
+    Returns ``(guards, failures)``. The boot path keeps the existing
+    "one failure does not drop the rest" behavior — it logs and
+    continues — but reload-time embedders use the ``failures`` list
+    to surface a clear signal back to the admin caller (e.g. when a
+    Hub install raises ``HttpError``, the install side-effects fail,
+    or a transitive dep like a spaCy model is missing). Without this
+    surface, the engine previously logged the failure and let
+    ``configure_app`` complete normally — admins saw ``reload OK``
+    and only noticed the silent inactivity when production traffic
+    bypassed the guardrail.
+    """
     from ..guardrails.guardrails_hub.guardrails_hub import GuardrailsHubGuard as GHGuard
 
     if not guardrails_obj:
-        return []
+        return [], []
 
     guards: list[BaseGuardrail] = []
+    failures: list[FailedGuardrail] = []
     for position, configs in (
         ("input", guardrails_obj.input),
         ("output", guardrails_obj.output),
     ):
         for guard in configs:
-            config_id = getattr(guard, "config_id", "<unknown>")
+            config_id = str(getattr(guard, "config_id", "<unknown>"))
             try:
                 guards.append(GHGuard(guard, position=position))
                 logger.info("Guardrail '%s' (%s) initialized", config_id, position)
-            except (Exception, SystemExit):
+            except (Exception, SystemExit) as exc:
                 logger.exception(
                     "Guardrail '%s' (%s) init failed; skipping",
                     config_id,
                     position,
                 )
-    return guards
+                failures.append(
+                    FailedGuardrail(
+                        config_id=config_id,
+                        position=position,
+                        error=str(exc),
+                    )
+                )
+    return guards, failures
 
 
 async def cleanup_agent(app: FastAPI):
@@ -116,18 +157,29 @@ async def configure_app(app: FastAPI, engine_config):
         app.state.post_configure_callbacks = []
 
     guardrails_obj = engine_config.guardrails
+    failed_guardrails: list[FailedGuardrail] = []
     try:
-        guardrails = _parse_guardrails(guardrails_obj) if guardrails_obj else []
+        guardrails, failed_guardrails = (
+            _parse_guardrails(guardrails_obj) if guardrails_obj else ([], [])
+        )
         logger.debug(f"Guardrails: {guardrails}")
     except Exception as e:
         logger.exception(f"Failed to parse guardrails: {e}, continuing without them")
         guardrails = []
+        failed_guardrails = []
+    # Mirror the failed_mcp_servers pattern — surface install failures
+    # so embedders (e.g. the standalone reload pipeline) can roll back
+    # the DB write instead of letting the request flow through with
+    # the guardrail silently inactive.
+    app.state.failed_guardrails = failed_guardrails
 
     # Use ConfigBuilder's centralized agent initialization, passing the registry
     try:
         mcp_registry = MCPClientRegistry(engine_config.mcp_servers or [])
     except Exception as e:
-        logger.exception(f"⚠️ Failed to initialize MCP registry: {e}, continuing without MCP servers")
+        logger.exception(
+            f"⚠️ Failed to initialize MCP registry: {e}, continuing without MCP servers"
+        )
         mcp_registry = MCPClientRegistry()
     set_active_registry(mcp_registry)
     app.state.mcp_registry = mcp_registry
@@ -136,7 +188,9 @@ async def configure_app(app: FastAPI, engine_config):
     # logs. Replaced on every reload so stale failures don't linger.
     app.state.failed_mcp_servers = mcp_registry.failed
     try:
-        agent_instance = await ConfigBuilder.initialize_agent_from_config(engine_config, mcp_registry)
+        agent_instance = await ConfigBuilder.initialize_agent_from_config(
+            engine_config, mcp_registry
+        )
     except Exception as e:
         raise ValueError(
             f"Error retrieving agent instance from ConfigBuilder: {e}"
@@ -156,7 +210,9 @@ async def configure_app(app: FastAPI, engine_config):
                     f"🔧 MCP Server {s.name}: [{s.transport.upper()}] {s.url or s.command}"
                 )
         except Exception as e:
-            logger.exception(f"Failed to assign mcp servers to agent: {e}, continuing without them")
+            logger.exception(
+                f"Failed to assign mcp servers to agent: {e}, continuing without them"
+            )
             mcp_servers = []
 
     # SSO / OIDC setup
@@ -220,9 +276,7 @@ async def configure_app(app: FastAPI, engine_config):
         try:
             await cb(app)
         except Exception:
-            logger.exception(
-                "post_configure_callback %r raised; continuing", cb
-            )
+            logger.exception("post_configure_callback %r raised; continuing", cb)
 
 
 @asynccontextmanager

--- a/libs/idun_agent_engine/tests/integration/guardrails/test_guardrails_runtime.py
+++ b/libs/idun_agent_engine/tests/integration/guardrails/test_guardrails_runtime.py
@@ -83,7 +83,7 @@ async def test_ban_list_guardrail_blocks_banned_words(
     ).build()
     await ConfigBuilder.initialize_agent_from_config(engine_config)
 
-    guardrails = _parse_guardrails(engine_config.guardrails)
+    guardrails, _ = _parse_guardrails(engine_config.guardrails)
 
     banned_message = "This message contains a badword in it"
 
@@ -111,7 +111,7 @@ async def test_ban_list_guardrail_allows_clean_messages(
     ).build()
     agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
 
-    guardrails = _parse_guardrails(engine_config.guardrails)
+    guardrails, _ = _parse_guardrails(engine_config.guardrails)
 
     clean_message = "This is a perfectly clean message"
     message = {"query": clean_message, "session_id": "test123"}
@@ -134,7 +134,7 @@ async def test_pii_guardrail_blocks_email_addresses(
     engine_config = ConfigBuilder.from_dict(langgraph_config_with_pii_guardrail).build()
     await ConfigBuilder.initialize_agent_from_config(engine_config)
 
-    guardrails = _parse_guardrails(engine_config.guardrails)
+    guardrails, _ = _parse_guardrails(engine_config.guardrails)
 
     message_with_email = "Please contact me at user@example.com for more info"
 
@@ -159,7 +159,7 @@ async def test_pii_guardrail_allows_messages_without_pii(
     engine_config = ConfigBuilder.from_dict(langgraph_config_with_pii_guardrail).build()
     agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
 
-    guardrails = _parse_guardrails(engine_config.guardrails)
+    guardrails, _ = _parse_guardrails(engine_config.guardrails)
 
     clean_message = "This message has no personal information"
     message = {"query": clean_message, "session_id": "test123"}
@@ -213,7 +213,7 @@ async def test_multiple_guardrails_all_must_pass(skip_if_no_guardrails_api_key):
     engine_config = ConfigBuilder.from_dict(config).build()
     agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
 
-    guardrails = _parse_guardrails(engine_config.guardrails)
+    guardrails, _ = _parse_guardrails(engine_config.guardrails)
 
     # Banned word should be blocked
     with pytest.raises(HTTPException) as exc_info:

--- a/libs/idun_agent_engine/tests/unit/server/test_lifespan.py
+++ b/libs/idun_agent_engine/tests/unit/server/test_lifespan.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from idun_agent_engine.core.engine_config import EngineConfig
-from idun_agent_engine.server.lifespan import lifespan
+from idun_agent_engine.server.lifespan import (
+    FailedGuardrail,
+    _parse_guardrails,
+    lifespan,
+)
 
 
 @pytest.mark.unit
@@ -57,3 +61,66 @@ class TestLifespan:
             # coroutine is called but not awaited — exactly the bug class
             # the AsyncMock-vs-MagicMock split in this fixture guards against.
             mock_agent.close.assert_awaited_once()
+
+
+@pytest.mark.unit
+class TestParseGuardrailsFailures:
+    """``_parse_guardrails`` returns successes + per-guard failures.
+
+    Hub install errors (401 from the hub URL, missing transitive deps
+    like presidio-analyzer / spaCy models) used to be silently logged
+    and dropped — the engine continued booting / reloading and the
+    admin saw success while the guardrail was inactive. Now failures
+    are collected and surfaced to ``app.state.failed_guardrails`` so
+    the standalone reload pipeline can roll back on regression.
+    """
+
+    def test_returns_failures_when_guard_init_raises(self):
+        guardrails_obj = MagicMock()
+        guardrails_obj.input = [
+            MagicMock(config_id="BAN_LIST"),
+            MagicMock(config_id="DETECT_PII"),
+        ]
+        guardrails_obj.output = []
+
+        with patch(
+            "idun_agent_engine.guardrails.guardrails_hub.guardrails_hub.GuardrailsHubGuard"
+        ) as mock_guard_cls:
+            # First instance raises (simulates Hub 401 / dep-missing);
+            # second instance succeeds.
+            instance_ok = MagicMock()
+            mock_guard_cls.side_effect = [
+                RuntimeError("hub install failed: 401"),
+                instance_ok,
+            ]
+
+            guards, failures = _parse_guardrails(guardrails_obj)
+
+        assert guards == [instance_ok]
+        assert failures == [
+            FailedGuardrail(
+                config_id="BAN_LIST",
+                position="input",
+                error="hub install failed: 401",
+            )
+        ]
+
+    def test_returns_empty_failures_on_clean_init(self):
+        guardrails_obj = MagicMock()
+        guardrails_obj.input = [MagicMock(config_id="BAN_LIST")]
+        guardrails_obj.output = []
+
+        with patch(
+            "idun_agent_engine.guardrails.guardrails_hub.guardrails_hub.GuardrailsHubGuard"
+        ) as mock_guard_cls:
+            mock_guard_cls.return_value = MagicMock()
+
+            guards, failures = _parse_guardrails(guardrails_obj)
+
+        assert len(guards) == 1
+        assert failures == []
+
+    def test_returns_empty_for_empty_guardrails(self):
+        guards, failures = _parse_guardrails(None)
+        assert guards == []
+        assert failures == []

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/engine_reload.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/engine_reload.py
@@ -33,7 +33,24 @@ def build_engine_reload_callable(
     ``configure_app`` with the supplied config. Any failure is wrapped
     in ``ReloadInitFailed`` so the standalone reload pipeline can
     record the outcome and surface a 500 to the admin caller.
+
+    Post-configure, the callable inspects ``app.state.failed_guardrails``
+    (populated by the engine's ``_parse_guardrails``). If the new
+    config introduced any guardrail that failed to install — typically
+    a Hub install error like 401 from ``hub://guardrails/<id>`` or a
+    missing transitive dep (presidio-analyzer, spaCy model) — the
+    callable raises ``ReloadInitFailed``. Without this surface the
+    engine logs the failure and ``configure_app`` returns normally,
+    so the admin sees ``reload OK`` while the new guardrail is in fact
+    inactive and traffic flows through. With this surface the
+    standalone reload pipeline rolls back the DB and returns 500, so
+    the admin caller sees the actual install failure and the prior
+    guard set stays active.
     """
+    prior_failed_keys: set[tuple[str, str]] = {
+        (f.config_id, f.position)
+        for f in getattr(engine_app.state, "failed_guardrails", []) or []
+    }
 
     async def _reload(config: EngineConfig) -> None:
         try:
@@ -45,5 +62,25 @@ def build_engine_reload_callable(
         except Exception as exc:
             logger.exception("engine_reload.configure_failed")
             raise ReloadInitFailed(str(exc)) from exc
+
+        nonlocal prior_failed_keys
+        new_failed = list(getattr(engine_app.state, "failed_guardrails", []) or [])
+        # Anything failing now that wasn't failing before is a regression
+        # introduced by the new config — surface it as a reload failure.
+        # Pre-existing failures are not re-raised on every reload (they
+        # would otherwise wedge admin from making any unrelated change).
+        new_failed_keys = {(f.config_id, f.position) for f in new_failed}
+        regressed = new_failed_keys - prior_failed_keys
+        prior_failed_keys = new_failed_keys
+        if regressed:
+            details = ", ".join(
+                f"{f.config_id} ({f.position}): {f.error}"
+                for f in new_failed
+                if (f.config_id, f.position) in regressed
+            )
+            logger.warning("engine_reload.guardrail_install_regressed %s", details)
+            raise ReloadInitFailed(
+                f"Guardrail install failed for new entries: {details}"
+            )
 
     return _reload

--- a/libs/idun_agent_standalone/tests/unit/services/test_engine_reload.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_engine_reload.py
@@ -38,3 +38,98 @@ async def test_configure_error_wraps_in_reload_init_failed(monkeypatch):
 
     assert "configure boom" in str(exc_info.value)
     assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+async def test_new_guardrail_install_failure_raises_reload_init_failed(monkeypatch):
+    """A new failed guardrail in the assembled config rolls the reload back.
+
+    Mirrors the case the e2e ``test_reload_pipeline_adds_input_guardrail``
+    scenario hits: admin POSTs a new BAN_LIST guard, the engine logs an
+    install failure (401 / missing dep) but ``configure_app`` returns
+    normally. Without this surface, the reload pipeline records
+    ``status: APPLIED`` while the guardrail is silently inactive.
+    With it, the new failure is detected and the reload pipeline
+    rolls back the DB write.
+    """
+    from idun_agent_engine.server.lifespan import FailedGuardrail
+
+    app = FastAPI()
+    # Pre-existing failures should NOT trigger rollback — they were
+    # already failing before this reload, so re-raising on every reload
+    # would wedge admin out of every unrelated change.
+    app.state.failed_guardrails = [
+        FailedGuardrail(config_id="OLD_GUARD", position="input", error="prior")
+    ]
+
+    async def _configure(_app, _cfg):
+        # Simulate a NEW guardrail failure landing on this reload.
+        _app.state.failed_guardrails = [
+            FailedGuardrail(config_id="OLD_GUARD", position="input", error="prior"),
+            FailedGuardrail(config_id="BAN_LIST", position="input", error="hub 401"),
+        ]
+
+    monkeypatch.setattr(engine_reload_module, "cleanup_agent", AsyncMock())
+    monkeypatch.setattr(engine_reload_module, "configure_app", _configure)
+
+    reload_callable = build_engine_reload_callable(app)
+    with pytest.raises(ReloadInitFailed) as exc_info:
+        await reload_callable(object())  # type: ignore[arg-type]
+
+    assert "BAN_LIST" in str(exc_info.value)
+    assert "hub 401" in str(exc_info.value)
+    # Pre-existing OLD_GUARD failure must NOT be in the error message —
+    # only the regression that the admin's mutation introduced.
+    assert "OLD_GUARD" not in str(exc_info.value)
+
+
+async def test_pre_existing_guardrail_failures_do_not_raise(monkeypatch):
+    """Re-raising on every reload would make admin unable to fix anything.
+
+    If a guard was already failing before this reload, we keep the
+    failure visible (it's still in ``app.state.failed_guardrails``) but
+    don't raise. The admin can still mutate any other resource.
+    """
+    from idun_agent_engine.server.lifespan import FailedGuardrail
+
+    app = FastAPI()
+    app.state.failed_guardrails = [
+        FailedGuardrail(config_id="BAN_LIST", position="input", error="prior")
+    ]
+
+    async def _configure(_app, _cfg):
+        # Same failure persists across the reload — no NEW regression.
+        _app.state.failed_guardrails = [
+            FailedGuardrail(config_id="BAN_LIST", position="input", error="prior")
+        ]
+
+    monkeypatch.setattr(engine_reload_module, "cleanup_agent", AsyncMock())
+    monkeypatch.setattr(engine_reload_module, "configure_app", _configure)
+
+    reload_callable = build_engine_reload_callable(app)
+    # Should NOT raise.
+    await reload_callable(object())  # type: ignore[arg-type]
+
+
+async def test_cleared_guardrail_failure_does_not_raise(monkeypatch):
+    """When a previously failing guard now installs cleanly, no raise.
+
+    Edge case: prior reload had a failed guard; this reload's config
+    fixes it (e.g. operator added the missing api_key). The set of
+    new failures is empty — definitely no regression.
+    """
+    from idun_agent_engine.server.lifespan import FailedGuardrail
+
+    app = FastAPI()
+    app.state.failed_guardrails = [
+        FailedGuardrail(config_id="BAN_LIST", position="input", error="prior")
+    ]
+
+    async def _configure(_app, _cfg):
+        _app.state.failed_guardrails = []
+
+    monkeypatch.setattr(engine_reload_module, "cleanup_agent", AsyncMock())
+    monkeypatch.setattr(engine_reload_module, "configure_app", _configure)
+
+    reload_callable = build_engine_reload_callable(app)
+    # Should NOT raise — failures only went down.
+    await reload_callable(object())  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Closes T1 roadmap entry **\"Engine Hub-install error handling in reload pipeline\"**.

Before this PR, when a guardrail's Hub install path raised — observed: HTTP 401 from \`hub://guardrails/<id>\` because the Guardrails CLI doesn't read \`GUARDRAILS_API_KEY\` env (it expects \`~/.guardrailsrc\`), or a transitive dep like \`presidio-analyzer\` or a spaCy model is missing — \`_parse_guardrails\` caught the exception, logged \`Guardrail '<id>' init failed; skipping\`, and let \`configure_app\` return normally. The standalone reload pipeline then recorded \`reload.status == \"reloaded\"\` and traffic bypassed the guardrail with no visible signal to the admin caller.

This PR makes the engine fail loud:

1. **Engine** — \`_parse_guardrails\` now returns \`(guards, failures)\` instead of swallowing. Failures land on \`app.state.failed_guardrails\` (matches the existing \`failed_mcp_servers\` pattern). Boot-path behavior unchanged: failures still log and the remaining guards still initialize.
2. **Standalone** — \`engine_reload._reload\` snapshots the prior \`app.state.failed_guardrails\` set at build time and, after \`configure_app\` completes, raises \`ReloadInitFailed\` if any **new** guardrail in the assembled config failed to install. The reload pipeline rolls back the DB write (existing behavior on \`ReloadInitFailed\`) and surfaces a 500 to the admin. Pre-existing failures are not re-raised on every reload — that would wedge the admin out of any unrelated mutation.

## Tests

7 new unit tests covering:
- \`_parse_guardrails\` returns \`(guards, failures)\` with one failed and one healthy guard.
- \`_parse_guardrails\` returns empty failures on clean init.
- \`_parse_guardrails\` returns empty for empty guardrails.
- \`engine_reload._reload\` raises \`ReloadInitFailed\` when a NEW failed guardrail appears.
- \`engine_reload._reload\` does NOT raise when only pre-existing failures persist.
- \`engine_reload._reload\` does NOT raise when failures clear (deletion path).
- The error message names the regressed guard config_id and the install error, but NOT pre-existing failures.

Existing 5 callers of \`_parse_guardrails\` in \`tests/integration/guardrails/\` updated to unpack the tuple — no behavioral change to those tests.

## Out of scope (deferred)

- The two e2e tests still marked \`xfail(strict=False)\` (\`test_reload_pipeline.py\`, \`test_guardrail_block.py\`) remain \`xfail\` because the underlying CI environment doesn't install the Hub-install transitive deps (presidio-analyzer + a spaCy model). With this PR they now fail loudly on a 500 from the engine instead of silently passing through; the assertion path is different but the strict=False outcome is the same. Wiring those CI deps is a separate follow-up.
- Boot-path fail-fast (\"refuse to start with broken guards\") is **not** changed here. Boot-time behavior is preserved on purpose to keep deploys resilient when one guardrail is misconfigured but others are fine.

## Test plan

- [x] 374 standalone tests pass + 4 new engine lifespan tests pass + 5 patched runtime tests pass
- [x] \`uv run ruff check\` + \`uv run black\` clean on touched files
- [ ] CI: required real-LLM matrix + Test engine all green
- [ ] CodeRabbit review — likely flags one or two style nits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent tracking of guardrail initialization failures across configure/reload cycles

* **Bug Fixes**
  * Enhanced error tracking and reporting for guardrail initialization failures
  * Engine reload now detects and reports newly introduced guardrail regressions while ignoring pre-existing failures

* **Tests**
  * Added comprehensive tests covering guardrail failure handling and engine reload behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/595)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->