### PR TITLE
ci(e2e): pre-install Guardrails Hub validators + lift xfails/skip

### DIFF
--- a/.github/workflows/e2e-real-llm.yml
+++ b/.github/workflows/e2e-real-llm.yml
@@ -104,8 +104,8 @@ jobs:
             --token "$GUARDRAILS_API_KEY" \
             --disable-remote-inferencing \
             --disable-metrics
-          uv run guardrails install hub://guardrails/ban_list
-          uv run guardrails install hub://guardrails/detect_pii
+          uv run guardrails hub install hub://guardrails/ban_list
+          uv run guardrails hub install hub://guardrails/detect_pii
 
       - name: Run pytest e2e for matrix pair
         run: uv run pytest tests/e2e/ -v --pair=${{ matrix.pair }} --maxfail=3
@@ -153,7 +153,7 @@ jobs:
             --token "$GUARDRAILS_API_KEY" \
             --disable-remote-inferencing \
             --disable-metrics
-          uv run guardrails install hub://guardrails/ban_list
+          uv run guardrails hub install hub://guardrails/ban_list
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/e2e-real-llm.yml
+++ b/.github/workflows/e2e-real-llm.yml
@@ -88,6 +88,25 @@ jobs:
       - name: Install workspace dependencies
         run: uv sync --group dev
 
+      - name: Pre-install Guardrails Hub validators
+        # Bootstraps ~/.guardrailsrc (the CLI's auth file) and eagerly
+        # downloads BanList + DetectPII validators along with their
+        # transitive deps (presidio-analyzer + a spaCy model for
+        # DetectPII). Without this step, the engine's _install_model
+        # path runs at boot/reload, and DetectPII's post-install hook
+        # silently fails on the runner (no spaCy model preinstalled),
+        # leaving the guard inactive — the exact silent-passthrough
+        # behavior PR #595 made loud. Pre-installing here turns
+        # _install_model into a fast no-op and makes the matrix
+        # non-flaky for guardrail scenarios.
+        run: |
+          uv run guardrails configure \
+            --token "$GUARDRAILS_API_KEY" \
+            --disable-remote-inferencing \
+            --disable-metrics
+          uv run guardrails install hub://guardrails/ban_list
+          uv run guardrails install hub://guardrails/detect_pii
+
       - name: Run pytest e2e for matrix pair
         run: uv run pytest tests/e2e/ -v --pair=${{ matrix.pair }} --maxfail=3
 
@@ -122,6 +141,19 @@ jobs:
 
       - name: Install workspace dependencies
         run: uv sync --group dev
+
+      - name: Pre-install Guardrails Hub validators
+        # admin-edit-and-reload.spec.ts adds a BAN_LIST guardrail via
+        # admin REST and asserts the reload-then-block. Same rationale
+        # as the pytest-matrix step above: bootstrap ~/.guardrailsrc and
+        # cache validator deps so the standalone subprocess's reload
+        # pipeline doesn't hit a slow/flaky Hub install during the test.
+        run: |
+          uv run guardrails configure \
+            --token "$GUARDRAILS_API_KEY" \
+            --disable-remote-inferencing \
+            --disable-metrics
+          uv run guardrails install hub://guardrails/ban_list
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/services/idun_agent_standalone_ui/e2e/admin-edit-and-reload.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/admin-edit-and-reload.spec.ts
@@ -5,13 +5,14 @@ const SENTINEL = "qwertanu";
 // This spec exercises the admin REST → commit_with_reload → engine pickup
 // pipeline by adding a BAN_LIST guardrail. The engine's guardrail
 // converter requires GUARDRAILS_API_KEY to inject into the api_key field;
-// the new e2e-real-llm.yml workflow forwards it, but the existing
-// standalone-ci.yml Playwright job doesn't (and shouldn't — its boot
-// uses an inline echo agent without guardrails). Skip cleanly when the
-// key isn't present so this spec only fires from the real-LLM workflow.
+// the e2e-real-llm.yml Playwright job forwards it AND pre-installs the
+// BAN_LIST validator (caches the Hub install). Skip cleanly when the
+// key isn't present so this spec only fires from the real-LLM workflow
+// — the standalone-ci.yml Playwright job boots an echo agent without
+// guardrails and shouldn't run this spec.
 test.skip(
-  !process.env.GUARDRAILS_API_KEY || process.env.CI === "true",
-  "admin-edit-and-reload requires GUARDRAILS_API_KEY AND a stable Guardrails Hub install path; deferred in CI pending engine fail-fast on Hub install errors (idun-dev roadmap T1: 'Engine Hub-install error handling in reload pipeline').",
+  !process.env.GUARDRAILS_API_KEY,
+  "admin-edit-and-reload requires GUARDRAILS_API_KEY; runs from the e2e-real-llm.yml Playwright job which forwards it from repo secrets.",
 );
 
 test("admin guardrail addition triggers reload — chat with sentinel blocked", async ({

--- a/services/idun_agent_standalone_ui/e2e/admin-edit-and-reload.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/admin-edit-and-reload.spec.ts
@@ -4,15 +4,16 @@ const SENTINEL = "qwertanu";
 
 // This spec exercises the admin REST → commit_with_reload → engine pickup
 // pipeline by adding a BAN_LIST guardrail. The engine's guardrail
-// converter requires GUARDRAILS_API_KEY to inject into the api_key field;
-// the e2e-real-llm.yml Playwright job forwards it AND pre-installs the
-// BAN_LIST validator (caches the Hub install). Skip cleanly when the
-// key isn't present so this spec only fires from the real-LLM workflow
-// — the standalone-ci.yml Playwright job boots an echo agent without
-// guardrails and shouldn't run this spec.
+// converter requires GUARDRAILS_API_KEY AND a working Guardrails Hub
+// install path. The e2e-real-llm.yml Playwright job pre-installs
+// hub://guardrails/ban_list before the run; the standalone-ci.yml
+// E2E (Playwright) job does not (and shouldn't — its boot uses an
+// echo agent). Gate on LLM_PROVIDER (same gate chat-real-llm.spec.ts
+// uses) so the spec only fires from e2e-real-llm.yml, and additionally
+// require GUARDRAILS_API_KEY for the engine's converter.
 test.skip(
-  !process.env.GUARDRAILS_API_KEY,
-  "admin-edit-and-reload requires GUARDRAILS_API_KEY; runs from the e2e-real-llm.yml Playwright job which forwards it from repo secrets.",
+  !process.env.LLM_PROVIDER || !process.env.GUARDRAILS_API_KEY,
+  "admin-edit-and-reload requires LLM_PROVIDER + GUARDRAILS_API_KEY; runs from the e2e-real-llm.yml Playwright job which exports both AND pre-installs the BAN_LIST validator.",
 );
 
 test("admin guardrail addition triggers reload — chat with sentinel blocked", async ({

--- a/tests/e2e/scenarios/test_guardrail_block.py
+++ b/tests/e2e/scenarios/test_guardrail_block.py
@@ -54,21 +54,6 @@ def _post_run_status(base_url: str, message: str) -> int:
 
 
 @pytest.mark.pair("lg-openai")
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "DETECT_PII boot-time install via the Guardrails Hub is unstable in "
-        "CI: the engine's lifespan parses the YAML guardrail block but the "
-        "DetectPII validator's transitive deps (presidio-analyzer + a spaCy "
-        "model such as en_core_web_lg) are not bootstrapped in the CI runner, "
-        "so the guard fails to construct yet boot continues — PII-laden "
-        "requests then flow through with 200 instead of 429. Same upstream "
-        "issue as test_reload_pipeline.py. Tracked in idun-dev roadmap T1: "
-        "'Engine Hub-install error handling in reload pipeline'. Locally with "
-        "those deps installed the test passes — strict=False keeps that "
-        "signal without forcing a green CI."
-    ),
-)
 def test_guardrail_blocks_pii(pair, render_config, standalone_with_config) -> None:
     if not os.environ.get("GUARDRAILS_API_KEY"):
         pytest.skip(

--- a/tests/e2e/scenarios/test_reload_pipeline.py
+++ b/tests/e2e/scenarios/test_reload_pipeline.py
@@ -43,17 +43,6 @@ def _send_chat_status(base_url: str, message: str) -> int:
         return r.status_code
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Guardrails Hub `install()` of BAN_LIST is unstable in CI — "
-        "engine logs HttpError on `hub://guardrails/ban_list` (401 Unauthorized) "
-        "but still reports reload.status=reloaded, so the guard never "
-        "becomes active and post-reload chat returns 200 instead of "
-        "429. Tracked in idun-dev roadmap T1: 'Engine Hub-install error "
-        "handling in reload pipeline'."
-    ),
-)
 @pytest.mark.pair("lg-openai")
 def test_reload_pipeline_adds_input_guardrail(
     pair, render_config, standalone_with_config


### PR DESCRIPTION
## Summary

Closes the T1 follow-up surfaced during PR #595: pre-installs the Guardrails Hub validators in the e2e-real-llm CI workflow so the lifted xfail tests (and the lifted Playwright skip) actually exercise the install path live, instead of relying on stale assumptions.

The ground truth from PR #595's CI run:
- \`test_reload_pipeline_adds_input_guardrail\` was already **XPASSing** in CI — the original \"401 Unauthorized\" xfail reason was stale once PR #588 wired \`GUARDRAILS_API_KEY\` into the workflow env. BAN_LIST install just works.
- \`test_guardrail_blocks_pii\` still XFailed because \`DetectPII\` needs presidio-analyzer + a spaCy model that the runner doesn't have.

## Changes

### Workflow — \`.github/workflows/e2e-real-llm.yml\`

Two new pre-install steps, one per job:

1. **pytest-matrix** — bootstraps \`~/.guardrailsrc\` (the CLI auth file the engine's \`_install_model\` writes via \`guardrails configure\`) and pre-installs both \`hub://guardrails/ban_list\` and \`hub://guardrails/detect_pii\`. The \`detect_pii\` install runs the validator's post-install hook, which pulls presidio-analyzer + the spaCy model into the runner's site-packages. After this step the standalone subprocess's reload/boot \`_install_model\` becomes a fast no-op.
2. **playwright** — same bootstrap + just \`ban_list\` (admin-edit-and-reload only adds BAN_LIST).

### Tests

- \`tests/e2e/scenarios/test_reload_pipeline.py\` — drop the \`xfail(strict=False)\` marker (was XPASSing already).
- \`tests/e2e/scenarios/test_guardrail_block.py\` — drop the \`xfail(strict=False)\` marker (deps now cached by the workflow step).
- \`services/idun_agent_standalone_ui/e2e/admin-edit-and-reload.spec.ts\` — drop the \`process.env.CI === \"true\"\` half of the skip; the \`!process.env.GUARDRAILS_API_KEY\` guard alone is sufficient (still skips the regular \`E2E (Playwright)\` job in standalone-ci.yml since that one doesn't forward the secret).

## Test plan

- [x] YAML parses (\`yaml.safe_load\` clean)
- [x] Local: \`uv run pytest tests/e2e/scenarios/test_reload_pipeline.py tests/e2e/scenarios/test_guardrail_block.py --pair=lg-openai -v\` → **2 passed in 34.3s** (no xfail markers, no skip)
- [ ] CI: pytest-matrix lg-openai shows 2 PASSED instead of 1 XPASSED + 1 XFAILED
- [ ] CI: Playwright e2e (real LLM) shows admin-edit-and-reload spec PASSED
- [ ] CodeRabbit review

## Roadmap impact

Together with PR #595 (engine error surfacing), this closes the v1 e2e guarantee gap on guardrails. Both pytest scenarios + the Playwright spec now genuinely exercise admin-add → reload → engine pickup → block, with no xfail or skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * End-to-end tests now run when both LLM provider and Guardrails API key are present; several guardrail-blocking and pipeline-reload tests were re-enabled (removed expected-failure marks) to validate blocking behavior and UI visibility.
* **Chores**
  * CI workflows pre-configure Guardrails auth and pre-install relevant validators before running end-to-end suites.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/596)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->