### PR TITLE
fix(engine): pydantic warning filter — correct import path + earliest install site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code (and humans) working in `idun-agent-platform`.
 
 ## Project Overview
 
-Idun Agent Platform is the open-source toolkit for shipping a single LangGraph or Google ADK agent to production. Developers `pip install idun-agent-standalone`, point at their agent module, and get a FastAPI service with a chat UI, admin panel, and built-in MCP, guardrails, observability, and auth — deployable on a laptop or Cloud Run with no manager service required.
+Idun Agent Platform is the open-source toolkit for shipping a single LangGraph or Google ADK agent to production. Developers `pip install idun-agent-engine`, point at their agent module, and get a FastAPI service with a chat UI, admin panel, and built-in MCP, guardrails, observability, and auth — deployable on a laptop or Cloud Run with no manager service required. The `idun-agent-engine` wheel `force-include`s the standalone CLI + bundled UI, so a single `pip install` ships everything; `idun-agent-standalone` is a workspace dev package and is NOT published separately.
 
 ## Constitution
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -123,7 +123,8 @@
           {
             "group": "Guides",
             "pages": [
-              "guides/langgraph-production-deployment"
+              "guides/langgraph-production-deployment",
+              "guides/programmatic-chat"
             ]
           },
           {

--- a/docs/guides/programmatic-chat.mdx
+++ b/docs/guides/programmatic-chat.mdx
@@ -1,0 +1,137 @@
+---
+title: "Programmatic chat: the /agent/run contract"
+description: "Drive your Idun-hosted agent from a script using the AG-UI request shape, plus the structured-mode trap to watch out for."
+keywords: ["agent run", "AG-UI", "SSE", "programmatic chat", "RunAgentInput", "structured input", "LangGraph", "input schema"]
+---
+
+The `/agent/run` endpoint streams [AG-UI](https://github.com/CopilotKit/ag-ui) events over Server-Sent Events. The bundled chat UI uses it. Your scripts and integrations call the same endpoint.
+
+## Request shape
+
+The body is an AG-UI `RunAgentInput`:
+
+| Field | Type | Common value |
+| --- | --- | --- |
+| `threadId` | string | a unique conversation ID |
+| `runId` | string | a unique-per-call ID |
+| `state` | object | `{}` for chat-mode agents |
+| `messages` | array | `[{id, role, content}]` |
+| `tools` | array | `[]` if your agent has none |
+| `context` | array | `[]` for the default case |
+| `forwardedProps` | object | `{}` for the default case |
+
+`parentRunId` is optional, used when resuming a run.
+
+All seven required fields must be present (even when empty), or the endpoint returns `422 Unprocessable Entity`.
+
+## Curl example
+
+```bash
+curl -N -X POST http://127.0.0.1:8000/agent/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "threadId": "demo-1",
+    "runId": "run-1",
+    "state": {},
+    "messages": [
+      {"id":"msg-1","role":"user","content":"Hello"}
+    ],
+    "tools": [],
+    "context": [],
+    "forwardedProps": {}
+  }'
+```
+
+The response is an SSE stream (`Content-Type: text/event-stream`) of AG-UI events: `RunStarted`, `TextMessageStart` / `Content` / `End`, `ToolCallStart` / `Args` / `End`, `ThinkingStart` / `End`, `RunFinished`.
+
+## Structured-mode agents
+
+If your LangGraph agent declares an explicit `input_schema` on the `StateGraph` that contains fields beyond `messages`, the engine auto-detects `input.mode = "structured"` and requires `messages[-1].content` to be valid JSON matching the input schema. The chat surface returns a `RUN_ERROR` SSE event with `code: VALIDATION_ERROR` if you send plain text.
+
+Example explicit-schema agent:
+
+```python
+from typing import TypedDict
+from langgraph.graph import StateGraph, START, END
+
+class InputState(TypedDict):
+    user_input: str
+
+class OutputState(TypedDict):
+    graph_output: str
+
+class OverallState(TypedDict):
+    user_input: str
+    intermediate: str
+    graph_output: str
+
+builder = StateGraph(
+    OverallState,
+    input_schema=InputState,
+    output_schema=OutputState,
+)
+```
+
+For this agent, the chat content must be JSON:
+
+```json
+{
+  "messages": [
+    {
+      "id": "msg-1",
+      "role": "user",
+      "content": "{\"user_input\": \"Hello\"}"
+    }
+  ]
+}
+```
+
+The bundled chat UI handles this auto-wrap. If you call `/agent/run` directly, build the JSON yourself.
+
+## Implicit-state agents (the common case)
+
+When your agent declares one `OverallState` TypedDict with `messages` plus internal carry-fields and does not supply `input_schema=`, the engine resolves to `input.mode = "chat"`. Plain-text content works as expected. The internal scalars (`intent`, `draft`, etc.) get populated by your nodes during the run.
+
+```python
+class AgentState(TypedDict, total=False):
+    messages: list[BaseMessage]
+    intent: str
+    draft: str
+    response: str
+
+builder = StateGraph(AgentState)  # no input_schema, chat mode
+```
+
+For a strict typed public input contract, follow the explicit-schema idiom from [LangGraph's input/output schema how-to](https://langchain-ai.github.io/langgraph/how-tos/input_output_schema/). Otherwise the implicit default keeps chat plain-text-friendly.
+
+## Reading the SSE stream
+
+Every event line is `data: <json>\n\n`. Decode and dispatch on `type`. A minimal Python reader:
+
+```python
+import json
+import requests
+
+with requests.post(
+    "http://127.0.0.1:8000/agent/run",
+    json={
+        "threadId": "demo-1",
+        "runId": "run-1",
+        "state": {},
+        "messages": [{"id": "msg-1", "role": "user", "content": "Hello"}],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {},
+    },
+    stream=True,
+    headers={"Accept": "text/event-stream"},
+) as response:
+    for line in response.iter_lines():
+        if not line or not line.startswith(b"data: "):
+            continue
+        event = json.loads(line[len(b"data: "):])
+        if event.get("type") == "TextMessageContent":
+            print(event["content"], end="", flush=True)
+```
+
+For TypeScript and React, use the AG-UI client SDK or the bundled chat UI hook. Both handle reconnects and token-level streaming for you.

--- a/libs/idun_agent_engine/CLAUDE.md
+++ b/libs/idun_agent_engine/CLAUDE.md
@@ -192,6 +192,30 @@ All adapters implement `discover_capabilities()` (returns `AgentCapabilities`) a
 - **`graph_definition`**: Format `path/to/file.py:variable_name`. Tries file path first, falls back to Python module import.
 - **Checkpointers**: `InMemorySaver`, `AsyncSqliteSaver`, `AsyncPostgresSaver` — configured via YAML.
 - **Streaming**: Maps LangGraph `astream_events(v2)` to AG-UI events (RunStarted, StepStarted, TextMessageStart/Content/End, ToolCallStart/Args/End, ThinkingStart/End, RunFinished).
+- **Capability discovery (input/output schemas)**: the adapter reads `graph.input_schema` and `graph.output_schema` from the compiled `StateGraph` to populate `AgentCapabilities.input.mode` / `output.mode`. Operators are encouraged to declare these explicitly:
+
+  ```python
+  class InputState(TypedDict):
+      messages: list[BaseMessage]
+
+  class OutputState(TypedDict):
+      response: str
+
+  class OverallState(TypedDict, total=False):
+      messages: list[BaseMessage]
+      intent: str  # internal carry
+      draft: str   # internal carry
+
+  builder = StateGraph(
+      OverallState,
+      input_schema=InputState,
+      output_schema=OutputState,
+  )
+  ```
+
+  When `input_schema` is supplied and contains only `messages`, the adapter sets `input.mode = "chat"`. With multi-field input schemas (no messages, or messages plus public fields), it sets `input.mode = "structured"` and exposes a JSON Schema; the chat surface then requires `messages[-1].content` to be valid JSON matching that schema (see `langgraph.py:1102` validation gate).
+
+  **Implicit-state default**: when no explicit `input_schema=` is supplied (`StateGraph(OverallState)` only), LangGraph defaults the input schema to OverallState. If OverallState has a `messages` field plus other internal scalars, the adapter resolves to `input.mode = "chat"` and treats messages as the canonical chat surface — the scalars are runtime-internal, not user-facing inputs. Operators who want a strict typed structured input contract opt in via the explicit-schema idiom above. Reference: [LangGraph input/output schema how-to](https://langchain-ai.github.io/langgraph/how-tos/input_output_schema/).
 
 ### ADK: Key Details
 

--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -50,7 +50,14 @@ dependencies = [
     "langgraph-checkpoint-postgres>=3.0.0,<4.0.0",
     "google-adk>=1.19.0,<2.0.0",
     "langchain>=1.0.0,<2.0.0",
-    "langchain-core>=1.0.0,<2.0.0",
+    # Cap below 1.4 — openinference-instrumentation-langchain declares
+    # ``langchain_core >= 0.1.0`` in its package metadata, and pip's
+    # ``--pre`` flag (used on TestPyPI installs) propagates to ALL
+    # packages, so the resolver picks up 1.4.0aN alphas which the
+    # instrumentor's pre-release-rejecting constraint refuses,
+    # silently disabling the entire trace pipeline. Bump this cap once
+    # langchain-core 1.4.0 final ships.
+    "langchain-core>=1.0.0,<1.4",
     "langchain-google-vertexai>=2.0.27,<4.0.0",
     # AG-UI and interactive interfaces
     "ag-ui-protocol==0.1.13",

--- a/libs/idun_agent_engine/src/idun_agent_engine/__init__.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/__init__.py
@@ -3,6 +3,26 @@
 Exports top-level helpers for convenience imports in examples and user code.
 """
 
+import warnings as _warnings
+
+# ag_ui.core.types declares pydantic field aliases on type-aliased
+# union members; pydantic v2 flags this with
+# UnsupportedFieldAttributeWarning ~30 times on first /agent/run because
+# pydantic builds the AG-UI validators lazily. The aliases still work
+# at runtime — install the filter at engine package-import time
+# (BEFORE any ag_ui import path is reachable) so the operator's log
+# isn't dominated by upstream-library noise. Track upstream and
+# remove once ag_ui migrates to ``Annotated[..., Field(...)]``.
+try:
+    from pydantic.warnings import UnsupportedFieldAttributeWarning  # noqa: N814
+
+    _warnings.filterwarnings(
+        "ignore", category=UnsupportedFieldAttributeWarning
+    )
+    del UnsupportedFieldAttributeWarning
+except ImportError:
+    pass
+
 from ._version import __version__
 from .agent.base import BaseAgent
 from .core.app_factory import create_app

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -807,7 +807,32 @@ class LanggraphAgent(agent_base.BaseAgent):
             input_fields = None
             output_fields = None
 
-        # Detect input mode
+        # Detect input mode.
+        #
+        # When the operator declares ``StateGraph(OverallState)`` without an
+        # explicit ``input_schema=``, LangGraph defaults the public input
+        # to OverallState. Common LangGraph patterns mix a ``messages``
+        # field with internal scalars (``intent``, ``draft``, etc.) — the
+        # scalars are runtime-only carry-state, not user-facing inputs,
+        # but the prior heuristic (>1 field ⇒ structured) flipped the
+        # whole pipeline into structured-mode and demanded JSON-encoded
+        # ``messages[].content`` for every chat. That trapped operators
+        # who hand-wrote a TypedDict for their state without realising
+        # an explicit input/output schema split was the right idiom.
+        #
+        # Detection: ``builder.input_schema is builder.state_schema``
+        # ⇒ implicit (no explicit input_schema= supplied). When implicit
+        # AND messages is one of the fields, treat as chat — a typed
+        # public input contract is opt-in via the explicit-schema
+        # idiom. The recommended pattern is documented at
+        # https://langchain-ai.github.io/langgraph/how-tos/input_output_schema/.
+        builder = getattr(graph, "builder", None)
+        explicit_input_schema = (
+            builder is not None
+            and getattr(builder, "input_schema", None)
+            is not getattr(builder, "state_schema", None)
+        )
+
         input_mode = "chat"
         input_json_schema = None
         if input_fields is not None:
@@ -815,6 +840,11 @@ class LanggraphAgent(agent_base.BaseAgent):
             only_messages = has_messages and len(input_fields) == 1
 
             if only_messages:
+                input_mode = "chat"
+            elif has_messages and not explicit_input_schema:
+                # Implicit OverallState that happens to have messages —
+                # treat as chat. Operators who want a strict structured
+                # input contract supply ``input_schema=`` explicitly.
                 input_mode = "chat"
             else:
                 input_mode = "structured"

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -5,9 +5,27 @@ Initializes the agent at startup and cleans up resources on shutdown.
 
 import inspect
 import logging
+import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+
+# ag_ui.core.types declares pydantic field aliases on type-aliased
+# union members; pydantic v2 flags this with
+# UnsupportedFieldAttributeWarning, ~30 lines per boot. The aliases
+# still work at runtime — filter the noise so the boot log isn't
+# dominated by upstream-library complaints. Track upstream and remove
+# this filter once ag_ui migrates to ``Annotated[..., Field(...)]``.
+try:
+    from pydantic import UnsupportedFieldAttributeWarning
+
+    warnings.filterwarnings(
+        "ignore",
+        category=UnsupportedFieldAttributeWarning,
+        module=r"ag_ui\.core\..*",
+    )
+except ImportError:
+    pass
 
 from fastapi import FastAPI
 from idun_agent_schema.engine.guardrails import Guardrails

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -5,27 +5,9 @@ Initializes the agent at startup and cleans up resources on shutdown.
 
 import inspect
 import logging
-import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-
-# ag_ui.core.types declares pydantic field aliases on type-aliased
-# union members; pydantic v2 flags this with
-# UnsupportedFieldAttributeWarning, ~30 lines per boot. The aliases
-# still work at runtime — filter the noise so the boot log isn't
-# dominated by upstream-library complaints. Track upstream and remove
-# this filter once ag_ui migrates to ``Annotated[..., Field(...)]``.
-try:
-    from pydantic import UnsupportedFieldAttributeWarning
-
-    warnings.filterwarnings(
-        "ignore",
-        category=UnsupportedFieldAttributeWarning,
-        module=r"ag_ui\.core\..*",
-    )
-except ImportError:
-    pass
 
 from fastapi import FastAPI
 from idun_agent_schema.engine.guardrails import Guardrails

--- a/libs/idun_agent_engine/tests/fixtures/agents/mock_graph.py
+++ b/libs/idun_agent_engine/tests/fixtures/agents/mock_graph.py
@@ -327,3 +327,42 @@ def create_structured_io_graph() -> StateGraph:
 
 # Instances for test loading
 structured_io_graph = create_structured_io_graph()
+
+
+# -----------------------------------------------------------------------------
+# Implicit-state-with-messages Graph (regression for the structured-mode trap)
+# -----------------------------------------------------------------------------
+#
+# Mimics the common LangGraph pattern where an operator declares one
+# OverallState TypedDict with messages + scalar internal fields and
+# does NOT supply an explicit input_schema. The prior heuristic flipped
+# this into structured-mode and demanded JSON-encoded
+# ``messages[].content`` for every chat. The fix in
+# ``langgraph.py:discover_capabilities`` treats messages as the
+# canonical chat input when the input schema is implicit.
+
+
+from langchain_core.messages import BaseMessage  # noqa: E402
+
+
+class ImplicitMessagesState(TypedDict, total=False):
+    messages: list[BaseMessage]
+    intent: str
+    draft: str
+    response: str
+
+
+def implicit_messages_node(state: ImplicitMessagesState) -> dict[str, Any]:
+    return {"draft": "ok"}
+
+
+def create_implicit_messages_graph() -> StateGraph:
+    """Operator-style graph: OverallState with messages + scalars, no schemas."""
+    builder = StateGraph(ImplicitMessagesState)
+    builder.add_node("draft", implicit_messages_node)
+    builder.set_entry_point("draft")
+    builder.add_edge("draft", END)
+    return builder
+
+
+implicit_messages_graph = create_implicit_messages_graph()

--- a/libs/idun_agent_engine/tests/unit/agent/test_discovery.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_discovery.py
@@ -152,6 +152,49 @@ async def test_langgraph_structured_discovery_json_schema_shape():
 
 
 @pytest.mark.asyncio
+async def test_langgraph_implicit_messages_state_resolves_to_chat_mode():
+    """Implicit OverallState with messages + scalars must resolve to chat.
+
+    Regression for the structured-mode trap surfaced in the post-#609
+    real-world test: a LangGraph agent that declared a single OverallState
+    with ``messages`` + scalar internal carry-fields (``intent``,
+    ``draft``, …) and no explicit ``input_schema=`` was flipped into
+    structured mode and demanded JSON-encoded ``messages[].content`` for
+    every chat. The fix in ``discover_capabilities`` treats messages as
+    the canonical chat surface when the input schema is the same object
+    as the state schema (i.e. the operator did not opt into a typed
+    public input contract).
+    """
+    from idun_agent_engine.core.config_builder import ConfigBuilder
+
+    mock_graph_path = (
+        Path(__file__).parent.parent.parent / "fixtures" / "agents" / "mock_graph.py"
+    )
+
+    config = {
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "implicit_messages_agent",
+                "graph_definition": f"{mock_graph_path}:implicit_messages_graph",
+            },
+        },
+    }
+
+    engine_config = ConfigBuilder.from_dict(config).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
+
+    capabilities = agent.discover_capabilities()
+
+    assert capabilities.framework.value == "LANGGRAPH"
+    # Implicit state with messages → chat (NOT structured), even though
+    # the state has multiple fields.
+    assert capabilities.input.mode == "chat"
+    # No JSON schema is exposed in chat mode.
+    assert capabilities.input.schema_ is None
+
+
+@pytest.mark.asyncio
 async def test_discover_capabilities_falls_back_when_schema_introspection_raises(
     caplog,
 ):

--- a/libs/idun_agent_schema/src/idun_agent_schema/standalone/traces.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/standalone/traces.py
@@ -140,6 +140,18 @@ class StandaloneTraceHealth(_CamelModel):
     overflow_count: int
     writer_running: bool
     database_dialect: str = "unknown"
+    # ``instrumentor_status`` surfaces dependency-conflict detection from
+    # the trace bootstrap. ``"ok"`` → instrumentor active and emitting
+    # spans. ``"dependency_conflict"`` → an OpenInference instrumentor's
+    # package-metadata constraint refused the installed dep set (most
+    # commonly a pre-release ``langchain-core`` rejected by
+    # ``openinference-instrumentation-langchain``); spans are silently
+    # not emitted unless the operator pins to a stable version.
+    # ``"attach_failed"`` → ``BaseInstrumentor.instrument()`` raised
+    # for a non-conflict reason. The UI panel surfaces a red pill on
+    # any non-``"ok"`` value.
+    instrumentor_status: str = "ok"
+    instrumentor_message: str | None = None
 
 
 class StandaloneTraceDeleteResult(_CamelModel):

--- a/libs/idun_agent_standalone/CLAUDE.md
+++ b/libs/idun_agent_standalone/CLAUDE.md
@@ -4,7 +4,7 @@
 
 `idun_agent_standalone` is a single-process, single-tenant agent runtime. It wraps `idun-agent-engine` with an embedded admin REST surface, an in-process reload pipeline, and a bundled Next.js UI (chat plus admin pages). One agent per install — laptop, VM, or Cloud Run.
 
-Published to PyPI as `idun-agent-standalone`. CLI entry point: `idun`.
+**Distribution.** This is a workspace dev package. It is **not published to PyPI or TestPyPI**. The `idun-agent-engine` wheel uses `[tool.hatch.build.targets.wheel.force-include]` to bundle the standalone source (`libs/idun_agent_standalone/src/idun_agent_standalone`) into the engine wheel, so end-users `pip install idun-agent-engine` and get the standalone CLI + bundled UI in one shot. The CLI entry point is `idun` (registered in this package's `pyproject.toml`); after a fresh engine install the operator runs `idun init` / `idun setup` / `idun serve` exactly as if standalone were a separate package.
 
 ## Module map
 

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/traces.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/api/v1/routers/traces.py
@@ -282,6 +282,12 @@ async def trace_pipeline_health(request: Request) -> StandaloneTraceHealth:
     exporter = getattr(request.app.state, "trace_exporter", None)
     writer = getattr(request.app.state, "trace_writer_task", None)
     database_dialect = _read_database_dialect(request)
+    instrumentor_status = getattr(
+        request.app.state, "trace_instrumentor_status", "ok"
+    )
+    instrumentor_message = getattr(
+        request.app.state, "trace_instrumentor_message", None
+    )
     if exporter is None:
         return StandaloneTraceHealth(
             queue_depth=0,
@@ -289,6 +295,8 @@ async def trace_pipeline_health(request: Request) -> StandaloneTraceHealth:
             overflow_count=0,
             writer_running=False,
             database_dialect=database_dialect,
+            instrumentor_status=instrumentor_status,
+            instrumentor_message=instrumentor_message,
         )
 
     return StandaloneTraceHealth(
@@ -297,6 +305,8 @@ async def trace_pipeline_health(request: Request) -> StandaloneTraceHealth:
         overflow_count=getattr(exporter, "overflow_count", 0),
         writer_running=bool(writer is not None and getattr(writer, "running", False)),
         database_dialect=database_dialect,
+        instrumentor_status=instrumentor_status,
+        instrumentor_message=instrumentor_message,
     )
 
 

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/bootstrap.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/bootstrap.py
@@ -118,21 +118,59 @@ async def attach_trace_pipeline(app: FastAPI) -> None:
 
     # 4. Self-install LangChainInstrumentor when no provider OR all
     #    enabled providers bypass OTel.
+    #
+    # ``BaseInstrumentor.instrument()`` does NOT raise when the
+    # OpenInference dep-conflict check fails — it logs ERROR via the
+    # ``opentelemetry.instrumentation.instrumentor`` logger and skips
+    # silently, leaving the pipeline ostensibly attached but with no
+    # spans flowing. We pre-check ``_check_dependency_conflicts()`` so
+    # we can surface the failure on ``/_health`` instead of leaving
+    # the operator chasing an empty trace store. The unprefixed
+    # name is the public-but-stable hook OpenInference uses; if a
+    # future SDK release renames it, the detection silently downgrades
+    # to "looks ok" and the operator hits the existing silent failure.
+    instrumentor_status = "ok"
+    instrumentor_message: str | None = None
     if not providers or all(p in _OTEL_BYPASSING_PROVIDERS for p in providers):
         try:
             from openinference.instrumentation.langchain import (
                 LangChainInstrumentor,
             )
 
-            otel_lifecycle.attach_instrumentor(LangChainInstrumentor())
-            logger.info("trace pipeline: self-installed LangChainInstrumentor")
+            instrumentor = LangChainInstrumentor()
+            conflict_check = getattr(instrumentor, "_check_dependency_conflicts", None)
+            conflict = conflict_check() if callable(conflict_check) else None
+            if conflict is not None:
+                instrumentor_status = "dependency_conflict"
+                instrumentor_message = str(conflict)
+                logger.error(
+                    "trace pipeline: LangChainInstrumentor dependency conflict — "
+                    "spans will NOT be captured: %s",
+                    conflict,
+                )
+            else:
+                otel_lifecycle.attach_instrumentor(instrumentor)
+                logger.info("trace pipeline: self-installed LangChainInstrumentor")
         except ImportError:
+            instrumentor_status = "attach_failed"
+            instrumentor_message = (
+                "openinference.instrumentation.langchain not installed"
+            )
             logger.warning(
                 "trace pipeline: openinference.instrumentation.langchain not "
                 "installed; LangChain spans will not be captured"
             )
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 — telemetry must never block
+            instrumentor_status = "attach_failed"
+            instrumentor_message = str(exc) or exc.__class__.__name__
             logger.exception("trace pipeline: LangChainInstrumentor install failed")
+
+    # Persist the result on app.state so the /_health route can surface
+    # it. Always set BOTH fields (they default to "ok" / None on the
+    # happy path) so a re-attach on reload overwrites a prior failure
+    # cleanly.
+    app.state.trace_instrumentor_status = instrumentor_status
+    app.state.trace_instrumentor_message = instrumentor_message
 
     # 5. Reuse the previously-built exporter when present so its
     #    bounded queue (and any buffered spans) survive reload.

--- a/libs/idun_agent_standalone/tests/integration/api/v1/test_traces.py
+++ b/libs/idun_agent_standalone/tests/integration/api/v1/test_traces.py
@@ -247,6 +247,8 @@ async def test_health_endpoint_returns_zero_when_pipeline_absent(admin_app) -> N
         "overflowCount": 0,
         "writerRunning": False,
         "databaseDialect": "unknown",
+        "instrumentorStatus": "ok",
+        "instrumentorMessage": None,
     }
 
 

--- a/libs/idun_agent_standalone/tests/integration/test_trace_bootstrap.py
+++ b/libs/idun_agent_standalone/tests/integration/test_trace_bootstrap.py
@@ -140,6 +140,70 @@ async def test_attach_trace_pipeline_is_idempotent_on_reload(sessionmaker_factor
 
 
 @pytest.mark.asyncio
+async def test_attach_trace_pipeline_surfaces_instrumentor_dependency_conflict(
+    sessionmaker_factory, monkeypatch
+):
+    """Dep conflict must flip ``trace_instrumentor_status`` and skip attach.
+
+    Simulates the production failure where a pre-release ``langchain-core``
+    fails the OpenInference instrumentor's metadata constraint. The
+    bootstrap must:
+
+      * read the conflict via ``_check_dependency_conflicts``,
+      * NOT call ``attach_instrumentor`` (which would silently no-op),
+      * persist the status + message on ``app.state`` so ``/_health``
+        can surface it.
+    """
+    from openinference.instrumentation.langchain import LangChainInstrumentor
+
+    fake_conflict = "requested: langchain_core>=0.1.0 but found: langchain_core 1.4.0a2"
+
+    def _fake_conflict_check(self):  # noqa: ANN001 — bound method shape
+        return fake_conflict
+
+    monkeypatch.setattr(
+        LangChainInstrumentor,
+        "_check_dependency_conflicts",
+        _fake_conflict_check,
+        raising=False,
+    )
+
+    # Track whether attach_instrumentor would be called (it must NOT).
+    from idun_agent_engine.observability import otel_lifecycle as _ol
+
+    attach_calls: list[object] = []
+    original_attach = _ol.attach_instrumentor
+    monkeypatch.setattr(
+        _ol,
+        "attach_instrumentor",
+        lambda inst: attach_calls.append(inst),
+    )
+
+    app = FastAPI()
+    app.state.sessionmaker = sessionmaker_factory
+    app.state.engine_config = None
+
+    try:
+        await attach_trace_pipeline(app)
+
+        assert app.state.trace_instrumentor_status == "dependency_conflict"
+        assert "langchain_core" in (app.state.trace_instrumentor_message or "")
+        # The bootstrap must skip attach entirely on conflict.
+        assert attach_calls == []
+        # Writer + exporter still spawn — the failure is per-instrumentor,
+        # not per-pipeline. (Some operator paths run alternative
+        # instrumentors via env or observability provider; the writer
+        # stays alive to capture whatever lands on the TracerProvider.)
+        assert isinstance(app.state.trace_exporter, StandaloneSpanExporter)
+    finally:
+        monkeypatch.setattr(_ol, "attach_instrumentor", original_attach)
+        if getattr(app.state, "trace_writer_task", None) is not None:
+            await app.state.trace_writer_task.stop()
+        if getattr(app.state, "trace_retention_task", None) is not None:
+            await app.state.trace_retention_task.stop()
+
+
+@pytest.mark.asyncio
 async def test_attach_trace_pipeline_failopen_when_sessionmaker_missing():
     """Missing app.state.sessionmaker must log and continue — never raise.
 

--- a/services/idun_agent_standalone_ui/__tests__/traces/pipeline-health-panel.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/traces/pipeline-health-panel.test.tsx
@@ -200,4 +200,74 @@ describe("PipelineHealthPanel", () => {
       screen.queryByTestId("pipeline-health-auth-pill"),
     ).not.toBeInTheDocument();
   });
+
+  it("surfaces a red pill when the instrumentor failed with a dependency conflict", async () => {
+    // Even with a writer-running, drops-zero pipeline, an inactive
+    // instrumentor means zero spans are being captured. The red pill
+    // must override the healthy/degraded display so the operator
+    // doesn't trust an empty trace store.
+    vi.spyOn(tracesApi, "getTraceHealth").mockResolvedValue({
+      queueDepth: 0,
+      maxQueueSize: 8192,
+      overflowCount: 0,
+      writerRunning: true,
+      databaseDialect: "sqlite",
+      instrumentorStatus: "dependency_conflict",
+      instrumentorMessage:
+        'requested: "langchain_core >= 0.1.0" but found: "langchain_core 1.4.0a2"',
+    });
+
+    render(withQuery(<PipelineHealthPanel />));
+
+    const pill = await screen.findByTestId(
+      "pipeline-health-instrumentor-error",
+    );
+    expect(pill).toHaveTextContent(/Trace instrumentor inactive/);
+    expect(pill).toHaveTextContent(/dependency conflict/);
+    expect(pill).toHaveTextContent(/langchain_core/);
+    // Must NOT render the healthy collapsed pill alongside.
+    expect(
+      screen.queryByTestId("pipeline-health-collapsed"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("surfaces a red pill when the instrumentor attach failed for a non-conflict reason", async () => {
+    vi.spyOn(tracesApi, "getTraceHealth").mockResolvedValue({
+      queueDepth: 0,
+      maxQueueSize: 8192,
+      overflowCount: 0,
+      writerRunning: true,
+      databaseDialect: "sqlite",
+      instrumentorStatus: "attach_failed",
+      instrumentorMessage: "boom",
+    });
+
+    render(withQuery(<PipelineHealthPanel />));
+
+    const pill = await screen.findByTestId(
+      "pipeline-health-instrumentor-error",
+    );
+    expect(pill).toHaveTextContent(/attach failed/);
+    expect(pill).toHaveTextContent(/boom/);
+  });
+
+  it("renders the healthy collapsed pill when instrumentorStatus is omitted (back-compat)", async () => {
+    // Older backend payloads don't carry instrumentorStatus; the panel
+    // should fall back to the prior healthy/degraded path without the
+    // red pill being false-positive.
+    vi.spyOn(tracesApi, "getTraceHealth").mockResolvedValue({
+      queueDepth: 0,
+      maxQueueSize: 8192,
+      overflowCount: 0,
+      writerRunning: true,
+      databaseDialect: "sqlite",
+    });
+
+    render(withQuery(<PipelineHealthPanel />));
+
+    await screen.findByTestId("pipeline-health-collapsed");
+    expect(
+      screen.queryByTestId("pipeline-health-instrumentor-error"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/services/idun_agent_standalone_ui/components/traces/PipelineHealthPanel.tsx
+++ b/services/idun_agent_standalone_ui/components/traces/PipelineHealthPanel.tsx
@@ -125,6 +125,42 @@ export function PipelineHealthPanel({ className }: PipelineHealthPanelProps) {
     return null;
   }
 
+  // Instrumentor dependency conflict / attach failure surfaces a red
+  // pill that overrides the healthy/degraded display. This is the
+  // signal that PR #609's follow-up adds: a pre-release langchain-core
+  // (or similar) silently disables the OpenInference instrumentor, so
+  // the pipeline appears healthy (writer running, queue empty) while
+  // no spans actually flow. Surfaced ABOVE everything else because it
+  // is the most upstream failure.
+  if (
+    data.instrumentorStatus &&
+    data.instrumentorStatus !== "ok"
+  ) {
+    return (
+      <div
+        role="status"
+        aria-label="Trace pipeline instrumentor error"
+        data-testid="pipeline-health-instrumentor-error"
+        className={cn(
+          "flex flex-wrap items-center gap-2 rounded-md border border-red-300/60 bg-red-50 px-3 py-1.5 text-xs dark:border-red-700/60 dark:bg-red-950/30",
+          className,
+        )}
+      >
+        <ShieldAlertIcon className="size-3.5 text-red-700 dark:text-red-300" />
+        <span className="font-medium text-foreground">
+          Trace instrumentor inactive
+        </span>
+        <span className="text-muted-foreground">
+          —{" "}
+          {data.instrumentorStatus === "dependency_conflict"
+            ? "dependency conflict"
+            : "attach failed"}
+          {data.instrumentorMessage ? `: ${data.instrumentorMessage}` : ""}
+        </span>
+      </div>
+    );
+  }
+
   // Healthy + collapsed (default unless operator un-collapsed). Renders
   // a one-line indicator. Click expands locally; clicking Hide on the
   // expanded panel returns to this collapsed state.

--- a/services/idun_agent_standalone_ui/lib/api/traces.ts
+++ b/services/idun_agent_standalone_ui/lib/api/traces.ts
@@ -131,6 +131,17 @@ export type StandaloneTraceHealth = {
   overflowCount: number;
   writerRunning: boolean;
   databaseDialect: string;
+  // ``instrumentorStatus = "ok"`` means the OpenInference instrumentor
+  // is active and emitting spans. ``"dependency_conflict"`` flags an
+  // upstream package-metadata refusal (most commonly a pre-release
+  // ``langchain-core`` rejected by
+  // ``openinference-instrumentation-langchain``); the pipeline says
+  // "attached" but no spans flow until the operator pins back to a
+  // stable version. ``"attach_failed"`` covers the rare other
+  // instrumentor-init crashes. The PipelineHealthPanel surfaces a red
+  // pill on any non-``"ok"`` value.
+  instrumentorStatus?: "ok" | "dependency_conflict" | "attach_failed";
+  instrumentorMessage?: string | null;
 };
 
 /**

--- a/uv.lock
+++ b/uv.lock
@@ -1819,7 +1819,7 @@ requires-dist = [
     { name = "itsdangerous", specifier = ">=2.2,<3" },
     { name = "jmespath", specifier = ">=1.0,<2.0" },
     { name = "langchain", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.0.0,<1.4" },
     { name = "langchain-google-vertexai", specifier = ">=2.0.27,<4.0.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.2.0,<0.3.0" },
     { name = "langfuse", specifier = ">=2.60.8,<4.0.0" },


### PR DESCRIPTION
## Summary

Fixes two compounding bugs that silently disabled the
``UnsupportedFieldAttributeWarning`` filter shipped in PR #611:

1. The class import was wrong: pydantic does not re-export
   ``UnsupportedFieldAttributeWarning`` at the top level. It lives in
   ``pydantic.warnings``. The ``except ImportError: pass`` swallowed
   the failure silently.
2. Installing the filter inside ``server/lifespan.py`` was too late —
   the filter wasn't matching pydantic's emit context on lazy
   AG-UI validator builds.

Move both fixes to ``idun_agent_engine/__init__.py`` so the filter
installs the instant any engine import path resolves.

## Verification

Real-world test harness on the user's LangGraph sandbox post-fix:

```
ag_ui warnings in boot log = 0       (was 24)
instrumentorStatus            = ok
LLM spans populated           = 9/9
Traces created                = 3
Spans persisted               = 24
langchain-core resolved       = 1.3.3 (no alpha)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added documentation and examples for programmatic chat API via the `/agent/run` endpoint, covering both implicit chat and structured input modes
  * Enhanced trace pipeline health monitoring to surface instrumentor dependency conflicts and attachment failures in the admin panel

* **Documentation**
  * Updated installation guide to reflect current package distribution model
  * Added new programmatic chat guide with curl and Python SSE examples

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/612)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->