### PR TITLE
fix(standalone): secure-by-default host + bind-all guardrail

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -49,10 +49,18 @@ RUN uv build --out-dir /dist
 # ---- Runtime ----
 FROM python:3.12-slim AS runtime
 
-# REQUIRED at deploy: set IDUN_ADMIN_AUTH_MODE=password (plus IDUN_SESSION_SECRET)
-# or IDUN_ALLOW_OPEN_ADMIN=1. With IDUN_HOST=0.0.0.0 below, startup will fail
-# fast without one of these — the bind-all + no-auth combination is rejected
-# by the standalone settings validator.
+# REQUIRED at deploy with IDUN_HOST=0.0.0.0 below — startup will fail fast
+# without one of these. The bind-all + no-auth combination is rejected by
+# the standalone settings validator.
+#
+# Password mode (recommended for production):
+#   IDUN_ADMIN_AUTH_MODE=password
+#   IDUN_ADMIN_PASSWORD_HASH=<bcrypt>      (use: idun hash-password)
+#   IDUN_SESSION_SECRET=<>=32 chars>       (use: openssl rand -hex 32)
+#   IDUN_SESSION_TTL_HOURS=24              (optional; 1-720, default 24)
+#
+# Trusted-network opt-out (no auth, bind-all):
+#   IDUN_ALLOW_OPEN_ADMIN=1
 ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     IDUN_IN_CONTAINER=1 \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -49,6 +49,7 @@ RUN uv build --out-dir /dist
 # ---- Runtime ----
 FROM python:3.12-slim AS runtime
 
+# Set IDUN_ADMIN_AUTH_MODE=password or IDUN_ALLOW_OPEN_ADMIN=1 at deploy time.
 ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     IDUN_IN_CONTAINER=1 \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -49,7 +49,10 @@ RUN uv build --out-dir /dist
 # ---- Runtime ----
 FROM python:3.12-slim AS runtime
 
-# Set IDUN_ADMIN_AUTH_MODE=password or IDUN_ALLOW_OPEN_ADMIN=1 at deploy time.
+# REQUIRED at deploy: set IDUN_ADMIN_AUTH_MODE=password (plus IDUN_SESSION_SECRET)
+# or IDUN_ALLOW_OPEN_ADMIN=1. With IDUN_HOST=0.0.0.0 below, startup will fail
+# fast without one of these — the bind-all + no-auth combination is rejected
+# by the standalone settings validator.
 ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     IDUN_IN_CONTAINER=1 \

--- a/docker/Dockerfile.example
+++ b/docker/Dockerfile.example
@@ -38,11 +38,16 @@ USER idun:idun
 
 EXPOSE 8000
 
-# Override defaults via env vars at deploy time:
-#   IDUN_ADMIN_AUTH_MODE=password            (required with IDUN_HOST=0.0.0.0,
-#                                             or set IDUN_ALLOW_OPEN_ADMIN=1)
+# REQUIRED at deploy time (with IDUN_HOST=0.0.0.0 set above, startup will fail
+# fast without one of these — the bind-all + no-auth combination is rejected
+# by the standalone settings validator):
+#   IDUN_ADMIN_AUTH_MODE=password            (secure option for production)
+#   IDUN_ALLOW_OPEN_ADMIN=1                  (or opt in to open admin on
+#                                             trusted networks only)
+# Required when using password mode:
 #   IDUN_ADMIN_PASSWORD_HASH=<hash>          (use: idun hash-password)
-#   IDUN_SESSION_SECRET=<32-byte-hex>         (use: openssl rand -hex 32)
+#   IDUN_SESSION_SECRET=<32-byte-hex>        (use: openssl rand -hex 32)
+# Optional overrides:
 #   DATABASE_URL=postgresql+asyncpg://<DB_USER>:<DB_PASSWORD>@<HOST>:5432/idun
 #   OPENAI_API_KEY=<your-key>                 (whatever your agent needs)
 

--- a/docker/Dockerfile.example
+++ b/docker/Dockerfile.example
@@ -39,11 +39,11 @@ USER idun:idun
 EXPOSE 8000
 
 # Override defaults via env vars at deploy time:
-#   IDUN_ADMIN_AUTH_MODE=password
+#   IDUN_ADMIN_AUTH_MODE=password            (required with IDUN_HOST=0.0.0.0,
+#                                             or set IDUN_ALLOW_OPEN_ADMIN=1)
 #   IDUN_ADMIN_PASSWORD_HASH=<hash>          (use: idun hash-password)
 #   IDUN_SESSION_SECRET=<32-byte-hex>         (use: openssl rand -hex 32)
 #   DATABASE_URL=postgresql+asyncpg://<DB_USER>:<DB_PASSWORD>@<HOST>:5432/idun
 #   OPENAI_API_KEY=<your-key>                 (whatever your agent needs)
 
-# `idun serve` reads host/port from IDUN_HOST/IDUN_PORT env (defaults: 0.0.0.0:8000).
 CMD ["idun", "serve"]

--- a/docs/standalone/cli.mdx
+++ b/docs/standalone/cli.mdx
@@ -84,8 +84,10 @@ Every flag has an env-var equivalent. Additional variables not exposed as flags:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `IDUN_ADMIN_PASSWORD_HASH` | — | Required when `auth_mode = password`. |
-| `IDUN_SESSION_SECRET` | — | 32-byte hex secret signing session cookies. Required when `auth_mode = password`. |
-| `IDUN_SESSION_TTL_SECONDS` | `86400` | Sliding-renewal cookie lifetime. |
-| `IDUN_TRACES_RETENTION_DAYS` | `30` | Hourly purge keeps the last N days of trace events. |
-| `IDUN_IN_CONTAINER` | unset | Set to `1` in container images to flip auth defaults to `password`. |
+| `IDUN_ADMIN_PASSWORD_HASH` | — | Bcrypt admin password hash. Consulted only on first boot to seed the admin row. Required when `auth_mode = password`. Generate with `idun hash-password`. |
+| `IDUN_SESSION_SECRET` | — | At least 32 characters. Signs the `idun_session` cookie. Required when `auth_mode = password`; startup fails fast when shorter. |
+| `IDUN_SESSION_TTL_HOURS` | `24` | Session cookie lifetime in hours (range `1..720`). |
+| `IDUN_ALLOW_OPEN_ADMIN` | `false` | Opt-in flag that lets `auth_mode=none` bind `0.0.0.0` / `::`. Containers and trusted networks only. |
+| `IDUN_TRACE_RETENTION_DAYS` | `14` | Days of trace events the daily retention task keeps before dropping. |
+| `IDUN_TRACES_INPUT_VALUE_MAX_BYTES` | `65536` | Per-attribute byte cap before the exporter truncates trace input/output values. |
+| `IDUN_PRICES_REFRESH` | `false` | When `true`, fetch the LiteLLM model-prices snapshot at boot (5 s timeout, snapshot fallback). |

--- a/docs/standalone/cli.mdx
+++ b/docs/standalone/cli.mdx
@@ -19,11 +19,12 @@ Flags (all optional — env vars take precedence when unset on the CLI):
 | Flag | Env var | Default | Description |
 |------|---------|---------|-------------|
 | `--config <path>` | `IDUN_CONFIG_PATH` | `./config.yaml` | Bootstrap YAML file. |
-| `--host <addr>` | `IDUN_HOST` | `127.0.0.1` (laptop), `0.0.0.0` (container) | Bind address. |
+| `--host <addr>` | `IDUN_HOST` | `127.0.0.1` | Bind address. Set `0.0.0.0` for containers (requires `IDUN_ADMIN_AUTH_MODE=password` or `IDUN_ALLOW_OPEN_ADMIN=1`). |
 | `--port <int>` | `IDUN_PORT` | `8000` | Bind port. |
-| `--auth-mode <mode>` | `IDUN_ADMIN_AUTH_MODE` | `none` (laptop), `password` (container) | Admin gate. `oidc` is reserved for MVP-2. |
+| `--auth-mode <mode>` | `IDUN_ADMIN_AUTH_MODE` | `none` | Admin gate. `oidc` is reserved for MVP-2. |
 | `--ui-dir <path>` | `IDUN_UI_DIR` | bundled static export | Override the chat/admin UI directory. |
 | `--database-url <url>` | `DATABASE_URL` | `sqlite+aiosqlite:///./idun.db` | SQLAlchemy URL. Use `postgresql+asyncpg://…` for Postgres. |
+| (no flag) | `IDUN_ALLOW_OPEN_ADMIN` | `false` | Opt in to binding `0.0.0.0` with `auth_mode=none`. Containers and trusted networks only. |
 
 ## init
 

--- a/libs/idun_agent_standalone/CLAUDE.md
+++ b/libs/idun_agent_standalone/CLAUDE.md
@@ -63,6 +63,8 @@ Two modes, gated by `IDUN_ADMIN_AUTH_MODE`:
 - `none` — open admin (laptop default). `require_auth` is a pass-through.
 - `password` — bcrypt-hashed admin password + signed session cookie. Strict-minimum scope: login / logout / change-password / me, no rate-limit, no CSRF token, no sliding renewal, no rotation invalidation of outstanding sessions.
 
+**Bind-all guardrail.** `core/settings.py` refuses to start when `IDUN_HOST` is `0.0.0.0` or `::` and `IDUN_ADMIN_AUTH_MODE=none`, unless `IDUN_ALLOW_OPEN_ADMIN=1`. Default host is `127.0.0.1`. Containers that need bind-all must either set `IDUN_ADMIN_AUTH_MODE=password` or opt in via `IDUN_ALLOW_OPEN_ADMIN=1`. **Why:** the prior default (`0.0.0.0` + `none`) exposed the admin REST surface on every network the host could reach with no authentication.
+
 <!-- VERIFY: env vars in libs/idun_agent_standalone/src/idun_agent_standalone/core/settings.py -->
 Required env vars in password mode:
 

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/core/settings.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/core/settings.py
@@ -10,6 +10,7 @@ from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _MIN_SESSION_SECRET_LEN = 32
+_BIND_ALL_HOSTS = frozenset({"0.0.0.0", "::"})
 
 
 class AuthMode(StrEnum):
@@ -32,7 +33,7 @@ class StandaloneSettings(BaseSettings):
     )
 
     config_path: Path = Field(default=Path("./config.yaml"), alias="IDUN_CONFIG_PATH")
-    host: str = Field(default="0.0.0.0", alias="IDUN_HOST")
+    host: str = Field(default="127.0.0.1", alias="IDUN_HOST")
     port: int = Field(default=8000, alias="IDUN_PORT")
     database_url: str = Field(
         default="sqlite+aiosqlite:///./idun_standalone.db",
@@ -66,6 +67,10 @@ class StandaloneSettings(BaseSettings):
         default=False,
         alias="IDUN_PRICES_REFRESH",
     )
+    allow_open_admin: bool = Field(
+        default=False,
+        alias="IDUN_ALLOW_OPEN_ADMIN",
+    )
 
     @field_validator("admin_password_hash", "session_secret", mode="before")
     @classmethod
@@ -92,5 +97,20 @@ class StandaloneSettings(BaseSettings):
                 "IDUN_ADMIN_AUTH_MODE=password requires "
                 f"IDUN_SESSION_SECRET to be at least {_MIN_SESSION_SECRET_LEN} "
                 "characters."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_open_admin_combo(self) -> Self:
+        """Refuse bind-all + no auth unless explicitly opted in."""
+        if (
+            self.host in _BIND_ALL_HOSTS
+            and self.auth_mode == AuthMode.NONE
+            and not self.allow_open_admin
+        ):
+            raise SettingsValidationError(
+                f"Refusing to bind IDUN_HOST={self.host} with "
+                "IDUN_ADMIN_AUTH_MODE=none. Set "
+                "IDUN_ADMIN_AUTH_MODE=password or IDUN_ALLOW_OPEN_ADMIN=1."
             )
         return self

--- a/libs/idun_agent_standalone/tests/unit/test_cli_init.py
+++ b/libs/idun_agent_standalone/tests/unit/test_cli_init.py
@@ -191,6 +191,7 @@ def test_init_browser_url_maps_wildcard_host_to_localhost(
     must use 127.0.0.1 — browsers can't navigate to wildcard bind
     addresses. The server still binds wherever IDUN_HOST says."""
     monkeypatch.setenv("IDUN_HOST", "0.0.0.0")
+    monkeypatch.setenv("IDUN_ALLOW_OPEN_ADMIN", "1")
     runner = CliRunner()
     result = runner.invoke(main, ["init"])
     assert result.exit_code == 0, result.output

--- a/libs/idun_agent_standalone/tests/unit/test_settings.py
+++ b/libs/idun_agent_standalone/tests/unit/test_settings.py
@@ -58,3 +58,37 @@ def test_secret_validators_strip_trailing_newlines(monkeypatch):
     settings = StandaloneSettings()
     assert settings.session_secret == "x" * 64
     assert settings.admin_password_hash == "hash-value"
+
+
+def test_default_host_is_loopback(monkeypatch):
+    monkeypatch.delenv("IDUN_HOST", raising=False)
+    settings = StandaloneSettings()
+    assert settings.host == "127.0.0.1"
+
+
+@pytest.mark.parametrize("bind_all", ["0.0.0.0", "::"])
+def test_bind_all_with_auth_none_is_rejected(monkeypatch, bind_all: str):
+    monkeypatch.setenv("IDUN_HOST", bind_all)
+    monkeypatch.setenv("IDUN_ADMIN_AUTH_MODE", "none")
+    monkeypatch.delenv("IDUN_ALLOW_OPEN_ADMIN", raising=False)
+    with pytest.raises(ValidationError) as exc_info:
+        StandaloneSettings()
+    assert "IDUN_ALLOW_OPEN_ADMIN" in str(exc_info.value)
+
+
+def test_bind_all_with_auth_none_allowed_when_opted_in(monkeypatch):
+    monkeypatch.setenv("IDUN_HOST", "0.0.0.0")
+    monkeypatch.setenv("IDUN_ADMIN_AUTH_MODE", "none")
+    monkeypatch.setenv("IDUN_ALLOW_OPEN_ADMIN", "1")
+    settings = StandaloneSettings()
+    assert settings.host == "0.0.0.0"
+    assert settings.allow_open_admin is True
+
+
+def test_bind_all_with_password_auth_is_allowed(monkeypatch):
+    monkeypatch.setenv("IDUN_HOST", "0.0.0.0")
+    monkeypatch.setenv("IDUN_ADMIN_AUTH_MODE", "password")
+    monkeypatch.setenv("IDUN_SESSION_SECRET", "x" * 32)
+    settings = StandaloneSettings()
+    assert settings.host == "0.0.0.0"
+    assert settings.auth_mode == AuthMode.PASSWORD


### PR DESCRIPTION
## Summary

Closes BACKLOG SEC-001 from `tasks/pre-release-review-and-journey-audit-11-05-2026`.

- Default `IDUN_HOST` flips from `0.0.0.0` to `127.0.0.1`. The prior default exposed the admin REST surface on every network the host could reach with no authentication (because `IDUN_ADMIN_AUTH_MODE` also defaults to `none`).
- New startup guardrail in `core/settings.py`: refuse to boot when `IDUN_HOST` is `0.0.0.0` or `::` and `IDUN_ADMIN_AUTH_MODE=none`, unless the operator opts in with `IDUN_ALLOW_OPEN_ADMIN=1`.
- Docs (`docs/standalone/cli.mdx`, `libs/idun_agent_standalone/CLAUDE.md`) and Dockerfile comments updated.

## Breaking change

Container deploys that previously relied on `IDUN_HOST=0.0.0.0` with no auth (the prior default in `Dockerfile.base`) will fail to start. Operators must set **one** of:

- `IDUN_ADMIN_AUTH_MODE=password` (recommended) + `IDUN_SESSION_SECRET` + `IDUN_ADMIN_PASSWORD_HASH`
- `IDUN_ALLOW_OPEN_ADMIN=1` (opt in to open admin on trusted networks only)

## Test plan

- [x] `uv run pytest libs/idun_agent_standalone/tests` — 485 passed, 9 skipped (Postgres-only).
- [x] `uv run ruff check libs/idun_agent_standalone` — clean.
- [x] Unit tests cover: default loopback host, bind-all + none rejected (`0.0.0.0` and `::`), bind-all opt-in allowed, bind-all + password auth allowed.
- [ ] Reviewer: verify `docker/Dockerfile.base` consumers in any deploy pipelines are aware of the breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting to allow binding to all interfaces for admin access.

* **Bug Fixes**
  * Default host changed to localhost for safer defaults.
  * Startup now blocks insecure bind-all + no-auth configurations unless opt-in is enabled.

* **Documentation**
  * Clarified CLI host/auth defaults and updated Docker deployment guidance.

* **Tests**
  * Added and updated tests covering host defaults and bind-all validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/614)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->