### PR TITLE
chore(ui): pre-release polish — wizard helper / secret masking / auth-mode signals / login dead-end (UI-014, UI-016, UI-011, UI-015)

### DIFF
--- a/services/idun_agent_standalone_ui/__tests__/admin/SecretInput.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/admin/SecretInput.test.tsx
@@ -45,4 +45,43 @@ describe("SecretInput", () => {
     expect(input).toHaveAttribute("autocomplete", "off");
     expect(input).toHaveAttribute("spellcheck", "false");
   });
+
+  it("links the toggle to the input via aria-controls (F7)", () => {
+    render(<SecretInput aria-label="secret" id="my-secret" />);
+    const input = screen.getByLabelText("secret");
+    const toggle = screen.getByRole("button", { name: /show secret/i });
+    expect(input).toHaveAttribute("id", "my-secret");
+    expect(toggle).toHaveAttribute("aria-controls", "my-secret");
+  });
+
+  it("auto-derives an id when none is provided so aria-controls still points somewhere", () => {
+    render(<SecretInput aria-label="secret" />);
+    const input = screen.getByLabelText("secret");
+    const toggle = screen.getByRole("button", { name: /show secret/i });
+    const inputId = input.getAttribute("id");
+    expect(inputId).toBeTruthy();
+    expect(toggle).toHaveAttribute("aria-controls", inputId!);
+  });
+
+  describe("when the input is disabled (F2)", () => {
+    it("disables the toggle button so the secret cannot be revealed", () => {
+      render(<SecretInput aria-label="secret" defaultValue="hunter2" disabled />);
+      const input = screen.getByLabelText("secret");
+      const toggle = screen.getByRole("button", { name: /show secret/i });
+      expect(input).toBeDisabled();
+      expect(toggle).toBeDisabled();
+      expect(toggle).toHaveAttribute("aria-disabled", "true");
+      expect(toggle).toHaveAttribute("tabindex", "-1");
+    });
+
+    it("does not flip type=password even if the toggle is somehow clicked", () => {
+      render(<SecretInput aria-label="secret" defaultValue="hunter2" disabled />);
+      const input = screen.getByLabelText("secret");
+      const toggle = screen.getByRole("button", { name: /show secret/i });
+      // Defensive: even if a stylesheet override let the user click, the
+      // onClick handler must guard.
+      fireEvent.click(toggle);
+      expect(input).toHaveAttribute("type", "password");
+    });
+  });
 });

--- a/services/idun_agent_standalone_ui/__tests__/admin/SecretInput.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/admin/SecretInput.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { SecretInput } from "@/components/admin/SecretInput";
+
+describe("SecretInput", () => {
+  it("renders as type=password by default", () => {
+    render(<SecretInput aria-label="secret" defaultValue="hunter2" />);
+    const input = screen.getByLabelText("secret");
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("clicking the toggle flips to type=text and back", () => {
+    render(<SecretInput aria-label="secret" defaultValue="hunter2" />);
+    const input = screen.getByLabelText("secret");
+    const toggle = screen.getByRole("button", { name: /show secret/i });
+
+    expect(input).toHaveAttribute("type", "password");
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(toggle);
+
+    expect(input).toHaveAttribute("type", "text");
+    const hide = screen.getByRole("button", { name: /hide secret/i });
+    expect(hide).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(hide);
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("preserves typed value across the reveal toggle", () => {
+    render(<SecretInput aria-label="secret" />);
+    const input = screen.getByLabelText("secret") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "abc123" } });
+    expect(input.value).toBe("abc123");
+
+    fireEvent.click(screen.getByRole("button", { name: /show secret/i }));
+    expect(input.value).toBe("abc123");
+    expect(input).toHaveAttribute("type", "text");
+  });
+
+  it("forwards autoComplete='off' and spellCheck=false by default", () => {
+    render(<SecretInput aria-label="secret" />);
+    const input = screen.getByLabelText("secret");
+    expect(input).toHaveAttribute("autocomplete", "off");
+    expect(input).toHaveAttribute("spellcheck", "false");
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/helpers/runtime-config-fixture.ts
+++ b/services/idun_agent_standalone_ui/__tests__/helpers/runtime-config-fixture.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared RuntimeConfig builder for unit + e2e tests.
+ *
+ * Use this in tests that need to inject `window.__IDUN_CONFIG__` instead of
+ * partial-stub objects. Spreads `DEFAULT_RUNTIME_CONFIG` so callers only
+ * override what they care about and the resulting object is structurally
+ * complete — consumers reading e.g. `cfg.theme.colors.light.background`
+ * will not blow up.
+ */
+
+import {
+  DEFAULT_RUNTIME_CONFIG,
+  type RuntimeConfig,
+} from "@/lib/runtime-config";
+
+export function makeRuntimeConfig(
+  overrides: Partial<RuntimeConfig> = {},
+): RuntimeConfig {
+  return {
+    ...DEFAULT_RUNTIME_CONFIG,
+    ...overrides,
+    theme: {
+      ...DEFAULT_RUNTIME_CONFIG.theme,
+      ...(overrides.theme ?? {}),
+    },
+  };
+}

--- a/services/idun_agent_standalone_ui/__tests__/login.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/login.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/lib/api", async () => {
 
 import { api, ApiError } from "@/lib/api";
 import { toast } from "sonner";
+import { makeRuntimeConfig } from "./helpers/runtime-config-fixture";
 
 describe("LoginPage", () => {
   beforeEach(() => {
@@ -37,15 +38,12 @@ describe("LoginPage", () => {
     // Pretend the runtime config injected by the FastAPI backend says
     // password auth is enabled. The dead-end-redirect behavior covered
     // by its own test below explicitly overrides this to "none".
-    (window as Window).__IDUN_CONFIG__ = {
-      ...((window as Window).__IDUN_CONFIG__ ?? {}),
-      authMode: "password",
-    } as Window["__IDUN_CONFIG__"];
+    window.__IDUN_CONFIG__ = makeRuntimeConfig({ authMode: "password" });
   });
 
   afterEach(() => {
     vi.clearAllMocks();
-    delete (window as Window).__IDUN_CONFIG__;
+    delete window.__IDUN_CONFIG__;
   });
 
   it("on success without ?next, redirects to /", async () => {
@@ -108,12 +106,25 @@ describe("LoginPage", () => {
     await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
   });
 
+  describe("when runtime config is missing entirely", () => {
+    // Fail-closed default: if window.__IDUN_CONFIG__ is undefined (network
+    // blip, CDN failure, dev mode without backend), the form should still
+    // render — never silently redirect operators away from their only
+    // sign-in surface.
+    beforeEach(() => {
+      delete window.__IDUN_CONFIG__;
+    });
+
+    it("renders the sign-in form (no auto-redirect)", () => {
+      render(<LoginPage />);
+      expect(screen.getByLabelText(/admin password/i)).toBeInTheDocument();
+      expect(replace).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when admin auth is disabled (UI-011)", () => {
     beforeEach(() => {
-      (window as Window).__IDUN_CONFIG__ = {
-        ...((window as Window).__IDUN_CONFIG__ ?? {}),
-        authMode: "none",
-      } as Window["__IDUN_CONFIG__"];
+      window.__IDUN_CONFIG__ = makeRuntimeConfig({ authMode: "none" });
     });
 
     it("does not render the sign-in form", () => {
@@ -142,6 +153,22 @@ describe("LoginPage", () => {
     it("falls back to / for unsafe ?next= values", async () => {
       useSearchParamsMock.mockReturnValue(
         new URLSearchParams("next=https://evil.com"),
+      );
+      render(<LoginPage />);
+      await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+    });
+
+    it("rejects ?next=/login to avoid an infinite redirect loop (CR-1)", async () => {
+      useSearchParamsMock.mockReturnValue(
+        new URLSearchParams("next=/login"),
+      );
+      render(<LoginPage />);
+      await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+    });
+
+    it("rejects ?next=/login/ (trailing slash) to avoid loops", async () => {
+      useSearchParamsMock.mockReturnValue(
+        new URLSearchParams("next=/login/"),
       );
       render(<LoginPage />);
       await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));

--- a/services/idun_agent_standalone_ui/__tests__/login.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/login.test.tsx
@@ -34,10 +34,18 @@ describe("LoginPage", () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams(""));
     (api.login as ReturnType<typeof vi.fn>).mockReset();
     (toast.error as ReturnType<typeof vi.fn>).mockReset();
+    // Pretend the runtime config injected by the FastAPI backend says
+    // password auth is enabled. The dead-end-redirect behavior covered
+    // by its own test below explicitly overrides this to "none".
+    (window as Window).__IDUN_CONFIG__ = {
+      ...((window as Window).__IDUN_CONFIG__ ?? {}),
+      authMode: "password",
+    } as Window["__IDUN_CONFIG__"];
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    delete (window as Window).__IDUN_CONFIG__;
   });
 
   it("on success without ?next, redirects to /", async () => {
@@ -98,5 +106,45 @@ describe("LoginPage", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
     await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+  });
+
+  describe("when admin auth is disabled (UI-011)", () => {
+    beforeEach(() => {
+      (window as Window).__IDUN_CONFIG__ = {
+        ...((window as Window).__IDUN_CONFIG__ ?? {}),
+        authMode: "none",
+      } as Window["__IDUN_CONFIG__"];
+    });
+
+    it("does not render the sign-in form", () => {
+      render(<LoginPage />);
+      expect(
+        screen.queryByLabelText(/admin password/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /sign in/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("redirects to / on mount", async () => {
+      render(<LoginPage />);
+      await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+    });
+
+    it("honors ?next=/admin/ when the form would have redirected there", async () => {
+      useSearchParamsMock.mockReturnValue(
+        new URLSearchParams("next=/admin/"),
+      );
+      render(<LoginPage />);
+      await waitFor(() => expect(replace).toHaveBeenCalledWith("/admin/"));
+    });
+
+    it("falls back to / for unsafe ?next= values", async () => {
+      useSearchParamsMock.mockReturnValue(
+        new URLSearchParams("next=https://evil.com"),
+      );
+      render(<LoginPage />);
+      await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+    });
   });
 });

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardEmpty.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardEmpty.test.tsx
@@ -16,6 +16,21 @@ describe("WizardEmpty", () => {
     expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
   });
 
+  it("shows helper text under the disabled Continue button (UI-014)", () => {
+    render(<WizardEmpty onContinue={vi.fn()} onRescan={vi.fn()} />);
+    expect(
+      screen.getByText(/select a framework to continue/i),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the helper text once a framework is selected (UI-014)", () => {
+    render(<WizardEmpty onContinue={vi.fn()} onRescan={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText(/langgraph/i));
+    expect(
+      screen.queryByText(/select a framework to continue/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("calls onContinue with the selected framework", () => {
     const onContinue = vi.fn();
     render(<WizardEmpty onContinue={onContinue} onRescan={vi.fn()} />);

--- a/services/idun_agent_standalone_ui/__tests__/onboarding/WizardManyDetected.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/onboarding/WizardManyDetected.test.tsx
@@ -70,6 +70,23 @@ describe("WizardManyDetected", () => {
     ).toBeDisabled();
   });
 
+  it("shows helper text under the disabled button until a row is picked (UI-014)", () => {
+    render(
+      <WizardManyDetected
+        detections={detections}
+        onConfirm={vi.fn()}
+        onRescan={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/select an agent to continue/i),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/B Agent/));
+    expect(
+      screen.queryByText(/select an agent to continue/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("calls onConfirm with the picked detection", () => {
     const onConfirm = vi.fn();
     render(

--- a/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 import { ProviderPicker } from "@/components/admin/ProviderPicker";
+import { SecretInput } from "@/components/admin/SecretInput";
 import {
   DiscordIcon,
   GoogleChatIcon,
@@ -479,11 +480,9 @@ function SecretField({
         <FormItem>
           <FormLabel>{label}</FormLabel>
           <FormControl>
-            <Input
+            <SecretInput
               {...field}
               value={typeof field.value === "string" ? field.value : ""}
-              type="password"
-              autoComplete="off"
               placeholder={placeholder}
             />
           </FormControl>

--- a/services/idun_agent_standalone_ui/app/admin/observability/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/observability/page.tsx
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 import { EditYamlSheet } from "@/components/admin/EditYamlSheet";
 import { ProviderPicker } from "@/components/admin/ProviderPicker";
+import { SecretInput } from "@/components/admin/SecretInput";
 import { cn } from "@/lib/utils";
 import {
   GcpLoggingIcon,
@@ -482,10 +483,8 @@ export default function ObservabilityPage() {
                       <FormItem>
                         <FormLabel>Secret key</FormLabel>
                         <FormControl>
-                          <Input
+                          <SecretInput
                             {...field}
-                            type="password"
-                            autoComplete="off"
                             placeholder="sk-lf-..."
                           />
                         </FormControl>
@@ -558,10 +557,8 @@ export default function ObservabilityPage() {
                       <FormItem>
                         <FormLabel>API key</FormLabel>
                         <FormControl>
-                          <Input
+                          <SecretInput
                             {...field}
-                            type="password"
-                            autoComplete="off"
                             placeholder="ls-..."
                           />
                         </FormControl>

--- a/services/idun_agent_standalone_ui/app/admin/settings/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/settings/page.tsx
@@ -273,9 +273,24 @@ function ProfileTab({ authMode }: { authMode: string }) {
             <div className="text-xs uppercase tracking-wider text-muted-foreground">
               Auth mode
             </div>
-            <Badge variant={authMode === "none" ? "secondary" : "default"}>
+            <Badge
+              variant={authMode === "none" ? "destructive" : "default"}
+            >
               {authMode}
             </Badge>
+            {authMode === "none" && (
+              <p className="text-xs text-destructive">
+                Production deployments must use{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px] text-foreground">
+                  password
+                </code>{" "}
+                mode. Set{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px] text-foreground">
+                  IDUN_ADMIN_AUTH_MODE=password
+                </code>{" "}
+                and restart.
+              </p>
+            )}
           </div>
         </div>
 

--- a/services/idun_agent_standalone_ui/app/login/page.tsx
+++ b/services/idun_agent_standalone_ui/app/login/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
+import { getRuntimeConfig } from "@/lib/runtime-config";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -20,6 +21,20 @@ function LoginForm() {
   const params = useSearchParams();
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
+
+  // When admin auth is disabled the password form does nothing on submit.
+  // Redirect to the chat root so the user isn't stuck on a non-functional
+  // page. Honor ?next=<path> if it's same-origin, otherwise go to "/".
+  const authMode =
+    typeof window !== "undefined" ? getRuntimeConfig().authMode : "password";
+  const authDisabled = authMode === "none";
+  useEffect(() => {
+    if (!authDisabled) return;
+    const raw = params?.get("next") ?? "/";
+    const next = isSafeNext(raw) ? raw : "/";
+    router.replace(next);
+  }, [authDisabled, params, router]);
+  if (authDisabled) return null;
 
   return (
     <div className="grid place-items-center min-h-screen bg-background p-6">

--- a/services/idun_agent_standalone_ui/app/login/page.tsx
+++ b/services/idun_agent_standalone_ui/app/login/page.tsx
@@ -4,7 +4,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
-import { getRuntimeConfig } from "@/lib/runtime-config";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -16,23 +15,35 @@ function isSafeNext(next: string): boolean {
   return next.startsWith("/") && !next.startsWith("//");
 }
 
+// Pick the post-login destination. Same-origin paths are honored, except
+// /login itself — redirecting to /login would loop. Falls back to "/".
+function pickPostLoginPath(raw: string): string {
+  const candidate = isSafeNext(raw) ? raw : "/";
+  if (candidate === "/login" || candidate.startsWith("/login/")) return "/";
+  return candidate;
+}
+
 function LoginForm() {
   const router = useRouter();
   const params = useSearchParams();
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
 
-  // When admin auth is disabled the password form does nothing on submit.
-  // Redirect to the chat root so the user isn't stuck on a non-functional
-  // page. Honor ?next=<path> if it's same-origin, otherwise go to "/".
-  const authMode =
-    typeof window !== "undefined" ? getRuntimeConfig().authMode : "password";
-  const authDisabled = authMode === "none";
+  // When admin auth is disabled the password form does nothing on submit,
+  // so redirect to the chat root. Read window.__IDUN_CONFIG__.authMode
+  // directly (not via getRuntimeConfig, which defaults to "none" when the
+  // runtime-config.js hasn't loaded yet — that fallback would lock
+  // operators out if the bootstrap script ever fails). Treat undefined as
+  // "config not loaded yet, show the form" rather than auto-redirecting.
+  const configuredAuthMode =
+    typeof window !== "undefined"
+      ? window.__IDUN_CONFIG__?.authMode
+      : undefined;
+  const authDisabled = configuredAuthMode === "none";
   useEffect(() => {
     if (!authDisabled) return;
     const raw = params?.get("next") ?? "/";
-    const next = isSafeNext(raw) ? raw : "/";
-    router.replace(next);
+    router.replace(pickPostLoginPath(raw));
   }, [authDisabled, params, router]);
   if (authDisabled) return null;
 
@@ -53,8 +64,7 @@ function LoginForm() {
             try {
               await api.login(password);
               const raw = params?.get("next") ?? "/";
-              const next = isSafeNext(raw) ? raw : "/";
-              router.replace(next);
+              router.replace(pickPostLoginPath(raw));
             } catch (err) {
               const status = err instanceof ApiError ? err.status : 0;
               toast.error(

--- a/services/idun_agent_standalone_ui/components/admin/SecretInput.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/SecretInput.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { Eye, EyeOff } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export type SecretInputProps = Omit<
+  React.ComponentProps<"input">,
+  "type"
+>;
+
+export const SecretInput = React.forwardRef<HTMLInputElement, SecretInputProps>(
+  function SecretInput({ className, autoComplete, spellCheck, ...props }, ref) {
+    const [revealed, setRevealed] = React.useState(false);
+    const Icon = revealed ? EyeOff : Eye;
+    const label = revealed ? "Hide secret" : "Show secret";
+
+    return (
+      <div className="relative">
+        <Input
+          {...props}
+          ref={ref}
+          type={revealed ? "text" : "password"}
+          autoComplete={autoComplete ?? "off"}
+          spellCheck={spellCheck ?? false}
+          className={cn("pr-9", className)}
+        />
+        <button
+          type="button"
+          aria-label={label}
+          aria-pressed={revealed}
+          onClick={() => setRevealed((v) => !v)}
+          className="absolute right-1 top-1/2 -translate-y-1/2 inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        >
+          <Icon className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    );
+  },
+);

--- a/services/idun_agent_standalone_ui/components/admin/SecretInput.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/SecretInput.tsx
@@ -7,32 +7,52 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 export type SecretInputProps = Omit<
-  React.ComponentProps<"input">,
+  React.ComponentProps<typeof Input>,
   "type"
 >;
 
 export const SecretInput = React.forwardRef<HTMLInputElement, SecretInputProps>(
-  function SecretInput({ className, autoComplete, spellCheck, ...props }, ref) {
+  function SecretInput(
+    { className, autoComplete, spellCheck, id, disabled, ...props },
+    ref,
+  ) {
     const [revealed, setRevealed] = React.useState(false);
     const Icon = revealed ? EyeOff : Eye;
     const label = revealed ? "Hide secret" : "Show secret";
+    // Stable id so the toggle button can target the input via aria-controls.
+    // Honor an explicit id from the caller, otherwise derive one.
+    const generatedId = React.useId();
+    const inputId = id ?? generatedId;
+
+    // Don't let the user reveal a disabled input — a disabled field can
+    // still leak its value if the toggle stays interactive.
+    const toggleInteractive = !disabled;
 
     return (
       <div className="relative">
         <Input
           {...props}
           ref={ref}
+          id={inputId}
           type={revealed ? "text" : "password"}
           autoComplete={autoComplete ?? "off"}
           spellCheck={spellCheck ?? false}
+          disabled={disabled}
           className={cn("pr-9", className)}
         />
         <button
           type="button"
           aria-label={label}
           aria-pressed={revealed}
-          onClick={() => setRevealed((v) => !v)}
-          className="absolute right-1 top-1/2 -translate-y-1/2 inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          aria-controls={inputId}
+          aria-disabled={disabled || undefined}
+          disabled={!toggleInteractive}
+          tabIndex={toggleInteractive ? 0 : -1}
+          onClick={() => {
+            if (!toggleInteractive) return;
+            setRevealed((v) => !v);
+          }}
+          className="absolute right-1 top-1/2 -translate-y-1/2 inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
         >
           <Icon className="h-3.5 w-3.5" />
         </button>

--- a/services/idun_agent_standalone_ui/components/onboarding/FrameworkPicker.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/FrameworkPicker.tsx
@@ -52,12 +52,19 @@ export function FrameworkPicker({ onContinue, onRescan }: FrameworkPickerProps) 
         >
           Re-scan
         </button>
-        <Button
-          onClick={() => selected && onContinue(selected)}
-          disabled={!selected}
-        >
-          Continue
-        </Button>
+        <div className="flex flex-col items-end gap-1">
+          <Button
+            onClick={() => selected && onContinue(selected)}
+            disabled={!selected}
+          >
+            Continue
+          </Button>
+          {!selected && (
+            <p className="text-xs text-muted-foreground">
+              Select a framework to continue
+            </p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/services/idun_agent_standalone_ui/components/onboarding/FrameworkPicker.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/FrameworkPicker.tsx
@@ -56,11 +56,12 @@ export function FrameworkPicker({ onContinue, onRescan }: FrameworkPickerProps) 
           <Button
             onClick={() => selected && onContinue(selected)}
             disabled={!selected}
+            aria-describedby={!selected ? "fw-continue-help" : undefined}
           >
             Continue
           </Button>
           {!selected && (
-            <p className="text-xs text-muted-foreground">
+            <p id="fw-continue-help" className="text-xs text-muted-foreground">
               Select a framework to continue
             </p>
           )}

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx
@@ -86,17 +86,24 @@ export function WizardManyDetected({
           >
             Re-scan
           </button>
-          <Button
-            onClick={() => {
-              const detection = byKey.get(selectedKey);
-              if (detection) {
-                onConfirm(detection);
-              }
-            }}
-            disabled={selectedKey === ""}
-          >
-            Use selected agent
-          </Button>
+          <div className="flex flex-col items-end gap-1">
+            <Button
+              onClick={() => {
+                const detection = byKey.get(selectedKey);
+                if (detection) {
+                  onConfirm(detection);
+                }
+              }}
+              disabled={selectedKey === ""}
+            >
+              Use selected agent
+            </Button>
+            {selectedKey === "" && (
+              <p className="text-xs text-muted-foreground">
+                Select an agent to continue
+              </p>
+            )}
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx
+++ b/services/idun_agent_standalone_ui/components/onboarding/WizardManyDetected.tsx
@@ -95,11 +95,17 @@ export function WizardManyDetected({
                 }
               }}
               disabled={selectedKey === ""}
+              aria-describedby={
+                selectedKey === "" ? "many-continue-help" : undefined
+              }
             >
               Use selected agent
             </Button>
             {selectedKey === "" && (
-              <p className="text-xs text-muted-foreground">
+              <p
+                id="many-continue-help"
+                className="text-xs text-muted-foreground"
+              >
                 Select an agent to continue
               </p>
             )}

--- a/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
+++ b/services/idun_agent_standalone_ui/e2e/onboarding.spec.ts
@@ -356,6 +356,36 @@ test("Re-scan: EMPTY → user clicks Re-scan → backend returns ONE_DETECTED �
 test("Login redirect (password mode): /onboarding 401 → /login → submit → back to /onboarding", async ({
   page,
 }) => {
+  // The standalone server boots with auth_mode=none in this e2e suite, but
+  // this test exercises the password-mode flow (the 401 → /login → submit
+  // chain only matters when auth is enforced). With UI-011 the /login page
+  // now redirects to / when runtime authMode === "none", which removes the
+  // form the test needs to fill. Override the runtime config to mark this
+  // page as password-mode so the form renders.
+  await page.route("**/runtime-config.js", async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/javascript",
+      body: `window.__IDUN_CONFIG__ = ${JSON.stringify({
+        theme: {
+          appName: "Idun Agent",
+          greeting: "How can I help?",
+          starterPrompts: [],
+          logo: { text: "IA" },
+          layout: "branded",
+          radius: "0.625",
+          fontSans: "",
+          fontSerif: "",
+          fontMono: "",
+          defaultColorScheme: "system",
+          colors: { light: {}, dark: {} },
+        },
+        authMode: "password",
+        layout: "branded",
+      })};\n`,
+      headers: { "Cache-Control": "no-store" },
+    });
+  });
   let scanAttempts = 0;
   await page.route("**/admin/api/v1/agent", async (route: Route) => {
     await route.fulfill({


### PR DESCRIPTION
## Summary

Four extra-small UI polish items from the May 2026 pre-release audit, bundled in a single PR.

Source: [`idun-dev/tasks/pre-release-review-and-journey-audit-11-05-2026/BACKLOG.md`](https://github.com/Idun-Group/idun-dev/blob/main/tasks/pre-release-review-and-journey-audit-11-05-2026/BACKLOG.md)
Plan: [`idun-dev/tasks/ui-pre-release-polish-11-05-2026/`](https://github.com/Idun-Group/idun-dev/tree/main/tasks/ui-pre-release-polish-11-05-2026)

| ID | What | Files |
| --- | --- | --- |
| **UI-014** | Helper text under disabled wizard Continue button | `components/onboarding/FrameworkPicker.tsx`, `WizardManyDetected.tsx` |
| **UI-016** | Shared `SecretInput` with reveal eye-toggle, swapped in at observability + integrations secret fields | new `components/admin/SecretInput.tsx` + 3 swap sites |
| **UI-011** | Redirect `/login` to `/` when `auth_mode=none` | `app/login/page.tsx` |
| **UI-015** | Destructive `AUTH MODE` badge + explanatory copy when `auth_mode=none` | `app/admin/settings/page.tsx` |

## Non-trivial decisions

- **UI-014**: chose helper text under the button over auto-selecting LangGraph. Smaller diff; auto-select would change first-paint behavior and surprise users who came in via `/onboarding/` deliberately.
- **UI-016**: the audit screenshot suggested unmasked inputs, but the codebase already had `type=\"password\"` everywhere it mattered. Shipped the eye-toggle as the genuine polish — operators sometimes need to verify a typed secret before saving. The toggle is omitted on the `/login` password field (sign-in screen, shoulder-surfing risk).
- **UI-011**: chose redirect over banner-on-form. The form does nothing in `none` mode; a banner-on-form leaves a non-functional form visible. Redirect honors `?next=<safe-path>` (reuses the existing `isSafeNext` open-redirect guard).
- **UI-015**: no dedicated vitest unit test. `ProfileTab` is internal to a file with an existing `@ts-nocheck` directive (deferred state per `services/idun_agent_standalone_ui/CLAUDE.md`). Refactoring to export it is out of scope. The change is mechanical (badge variant + conditional `<p>`); visual evidence in the audit folder.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — all new tests pass; 6 pre-existing failures in `__tests__/api/*` are **unrelated to this PR** (verified by stashing this branch on `b13b2086` and re-running — same failures)
- [x] `npx eslint <changed files>` — no new errors; 6 errors in touched files are pre-existing (most notably `autoFocus` on `app/login/page.tsx` Input shifted line numbers from 63 → 78 because of my 16 added lines; same code)
- [ ] CI: standalone UI suite + e2e LG+OpenAI required-check pair
- [ ] Manual smoke (suggested for reviewer): with `IDUN_ADMIN_AUTH_MODE=none`, confirm `/login` redirects to `/` and `/admin/settings` shows the red `AUTH MODE: none` badge with the warning paragraph. Visit `/onboarding/` in an empty folder and confirm the disabled Continue shows the helper text. Visit `/admin/observability/` (Langfuse) and confirm the secret-key field has the eye-toggle.

## Tests added

- `__tests__/admin/SecretInput.test.tsx` — type masking + toggle + value preservation + default `autoComplete=\"off\"` / `spellCheck=false`
- `__tests__/login.test.tsx` — new nested describe for `auth_mode=none` (no form, redirect fires, honors `?next`, falls back to `/` for unsafe values). Existing tests updated to inject `window.__IDUN_CONFIG__.authMode=\"password\"` in `beforeEach`.
- `__tests__/onboarding/WizardEmpty.test.tsx` + `WizardManyDetected.test.tsx` — helper-text visibility assertions.

## Out of scope (deferred to other PRs in the audit backlog)

- `UI-001` (hide MVP-2 placeholder cards on `/admin/`)
- `CLI-002` (suppress 3 dependency warnings on every CLI invocation)
- `ENGINE-001` (update `/_engine/info` to advertise `/agent/run`)
- `UI-012` (wrap `/logs/` 404 in admin chrome)
- `WIZARD-002` (default starter to no-LLM echo agent)
- `TYPECHECK-001` (flip `next.config.mjs:typescript.ignoreBuildErrors` back to `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /idun-team:feature-loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show/hide secret toggle added for secret inputs across admin pages with improved accessibility and disabled-state behavior.
  * Inline helper prompts added to onboarding steps for framework/agent selection.
  * Settings shows a destructive-style badge and inline warning when admin auth is disabled.
  * Login now respects runtime auth mode and safely redirects when admin auth is disabled.

* **Tests**
  * Expanded unit and E2E coverage for secret input accessibility/disabled behavior, login runtime-config edge cases, and onboarding flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/615)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->