### PR TITLE
feat(ui): admin UX rework — capability catalog on MCP, Integrations, Guardrails

### DIFF
--- a/services/idun_agent_standalone_ui/app/admin/guardrails/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/guardrails/page.tsx
@@ -820,6 +820,7 @@ export default function GuardrailsPage() {
       )}
 
       <ProviderPicker
+        aria-label="Choose guard type"
         value={sheetType ?? ("" as GuardId)}
         onChange={openCreate}
         options={GUARD_CATALOG}

--- a/services/idun_agent_standalone_ui/app/admin/guardrails/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/guardrails/page.tsx
@@ -2,12 +2,26 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Pencil, Plus, RotateCcw, Trash2 } from "lucide-react";
+import {
+  Ban,
+  Globe,
+  Lock,
+  Pencil,
+  RotateCcw,
+  Scale,
+  ShieldAlert,
+  Skull,
+  Target,
+  Trash2,
+  Trophy,
+  Type,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useForm, type Control } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { ProviderPicker, type ProviderOption } from "@/components/admin/ProviderPicker";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   AlertDialog,
@@ -46,6 +60,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
   SheetContent,
@@ -90,6 +105,63 @@ const GUARD_LABELS: Record<GuardId, string> = {
   correct_language: "Correct Language",
   restrict_to_topic: "Restrict to Topic",
 };
+
+const GUARD_CATALOG: ProviderOption<GuardId>[] = [
+  {
+    id: "ban_list",
+    label: GUARD_LABELS.ban_list,
+    description: "Block messages containing forbidden words or phrases.",
+    icon: <Ban size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "detect_pii",
+    label: GUARD_LABELS.detect_pii,
+    description: "Catch emails, phone numbers, credit cards, and other personal data.",
+    icon: <Lock size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "nsfw_text",
+    label: GUARD_LABELS.nsfw_text,
+    description: "Block adult or sexual content.",
+    icon: <ShieldAlert size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "toxic_language",
+    label: GUARD_LABELS.toxic_language,
+    description: "Filter slurs, harassment, and threats from inputs and outputs.",
+    icon: <Skull size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "gibberish_text",
+    label: GUARD_LABELS.gibberish_text,
+    description: "Reject inputs that don't form coherent language.",
+    icon: <Type size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "bias_check",
+    label: GUARD_LABELS.bias_check,
+    description: "Detect biased or stereotyping language.",
+    icon: <Scale size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "competition_check",
+    label: GUARD_LABELS.competition_check,
+    description: "Block mentions of competitors you've listed.",
+    icon: <Trophy size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "correct_language",
+    label: GUARD_LABELS.correct_language,
+    description: "Validate that the output is in the expected language.",
+    icon: <Globe size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "restrict_to_topic",
+    label: GUARD_LABELS.restrict_to_topic,
+    description: "Keep the conversation on the topics you allow.",
+    icon: <Target size={44} className="text-foreground/70" />,
+  },
+];
 
 const PII_ENTITIES = [
   "Email",
@@ -252,12 +324,28 @@ function formGuardToWire(g: GuardFormValues): Record<string, unknown> {
 }
 
 function emptyRowForm(): RowFormValues {
+  return emptyRowFormFor("ban_list");
+}
+
+function emptyRowFormFor(guardId: GuardId): RowFormValues {
+  const d = GUARD_DEFAULTS[guardId];
   return {
     name: "",
     enabled: true,
     position: "input",
     sortOrder: 0,
-    guard: { config_id: "ban_list", api_key: "", reject_message: "ban!!", banned_words: "" },
+    guard: {
+      config_id: guardId,
+      api_key: "",
+      reject_message: d.reject_message ?? "",
+      banned_words: d.banned_words ?? "",
+      pii_entities: d.pii_entities ?? "",
+      competitors: d.competitors ?? "",
+      expected_languages: d.expected_languages ?? "",
+      valid_topics: d.valid_topics ?? "",
+      invalid_topics: d.invalid_topics ?? "",
+      threshold: d.threshold,
+    },
   };
 }
 
@@ -545,6 +633,7 @@ export default function GuardrailsPage() {
 
   const [working, setWorking] = useState<GuardrailRow[]>(initialList);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [sheetType, setSheetType] = useState<GuardId | null>(null);
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
   const [confirmIdx, setConfirmIdx] = useState<number | null>(null);
   const [restartRequired, setRestartRequired] = useState(false);
@@ -566,24 +655,33 @@ export default function GuardrailsPage() {
 
   const watchedGuardId = form.watch("guard.config_id");
 
-  function openSheetFor(index: number | null) {
+  function openCreate(guardId: GuardId) {
+    setSheetType(guardId);
+    setEditingIdx(null);
+    form.reset(emptyRowFormFor(guardId));
+    setSheetOpen(true);
+  }
+
+  function openEdit(index: number) {
+    const row = working[index];
+    if (!row) return;
+    const guardId: GuardId = isGuardId(row.guardrail.config_id)
+      ? row.guardrail.config_id
+      : "ban_list";
+    setSheetType(guardId);
     setEditingIdx(index);
-    if (index === null) {
-      form.reset(emptyRowForm());
-    } else {
-      const row = working[index];
-      form.reset({
-        name: row.name,
-        enabled: row.enabled,
-        position: row.position,
-        sortOrder: row.sortOrder,
-        guard: wireGuardToForm(row.guardrail),
-      });
-    }
+    form.reset({
+      name: row.name,
+      enabled: row.enabled,
+      position: row.position,
+      sortOrder: row.sortOrder,
+      guard: wireGuardToForm(row.guardrail),
+    });
     setSheetOpen(true);
   }
 
   function closeSheet() {
+    setSheetType(null);
     setSheetOpen(false);
     setEditingIdx(null);
   }
@@ -721,18 +819,23 @@ export default function GuardrailsPage() {
         </Alert>
       )}
 
+      <ProviderPicker
+        value={sheetType ?? ("" as GuardId)}
+        onChange={openCreate}
+        options={GUARD_CATALOG}
+        columns={3}
+      />
+
+      <Separator />
+
       <Card>
-        <CardHeader className="flex-row items-center justify-between">
+        <CardHeader>
           <div className="space-y-1">
             <CardTitle>Configured guards</CardTitle>
             <CardDescription>
               {working.length} guard{working.length === 1 ? "" : "s"}
             </CardDescription>
           </div>
-          <Button onClick={() => openSheetFor(null)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Add guard
-          </Button>
         </CardHeader>
         <CardContent>
           {working.length === 0 ? (
@@ -796,7 +899,7 @@ export default function GuardrailsPage() {
                         <Button
                           variant="ghost"
                           size="icon"
-                          onClick={() => openSheetFor(i)}
+                          onClick={() => openEdit(i)}
                           aria-label={`Edit ${row.name}`}
                         >
                           <Pencil className="h-4 w-4" />
@@ -837,7 +940,9 @@ export default function GuardrailsPage() {
         >
           <SheetHeader className="border-b border-border px-6 py-4">
             <SheetTitle>
-              {editingIdx === null ? "Add guard" : "Edit guard"}
+              {editingIdx === null
+                ? `Add ${sheetType ? GUARD_LABELS[sheetType] : "guard"}`
+                : `Edit ${sheetType ? GUARD_LABELS[sheetType] : "guard"}`}
             </SheetTitle>
           </SheetHeader>
           <div className="flex-1 overflow-y-auto px-6 py-4">
@@ -943,64 +1048,6 @@ export default function GuardrailsPage() {
                     )}
                   />
                 </div>
-
-                <FormField
-                  control={form.control}
-                  name="guard.config_id"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Guard type</FormLabel>
-                      <Select
-                        value={field.value}
-                        onValueChange={(next) => {
-                          const id = next as GuardId;
-                          field.onChange(id);
-                          const d = GUARD_DEFAULTS[id];
-                          form.setValue(
-                            "guard.reject_message",
-                            d.reject_message ?? "",
-                          );
-                          form.setValue(
-                            "guard.banned_words",
-                            d.banned_words ?? "",
-                          );
-                          form.setValue(
-                            "guard.pii_entities",
-                            d.pii_entities ?? "",
-                          );
-                          form.setValue("guard.competitors", d.competitors ?? "");
-                          form.setValue(
-                            "guard.expected_languages",
-                            d.expected_languages ?? "",
-                          );
-                          form.setValue(
-                            "guard.valid_topics",
-                            d.valid_topics ?? "",
-                          );
-                          form.setValue(
-                            "guard.invalid_topics",
-                            d.invalid_topics ?? "",
-                          );
-                          form.setValue("guard.threshold", d.threshold);
-                        }}
-                      >
-                        <FormControl>
-                          <SelectTrigger className="w-full">
-                            <SelectValue />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {GUARD_IDS.map((id) => (
-                            <SelectItem key={id} value={id}>
-                              {GUARD_LABELS[id]}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
 
                 <GuardFields
                   control={form.control}

--- a/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
@@ -651,6 +651,7 @@ export default function IntegrationsPage() {
       </header>
 
       <ProviderPicker
+        aria-label="Choose channel"
         value={sheetType ?? ("" as Provider)}
         onChange={openCreate}
         options={CATALOG_OPTIONS}

--- a/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/integrations/page.tsx
@@ -2,14 +2,14 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus, Settings, Trash2 } from "lucide-react";
+import { Settings, Trash2 } from "lucide-react";
 import * as React from "react";
 import { useEffect, useState } from "react";
 import { useForm, type Control } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
-import { ProviderPicker } from "@/components/admin/ProviderPicker";
+import { ProviderPicker, type ProviderOption } from "@/components/admin/ProviderPicker";
 import {
   DiscordIcon,
   GoogleChatIcon,
@@ -47,6 +47,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
   SheetContent,
@@ -110,12 +111,38 @@ function providerIcon(p: Provider, size = 40): React.ReactNode {
   }
 }
 
-const PROVIDER_PICKER_OPTIONS = PROVIDERS.map((p) => ({
-  id: p,
-  label: PROVIDER_META[p].label,
-  description: PROVIDER_META[p].summary,
-  icon: providerIcon(p, 44),
-}));
+const CATALOG_OPTIONS: ProviderOption<Provider>[] = [
+  {
+    id: "SLACK",
+    label: "Slack",
+    description: "Send and receive messages in any Slack channel.",
+    icon: <SlackIcon size={44} />,
+  },
+  {
+    id: "DISCORD",
+    label: "Discord",
+    description: "Run your agent inside Discord servers and DMs.",
+    icon: <DiscordIcon size={44} />,
+  },
+  {
+    id: "WHATSAPP",
+    label: "WhatsApp",
+    description: "Reach users on WhatsApp Business through the cloud API.",
+    icon: <WhatsAppIcon size={44} />,
+  },
+  {
+    id: "GOOGLE_CHAT",
+    label: "Google Chat",
+    description: "Wire your agent into Google Chat spaces and direct messages.",
+    icon: <GoogleChatIcon size={44} />,
+  },
+  {
+    id: "TEAMS",
+    label: "Microsoft Teams",
+    description: "Talk to your agent from Teams via the Bot Framework.",
+    icon: <MicrosoftTeamsIcon size={44} />,
+  },
+];
 
 function isProvider(v: unknown): v is Provider {
   return typeof v === "string" && (PROVIDERS as readonly string[]).includes(v);
@@ -503,6 +530,7 @@ export default function IntegrationsPage() {
 
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | "new" | null>(null);
+  const [sheetType, setSheetType] = useState<Provider | null>(null);
   const [confirmId, setConfirmId] = useState<string | null>(null);
 
   const form = useForm<FormValues>({
@@ -554,8 +582,9 @@ export default function IntegrationsPage() {
   });
 
   function openSheetForExisting(row: IntegrationRead) {
-    setEditingId(row.id);
     const provider = readProvider(row);
+    setSheetType(provider);
+    setEditingId(row.id);
     const config = readConfig(row);
     const next = configToValues(provider, config);
     next.name = row.name;
@@ -564,13 +593,15 @@ export default function IntegrationsPage() {
     setSheetOpen(true);
   }
 
-  function openSheetForNew() {
+  function openCreate(provider: Provider) {
+    setSheetType(provider);
     setEditingId("new");
-    form.reset(emptyForm());
+    form.reset({ ...emptyForm(), provider });
     setSheetOpen(true);
   }
 
   function closeSheet() {
+    setSheetType(null);
     setSheetOpen(false);
     setEditingId(null);
   }
@@ -619,12 +650,14 @@ export default function IntegrationsPage() {
         </p>
       </header>
 
-      <div className="flex justify-end">
-        <Button onClick={openSheetForNew}>
-          <Plus className="mr-2 h-4 w-4" />
-          Add integration
-        </Button>
-      </div>
+      <ProviderPicker
+        value={sheetType ?? ("" as Provider)}
+        onChange={openCreate}
+        options={CATALOG_OPTIONS}
+        columns={3}
+      />
+
+      <Separator />
 
       {rows.length === 0 ? (
         <Card>
@@ -661,7 +694,9 @@ export default function IntegrationsPage() {
         >
           <SheetHeader className="border-b border-border px-6 py-4">
             <SheetTitle>
-              {editingId === "new" ? "Add integration" : "Configure integration"}
+              {editingId === "new"
+                ? `Add ${sheetType ? PROVIDER_META[sheetType].label : "integration"}`
+                : `Configure ${sheetType ? PROVIDER_META[sheetType].label : "integration"}`}
             </SheetTitle>
           </SheetHeader>
           <div className="flex-1 overflow-y-auto px-6 py-4">
@@ -682,30 +717,6 @@ export default function IntegrationsPage() {
                       </FormControl>
                       <FormDescription>
                         Display name. The slug is derived from this.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="provider"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Provider</FormLabel>
-                      <FormControl>
-                        <fieldset disabled={editingId !== "new"} className="contents">
-                          <ProviderPicker
-                            value={field.value}
-                            onChange={(v) => field.onChange(v as Provider)}
-                            options={PROVIDER_PICKER_OPTIONS}
-                            columns={2}
-                          />
-                        </fieldset>
-                      </FormControl>
-                      <FormDescription>
-                        Provider cannot change after creation.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>

--- a/services/idun_agent_standalone_ui/app/admin/mcp/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/mcp/page.tsx
@@ -747,7 +747,11 @@ export default function McpPage() {
           <SheetHeader className="border-b border-border px-6 py-4">
             <SheetTitle>
               {editingIdx === null
-                ? `Add MCP server — ${sheetType ? TRANSPORT_LABELS[sheetType] : ""}`
+                ? `Add MCP server — ${
+                    sheetType
+                      ? (TRANSPORT_CATALOG.find((o) => o.id === sheetType)?.label ?? sheetType)
+                      : ""
+                  }`
                 : "Edit MCP server"}
             </SheetTitle>
           </SheetHeader>

--- a/services/idun_agent_standalone_ui/app/admin/mcp/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/mcp/page.tsx
@@ -612,6 +612,7 @@ export default function McpPage() {
       )}
 
       <ProviderPicker
+        aria-label="Choose transport"
         value={sheetType ?? ("" as Transport)}
         onChange={openCreate}
         options={TRANSPORT_CATALOG}
@@ -746,13 +747,15 @@ export default function McpPage() {
         >
           <SheetHeader className="border-b border-border px-6 py-4">
             <SheetTitle>
-              {editingIdx === null
-                ? `Add MCP server — ${
-                    sheetType
-                      ? (TRANSPORT_CATALOG.find((o) => o.id === sheetType)?.label ?? sheetType)
-                      : ""
-                  }`
-                : "Edit MCP server"}
+              {(() => {
+                const transportLabel = sheetType
+                  ? (TRANSPORT_CATALOG.find((o) => o.id === sheetType)?.label ?? sheetType)
+                  : "";
+                const suffix = transportLabel ? ` — ${transportLabel}` : "";
+                return editingIdx === null
+                  ? `Add MCP server${suffix}`
+                  : `Edit MCP server${suffix}`;
+              })()}
             </SheetTitle>
           </SheetHeader>
           <div className="flex-1 overflow-y-auto px-6 py-4">

--- a/services/idun_agent_standalone_ui/app/admin/mcp/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/mcp/page.tsx
@@ -6,10 +6,14 @@ import {
   AlertCircle,
   CheckCircle2,
   FileCode,
+  Globe,
   Loader2,
   Pencil,
+  Plug,
   Plus,
+  Radio,
   RotateCcw,
+  Terminal,
   Trash2,
   Wrench,
   X,
@@ -21,6 +25,7 @@ import { stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 
 import { EditYamlSheet } from "@/components/admin/EditYamlSheet";
+import { ProviderPicker, type ProviderOption } from "@/components/admin/ProviderPicker";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   AlertDialog,
@@ -60,13 +65,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
   SheetContent,
@@ -97,6 +96,36 @@ const TRANSPORT_LABELS: Record<Transport, string> = {
   sse: "sse",
   websocket: "websocket",
 };
+
+const TRANSPORT_CATALOG: ProviderOption<Transport>[] = [
+  {
+    id: "streamable_http",
+    label: "Streamable HTTP",
+    description:
+      "Connect to a remote MCP server over HTTP streaming. The modern default.",
+    icon: <Globe size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "sse",
+    label: "SSE",
+    description:
+      "Server-Sent Events transport. Use when a server only exposes SSE.",
+    icon: <Radio size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "websocket",
+    label: "WebSocket",
+    description: "Bidirectional WebSocket connection for live tool servers.",
+    icon: <Plug size={44} className="text-foreground/70" />,
+  },
+  {
+    id: "stdio",
+    label: "STDIO",
+    description:
+      "Run a local MCP process and pipe over stdin / stdout. Great for filesystem, git, local tools.",
+    icon: <Terminal size={44} className="text-foreground/70" />,
+  },
+];
 
 /** A row in the local working list. `id` is null for unsaved additions. */
 type ServerRow = {
@@ -317,6 +346,7 @@ export default function McpPage() {
 
   const [working, setWorking] = useState<ServerRow[]>(initialList);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [sheetType, setSheetType] = useState<Transport | null>(null);
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
   const [confirmIdx, setConfirmIdx] = useState<number | null>(null);
   const [yamlOpen, setYamlOpen] = useState(false);
@@ -354,18 +384,27 @@ export default function McpPage() {
   const watchedHeaders = form.watch("headers");
   const watchedEnv = form.watch("env");
 
-  function openSheetFor(index: number | null) {
+  function openCreate(transport: Transport) {
+    setSheetType(transport);
+    setEditingIdx(null);
+    form.reset({ ...emptyFormValues(), transport });
+    setSheetOpen(true);
+  }
+
+  function openEdit(index: number) {
+    const row = working[index];
+    if (!row) return;
+    const transport: Transport = isTransport(row.config.transport)
+      ? row.config.transport
+      : "stdio";
+    setSheetType(transport);
     setEditingIdx(index);
-    if (index === null) {
-      form.reset(emptyFormValues());
-    } else {
-      const row = working[index];
-      form.reset(configToFormValues(row.name, row.enabled, row.config));
-    }
+    form.reset(configToFormValues(row.name, row.enabled, row.config));
     setSheetOpen(true);
   }
 
   function closeSheet() {
+    setSheetType(null);
     setSheetOpen(false);
     setEditingIdx(null);
   }
@@ -572,18 +611,23 @@ export default function McpPage() {
         </Alert>
       )}
 
+      <ProviderPicker
+        value={sheetType ?? ("" as Transport)}
+        onChange={openCreate}
+        options={TRANSPORT_CATALOG}
+        columns={4}
+      />
+
+      <Separator />
+
       <Card>
-        <CardHeader className="flex-row items-center justify-between">
+        <CardHeader>
           <div className="space-y-1">
             <CardTitle>Configured servers</CardTitle>
             <CardDescription>
               {working.length} server{working.length === 1 ? "" : "s"}
             </CardDescription>
           </div>
-          <Button onClick={() => openSheetFor(null)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Add server
-          </Button>
         </CardHeader>
         <CardContent>
           {working.length === 0 ? (
@@ -652,7 +696,7 @@ export default function McpPage() {
                         <Button
                           variant="ghost"
                           size="icon"
-                          onClick={() => openSheetFor(i)}
+                          onClick={() => openEdit(i)}
                           aria-label={`Edit ${row.name}`}
                         >
                           <Pencil className="h-4 w-4" />
@@ -702,7 +746,9 @@ export default function McpPage() {
         >
           <SheetHeader className="border-b border-border px-6 py-4">
             <SheetTitle>
-              {editingIdx === null ? "Add MCP server" : "Edit MCP server"}
+              {editingIdx === null
+                ? `Add MCP server — ${sheetType ? TRANSPORT_LABELS[sheetType] : ""}`
+                : "Edit MCP server"}
             </SheetTitle>
           </SheetHeader>
           <div className="flex-1 overflow-y-auto px-6 py-4">
@@ -747,34 +793,6 @@ export default function McpPage() {
                           onCheckedChange={field.onChange}
                         />
                       </FormControl>
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="transport"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Transport</FormLabel>
-                      <Select
-                        value={field.value}
-                        onValueChange={(v) => field.onChange(v as Transport)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className="w-full">
-                            <SelectValue placeholder="Pick a transport" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {TRANSPORTS.map((t) => (
-                            <SelectItem key={t} value={t}>
-                              {TRANSPORT_LABELS[t]}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
                     </FormItem>
                   )}
                 />

--- a/services/idun_agent_standalone_ui/components/admin/ProviderPicker.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/ProviderPicker.tsx
@@ -19,6 +19,8 @@ type ProviderPickerProps<T extends string = string> = {
   options: ProviderOption<T>[];
   columns?: 2 | 3 | 4;
   className?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
 };
 
 export function ProviderPicker<T extends string = string>({
@@ -27,10 +29,14 @@ export function ProviderPicker<T extends string = string>({
   options,
   columns = 3,
   className,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
 }: ProviderPickerProps<T>) {
   return (
     <div
       role="radiogroup"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
       className={cn(
         "grid gap-3",
         columns === 2 && "sm:grid-cols-2",


### PR DESCRIPTION
## Summary

Promotes the existing `ProviderPicker` to the first viewport on the three admin pages (MCP, Integrations, Guardrails), so users see what's available before they have to click "+ Add" to discover anything. Matches the showcase pattern already used by Memory / SSO / Observability.

- 5-card provider catalog above the configured-integrations grid (Slack, Discord, WhatsApp, Google Chat, Microsoft Teams)
- 4-card transport catalog above the configured-MCP-servers table (Streamable HTTP, SSE, WebSocket, STDIO)
- 9-card guard catalog (3×3) above the configured-guards table
- In-Sheet type/provider selectors deleted on all three pages (the catalog now drives type selection)
- CardHeader `Add …` buttons deleted (catalog is the sole ADD entry point)
- Catalog card highlight tracks the Sheet's open lifetime — clears on Save / Cancel / Esc / X / overlay click
- `ProviderPicker` gains optional `aria-label` / `aria-labelledby` props to restore the accessible name on each standalone catalog
- No new shared components: reuses existing `ProviderPicker` and `Sheet`

## Commits

- `b7787519` — `feat(ui): promote provider catalog on integrations admin page`
- `96b7845f` — `feat(ui): promote transport catalog on MCP admin page`
- `d537dda6` — `fix(ui): use human-readable transport label in MCP Sheet title`
- `4e0400fa` — `feat(ui): promote guard catalog on guardrails admin page`
- `cf662e60` — `fix(ui): label catalog pickers + symmetric MCP edit-title` (review feedback from Idun `/review-pr` + CodeRabbit)

## Spec & plan

- [SPEC.md](https://github.com/Idun-Group/idun-dev/blob/main/tasks/admin-ux-rework-standalone-ui-11-05-2026/SPEC.md)
- [PLAN.md](https://github.com/Idun-Group/idun-dev/blob/main/tasks/admin-ux-rework-standalone-ui-11-05-2026/PLAN.md)

## Gates

- ✅ `pnpm typecheck` clean
- ✅ `pnpm build` clean (static export)
- ✅ `pnpm test` baseline preserved (288/294 tests pass — the 6 pre-existing failures are all in `__tests__/api/*.test.ts` and unrelated to UI)
- ✅ `ui` CI gate (new since v1) green
- ✅ `Coding guidelines drift check (advisory)` green
- ✅ `Lint, type-check, and secrets scan` green
- ✅ All build / docker / playwright / wheel / engine / schema gates green
- ⚠️ `pytest e2e — adk-gemini` fails on an **external infra issue** (HTTP 403 from `pypi.guardrailsai.com` while pre-installing `guardrails-grhub-detect-pii`). Unrelated to this PR — `pytest e2e — lg-gemini` and `lg-openai` both pass.

## Test plan

- [ ] Visit `/admin/integrations` — 5 provider cards visible above the configured grid. Click any card → Sheet opens with that provider pre-selected; card shows the emerald ring. Edit an existing integration → catalog highlights its provider.
- [ ] Visit `/admin/mcp` — 4 transport cards visible above the configured servers table. Click any card → Sheet opens with that transport pre-selected. Sheet title shows the human-readable label in BOTH add and edit modes (e.g. "Add MCP server — Streamable HTTP" / "Edit MCP server — Streamable HTTP"). Edit / Delete / Discover-tools / YAML editor still work.
- [ ] Visit `/admin/guardrails` — 9 guard cards visible in a 3×3 grid. Click any card → Sheet opens with that guard's fields. Edit / Delete / Toggle / Position / Order still work.
- [ ] Memory, SSO, Observability pages unchanged (the reference showcase pages).
- [ ] Save round-trip on each page: pick from catalog → fill → Save → appears in configured list → reload → still there.
- [ ] Screen reader announces each picker's purpose (e.g. "Choose channel, radio group").

## Reviews

Both review systems converged on the same items:

- ✅ **CodeRabbit** — 4 `💤 Low value` nitpicks: 3× `"" as Type` casts + MCP edit-title asymmetry. The edit-title issue is fixed in `cf662e60`; the casts are deferred (see Follow-ups).
- ✅ **Idun `/review-pr`** ([comment](https://github.com/Idun-Group/idun-agent-platform/pull/616#issuecomment-4419614690)) — 0 warn, 3 advise:
  - **UI-002** (genuinely new a11y regression) — **fixed in `cf662e60`** (aria-label on each picker).
  - **TYPE-002** (3× `"" as Type` casts) — deferred to follow-up; needs `ProviderPicker` contract widening (`T | null`).
  - **TEST-001/004** (no UI tests) — deferred to follow-up; SPEC explicit out-of-scope.

## Known follow-ups (not blocking)

1. **`ProviderPicker` value-prop nullability.** Widen `ProviderPicker`'s `value: T` to `T | null` (or `T | ""`) and drop the `("" as T)` sentinel casts at the 3 call sites. Touches the shared component + the existing Memory/SSO/Observability consumers — deserves its own PR. CodeRabbit ×3, Idun TYPE-002, and the per-task code reviews all converge on this.
2. **UI tests for the catalog flow.** Add `__tests__/admin/{mcp,integrations,guardrails}.test.tsx` covering: catalog click → Sheet open with pre-typed form → close clears highlight; edit-row → Sheet prefilled + matching catalog highlight. Idun TEST-001/004.
3. **`ProviderPicker` roving tabindex.** Pre-existing in the shared component — `role="radiogroup"` per WAI-ARIA expects arrow-key navigation between options with a single tab stop; today each option has independent focus. Separate a11y PR.
4. **MCP `TRANSPORT_LABELS` / `TRANSPORT_CATALOG.label` parallel naming.** Two sources of truth for transport display names (lowercase ids vs human-readable). Cleanup: derive a single `TRANSPORT_LABEL` map from `TRANSPORT_CATALOG` and retire `TRANSPORT_LABELS`.
5. **`Configure` (Integrations card footer) vs `Edit` (MCP/Guardrails table rows)** — label inconsistency across the three pages. Out of scope here.
6. **State update.** Per `/idun-team:feature-loop` gate #2, state-phase-1.md was kept in sync after each task commit; see `tasks/admin-ux-rework-standalone-ui-11-05-2026/state-phase-1.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin pages (Guardrails, Integrations, MCP): provider/transport picker UI with icons, labels and descriptions for creating entries.
* **Improvements**
  * Add/edit sheets are provider-aware: titles reflect selected type and form defaults initialize per provider.
  * In-sheet provider/transport selectors removed in favor of the external picker.
  * ProviderPicker: optional accessibility props (aria-label / aria-labelledby) added.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/616)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->