### PR TITLE
fix(ui): link to Guardrails AI hub keys in API key help text

### DIFF
--- a/services/idun_agent_standalone_ui/app/admin/guardrails/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/guardrails/page.tsx
@@ -414,6 +414,16 @@ function GuardFields({
             <FormDescription>
               Stored on the row and forwarded to the engine on save. If left
               empty, the engine falls back to the GUARDRAILS_API_KEY env var.
+              Get a key from{" "}
+              <a
+                href="https://guardrailsai.com/hub/keys"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                guardrailsai.com/hub/keys
+              </a>
+              .
             </FormDescription>
             <FormMessage />
           </FormItem>


### PR DESCRIPTION
## Summary
- Adds a "Get a key from guardrailsai.com/hub/keys" link to the API key field description on `/admin/guardrails` so users can quickly find where to issue a Guardrails Hub key.
- Cosmetic-only change to the existing `FormDescription` under the API key input in `app/admin/guardrails/page.tsx`. No behavior changes.

## Test plan
- [ ] `pnpm typecheck` passes (verified locally)
- [ ] `pnpm build` succeeds (verified locally)
- [ ] Visual: link renders inside the API key help text, opens `https://guardrailsai.com/hub/keys` in a new tab with `rel="noopener noreferrer"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the API key field help text in the guard editor with a direct link to obtain keys from guardrailsai.com/hub.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/618)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->