### PR TITLE
fix(standalone): RSC shell routes + admin link prefixes (trace 404 noise)

### DIFF
--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -278,14 +278,30 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
 def _register_trace_detail_routes(app: FastAPI, ui_dir: Path) -> None:
     """Wire the SPA-rewrite routes for ``/admin/traces/{trace_id}``.
 
-    Both URL forms (``/admin/traces/<id>`` and ``/admin/traces/<id>/``)
-    need explicit route declarations. FastAPI's ``redirect_slashes=True``
-    only redirects ``/foo/`` back to ``/foo`` for routes declared
-    without the trailing slash, *not* the inverse — and once
-    ``StaticFiles(html=True)`` is mounted at ``/``, the slashed form is
-    consumed by the static handler before the dynamic route sees it,
-    yielding ``404`` on every link-share / Slack-unfurl form. Declaring
-    the slashed sibling route fixes that.
+    Four URL flavors need explicit declarations:
+
+    * ``/admin/traces/<id>`` and ``/admin/traces/<id>/`` — HTML shell.
+      FastAPI's ``redirect_slashes=True`` only redirects ``/foo/`` back
+      to ``/foo`` for routes declared without the trailing slash, *not*
+      the inverse — and once ``StaticFiles(html=True)`` is mounted at
+      ``/``, the slashed form is consumed by the static handler before
+      the dynamic route sees it, yielding ``404`` on every link-share /
+      Slack-unfurl form. Declaring the slashed sibling route fixes that.
+    * ``/admin/traces/<id>/index.txt`` and ``/admin/traces/<id>.txt`` —
+      RSC payload. Next 15 in ``output: "export"`` mode prefetches the
+      React Flight stream from these paths on hover (``/index.txt``) and
+      on ``router.replace`` query-string-only navigations (``.txt``).
+      Without an explicit handler the directory form ``404``s and the
+      file form gets absorbed by the ``{trace_id}`` HTML route (trace_id
+      ends up as ``<id>.txt``), which serves HTML to a client expecting a
+      Flight stream — the client then bails to a full hard navigation,
+      re-firing ``/runtime-config.js``, ``/sso/info``, ``/auth/me`` and
+      the trace fetch on every span click. Serving the placeholder's
+      RSC payload here keeps client navigation in-app.
+
+      The ``.txt`` routes are declared **before** the HTML routes so
+      FastAPI matches them more specifically — otherwise the
+      ``{trace_id}`` path param greedily absorbs the ``.txt`` suffix.
 
     The selected SPA shell is resolved once at boot (the file layout
     cannot change at runtime and the request handler is on the async
@@ -295,6 +311,10 @@ def _register_trace_detail_routes(app: FastAPI, ui_dir: Path) -> None:
     falls back to the legacy ``__trace__/`` directory when the static
     export was produced by ``pnpm build`` directly (no rename pass),
     and falls back to the root ``index.html`` when neither exists.
+    The RSC payload follows the same resolution; when no ``.txt`` is
+    present the route returns ``404`` rather than fabricating one — a
+    missing RSC payload signals a broken build and shouldn't be papered
+    over by serving the HTML shell with the wrong content type.
 
     The literal ``__trace__`` segment is the build-time placeholder
     path. Even after the rename it remains reachable via the dynamic
@@ -321,6 +341,16 @@ def _register_trace_detail_routes(app: FastAPI, ui_dir: Path) -> None:
     else:
         selected_trace_shell = spa_root_shell
 
+    trace_rsc_renamed = ui_dir / "admin" / "traces" / "_shell" / "index.txt"
+    trace_rsc_legacy = ui_dir / "admin" / "traces" / "__trace__" / "index.txt"
+    selected_trace_rsc: Path | None
+    if trace_rsc_renamed.is_file():
+        selected_trace_rsc = trace_rsc_renamed
+    elif trace_rsc_legacy.is_file():
+        selected_trace_rsc = trace_rsc_legacy
+    else:
+        selected_trace_rsc = None
+
     placeholder_trace_id = "__trace__"
 
     def _serve_or_410(trace_id: str) -> FileResponse:
@@ -329,6 +359,23 @@ def _register_trace_detail_routes(app: FastAPI, ui_dir: Path) -> None:
                 status_code=410, detail="trace placeholder is not a real id"
             )
         return FileResponse(selected_trace_shell)
+
+    def _serve_rsc_or_410(trace_id: str) -> FileResponse:
+        if selected_trace_rsc is None:
+            raise HTTPException(status_code=404)
+        if trace_id == placeholder_trace_id:
+            raise HTTPException(
+                status_code=410, detail="trace placeholder is not a real id"
+            )
+        return FileResponse(selected_trace_rsc, media_type="text/x-component")
+
+    @app.get("/admin/traces/{trace_id}/index.txt", include_in_schema=False)
+    async def _trace_detail_rsc_dir(trace_id: str) -> FileResponse:
+        return _serve_rsc_or_410(trace_id)
+
+    @app.get("/admin/traces/{trace_id}.txt", include_in_schema=False)
+    async def _trace_detail_rsc_file(trace_id: str) -> FileResponse:
+        return _serve_rsc_or_410(trace_id)
 
     @app.get("/admin/traces/{trace_id}", include_in_schema=False)
     async def _trace_detail_spa_shell(trace_id: str) -> FileResponse:

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -361,12 +361,16 @@ def _register_trace_detail_routes(app: FastAPI, ui_dir: Path) -> None:
         return FileResponse(selected_trace_shell)
 
     def _serve_rsc_or_410(trace_id: str) -> FileResponse:
-        if selected_trace_rsc is None:
-            raise HTTPException(status_code=404)
+        # Placeholder check runs first so stale ``__trace__`` links keep
+        # surfacing as ``410 Gone`` even on a broken build that shipped
+        # ``index.html`` without ``index.txt`` — operators get the same
+        # "this isn't a real trace id" signal as the HTML route.
         if trace_id == placeholder_trace_id:
             raise HTTPException(
                 status_code=410, detail="trace placeholder is not a real id"
             )
+        if selected_trace_rsc is None:
+            raise HTTPException(status_code=404)
         return FileResponse(selected_trace_rsc, media_type="text/x-component")
 
     @app.get("/admin/traces/{trace_id}/index.txt", include_in_schema=False)

--- a/libs/idun_agent_standalone/tests/unit/test_trace_spa_rewrite.py
+++ b/libs/idun_agent_standalone/tests/unit/test_trace_spa_rewrite.py
@@ -163,6 +163,23 @@ async def test_rsc_route_404s_when_payload_missing(shell_ui_dir_no_rsc: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_placeholder_410_still_wins_on_broken_build(
+    shell_ui_dir_no_rsc: Path,
+) -> None:
+    """Placeholder ``__trace__`` returns ``410`` even when no RSC payload
+    exists. The placeholder check must run before the missing-RSC check
+    so stale links keep surfacing the operator-friendly Gone signal
+    instead of a generic ``404``."""
+    app = _build_app(shell_ui_dir_no_rsc)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        rsc_dir = await client.get("/admin/traces/__trace__/index.txt")
+        rsc_file = await client.get("/admin/traces/__trace__.txt")
+    assert rsc_dir.status_code == 410
+    assert rsc_file.status_code == 410
+
+
+@pytest.mark.asyncio
 async def test_legacy_trace_directory_is_resolved(shell_ui_dir_legacy: Path) -> None:
     """Unrenamed ``__trace__/`` (raw ``pnpm build`` output) is the
     fallback for direct-build workflows like ``e2e/boot-standalone.sh``."""

--- a/libs/idun_agent_standalone/tests/unit/test_trace_spa_rewrite.py
+++ b/libs/idun_agent_standalone/tests/unit/test_trace_spa_rewrite.py
@@ -1,0 +1,164 @@
+"""Unit tests for the trace-detail SPA rewrite + RSC payload routes.
+
+Covers ``_register_trace_detail_routes`` directly so we can exercise the
+route precedence (``.txt`` flavor must beat the greedy HTML route) and
+the shell/RSC resolution fallbacks (renamed ``_shell/`` → legacy
+``__trace__/`` → root) without booting the full standalone or
+materialising a real Next export.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from idun_agent_standalone.app import _register_trace_detail_routes
+
+
+def _write_shell(
+    ui_dir: Path,
+    *,
+    shell_dir: str = "_shell",
+    html: str = "<html>shell</html>",
+    rsc: str | None = "0:[\"shell-rsc\",null]\n",
+) -> None:
+    """Materialise a minimal Next export under ``ui_dir``.
+
+    ``shell_dir`` switches between the renamed ``_shell/`` (post
+    Make-target rename) and the legacy ``__trace__/`` (raw ``pnpm
+    build`` output). ``rsc=None`` simulates a broken build that emits
+    HTML without the RSC ``.txt`` flavor.
+    """
+    traces_dir = ui_dir / "admin" / "traces" / shell_dir
+    traces_dir.mkdir(parents=True)
+    (traces_dir / "index.html").write_text(html)
+    if rsc is not None:
+        (traces_dir / "index.txt").write_text(rsc)
+    (ui_dir / "index.html").write_text("<html>root</html>")
+
+
+def _build_app(ui_dir: Path) -> FastAPI:
+    app = FastAPI()
+    _register_trace_detail_routes(app, ui_dir)
+    return app
+
+
+@pytest.fixture
+def shell_ui_dir(tmp_path: Path) -> Path:
+    _write_shell(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_html_shell_served_for_unslashed_trace_id(shell_ui_dir: Path) -> None:
+    app = _build_app(shell_ui_dir)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/traces/abc123")
+    assert response.status_code == 200
+    assert response.text == "<html>shell</html>"
+
+
+@pytest.mark.asyncio
+async def test_html_shell_served_for_slashed_trace_id(shell_ui_dir: Path) -> None:
+    """The slashed variant covers Slack-unfurl / link-share URLs."""
+    app = _build_app(shell_ui_dir)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/traces/abc123/")
+    assert response.status_code == 200
+    assert response.text == "<html>shell</html>"
+
+
+@pytest.mark.asyncio
+async def test_rsc_payload_served_for_directory_form(shell_ui_dir: Path) -> None:
+    """``/admin/traces/<id>/index.txt`` is what Next prefetches on hover."""
+    app = _build_app(shell_ui_dir)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/traces/abc123/index.txt")
+    assert response.status_code == 200
+    assert response.text == "0:[\"shell-rsc\",null]\n"
+    assert response.headers["content-type"].startswith("text/x-component")
+
+
+@pytest.mark.asyncio
+async def test_rsc_payload_served_for_file_form(shell_ui_dir: Path) -> None:
+    """``/admin/traces/<id>.txt`` is what Next prefetches on query-string nav.
+
+    This route must win over the greedy ``{trace_id}`` HTML route — if
+    it doesn't, the HTML shell is served as ``text/html`` and Next bails
+    to a hard navigation (page reload).
+    """
+    app = _build_app(shell_ui_dir)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/traces/abc123.txt")
+    assert response.status_code == 200
+    assert response.text == "0:[\"shell-rsc\",null]\n"
+    assert response.headers["content-type"].startswith("text/x-component")
+
+
+@pytest.mark.asyncio
+async def test_rsc_payload_passes_through_rsc_query_token(shell_ui_dir: Path) -> None:
+    """Real RSC prefetches carry ``?_rsc=<build-id>`` plus arbitrary
+    other query params (``?span=...``). The route must accept any query
+    string and still serve the payload."""
+    app = _build_app(shell_ui_dir)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/admin/traces/abc123/index.txt",
+            params={"_rsc": "idhyg", "span": "deadbeef"},
+        )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_placeholder_segment_returns_410_for_html(shell_ui_dir: Path) -> None:
+    app = _build_app(shell_ui_dir)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/traces/__trace__")
+    assert response.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_placeholder_segment_returns_410_for_rsc(shell_ui_dir: Path) -> None:
+    app = _build_app(shell_ui_dir)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/traces/__trace__/index.txt")
+    assert response.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_rsc_route_404s_when_payload_missing(tmp_path: Path) -> None:
+    """A build that emits ``index.html`` but no ``index.txt`` returns
+    ``404`` for the RSC route rather than fabricating one — serving HTML
+    as ``text/x-component`` would silently break the RSC client."""
+    _write_shell(tmp_path, rsc=None)
+    app = _build_app(tmp_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        rsc = await client.get("/admin/traces/abc123/index.txt")
+        html = await client.get("/admin/traces/abc123")
+    assert rsc.status_code == 404
+    assert html.status_code == 200  # HTML shell still serves
+
+
+@pytest.mark.asyncio
+async def test_legacy_trace_directory_is_resolved(tmp_path: Path) -> None:
+    """Unrenamed ``__trace__/`` (raw ``pnpm build`` output) is the
+    fallback for direct-build workflows like ``e2e/boot-standalone.sh``."""
+    _write_shell(tmp_path, shell_dir="__trace__")
+    app = _build_app(tmp_path)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        html = await client.get("/admin/traces/abc123")
+        rsc = await client.get("/admin/traces/abc123/index.txt")
+    assert html.status_code == 200
+    assert rsc.status_code == 200
+    assert rsc.headers["content-type"].startswith("text/x-component")

--- a/libs/idun_agent_standalone/tests/unit/test_trace_spa_rewrite.py
+++ b/libs/idun_agent_standalone/tests/unit/test_trace_spa_rewrite.py
@@ -51,6 +51,20 @@ def shell_ui_dir(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture
+def shell_ui_dir_no_rsc(tmp_path: Path) -> Path:
+    """``index.html`` only — simulates a broken build with no RSC payload."""
+    _write_shell(tmp_path, rsc=None)
+    return tmp_path
+
+
+@pytest.fixture
+def shell_ui_dir_legacy(tmp_path: Path) -> Path:
+    """Unrenamed ``__trace__/`` directory (raw ``pnpm build`` output)."""
+    _write_shell(tmp_path, shell_dir="__trace__")
+    return tmp_path
+
+
 @pytest.mark.asyncio
 async def test_html_shell_served_for_unslashed_trace_id(shell_ui_dir: Path) -> None:
     app = _build_app(shell_ui_dir)
@@ -135,12 +149,11 @@ async def test_placeholder_segment_returns_410_for_rsc(shell_ui_dir: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_rsc_route_404s_when_payload_missing(tmp_path: Path) -> None:
+async def test_rsc_route_404s_when_payload_missing(shell_ui_dir_no_rsc: Path) -> None:
     """A build that emits ``index.html`` but no ``index.txt`` returns
     ``404`` for the RSC route rather than fabricating one — serving HTML
     as ``text/x-component`` would silently break the RSC client."""
-    _write_shell(tmp_path, rsc=None)
-    app = _build_app(tmp_path)
+    app = _build_app(shell_ui_dir_no_rsc)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         rsc = await client.get("/admin/traces/abc123/index.txt")
@@ -150,11 +163,10 @@ async def test_rsc_route_404s_when_payload_missing(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_legacy_trace_directory_is_resolved(tmp_path: Path) -> None:
+async def test_legacy_trace_directory_is_resolved(shell_ui_dir_legacy: Path) -> None:
     """Unrenamed ``__trace__/`` (raw ``pnpm build`` output) is the
     fallback for direct-build workflows like ``e2e/boot-standalone.sh``."""
-    _write_shell(tmp_path, shell_dir="__trace__")
-    app = _build_app(tmp_path)
+    app = _build_app(shell_ui_dir_legacy)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         html = await client.get("/admin/traces/abc123")

--- a/services/idun_agent_standalone_ui/app/admin/page.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/page.tsx
@@ -115,7 +115,7 @@ export default function DashboardPage() {
             <CardDescription>Latest chat sessions.</CardDescription>
           </div>
           <Button asChild variant="ghost" size="sm">
-            <Link href="/traces/">
+            <Link href="/admin/traces/">
               View all
               <ArrowUpRight className="h-3.5 w-3.5 ml-1" />
             </Link>
@@ -159,7 +159,7 @@ export default function DashboardPage() {
                     <TableCell>
                       <Button asChild variant="ghost" size="sm">
                         <Link
-                          href={`/traces/session/?id=${encodeURIComponent(s.id)}`}
+                          href={`/admin/traces/session/?id=${encodeURIComponent(s.id)}`}
                         >
                           Open
                         </Link>

--- a/services/idun_agent_standalone_ui/components/admin/GlobalCommand.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/GlobalCommand.tsx
@@ -46,8 +46,8 @@ type PageEntry = {
 
 const PAGES: PageEntry[] = [
   { href: "/admin/", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/traces/", label: "Traces", icon: Activity },
-  { href: "/logs/", label: "Logs", icon: FileText },
+  { href: "/admin/traces/", label: "Traces", icon: Activity },
+  { href: "/admin/logs/", label: "Logs", icon: FileText },
   { href: "/admin/agent/", label: "Configuration", icon: Cog },
   { href: "/admin/guardrails/", label: "Guardrails", icon: Shield },
   { href: "/admin/memory/", label: "Memory", icon: Database },
@@ -147,7 +147,7 @@ export function GlobalCommand({ open, onOpenChange }: Props) {
                     key={s.id}
                     value={`trace ${label} ${s.id}`}
                     onSelect={() =>
-                      go(`/traces/session/?id=${encodeURIComponent(s.id)}`)
+                      go(`/admin/traces/session/?id=${encodeURIComponent(s.id)}`)
                     }
                   >
                     <Activity className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary

Fixes the two highest-signal trace-UI bugs from the log audit:

- **RSC shell routes** — Adds explicit `/admin/traces/{id}/index.txt` and `/admin/traces/{id}.txt` handlers that serve the placeholder's React Flight payload with `Content-Type: text/x-component`. Without these, Next 15's RSC prefetcher 404'd on hover and forced a hard navigation on every span click — re-firing `/runtime-config.js`, `/sso/info`, `/auth/me`, and the trace fetch per click. Side effect of the fix: the duplicate-bootstrap-per-click noise also disappears.
- **Admin link prefixes** — The dashboard's "View all" link and three Command-palette entries (`Traces`, `Logs`, `Recent traces`) pointed to `/traces/` and `/logs/` without the `/admin` prefix every other admin Link uses. Aligns them.

## Why (observed in production-bundle logs)

```
GET /admin/traces/{id}/index.txt?_rsc=idhyg → 404  (× every trace row)
GET /traces/index.txt?_rsc=1yg7h           → 404 → 307 /admin/traces/
```

Detailed triage (regression risk + alternatives weighed): see PR-1 of the audit thread.

## What could break

- **RSC content-type change.** Browsers / RSC clients that previously got HTML at `/admin/traces/<id>.txt` (greedy `{trace_id}` route absorbing `.txt`) now get `text/x-component`. This is the correct behavior; old "200 OK" was an accident. No tests pinned the old behavior.
- **Missing `index.txt` in the static export** would now surface as 404 instead of a silent HTML fallback. Intentional — that's a broken build, not a fallback we should paper over.
- **Link prefix flip** changes the URL the dashboard nav points to. The destinations (`/admin/traces/`, `/admin/logs/`) already exist (Traces) or are documented as runtime-404 deferred features (Logs).

## Test plan

- [x] 9 new unit tests in `tests/unit/test_trace_spa_rewrite.py` cover: HTML shell (both slash forms), RSC payload (both forms), RSC query-string pass-through, `__trace__` placeholder → 410 (both forms), missing-RSC build → 404, legacy `__trace__/` directory fallback.
- [x] `uv run pytest libs/idun_agent_standalone/tests/unit` — all pass.
- [x] `ruff check` — clean.
- [x] `pnpm typecheck` on the UI — clean.
- [ ] Manual: rebuild + reinstall the wheel in `~/Downloads/test-idun-standalone/`, navigate `/admin/traces` → click a trace → click between spans. Network panel should show **zero** repeats of `runtime-config.js` / `auth/me` after the first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin dashboard and command palette now route to admin-scoped traces/logs pages.
  * Trace detail endpoints now reliably return correct status codes: placeholder trace IDs return 410, missing component payloads return 404, and RSC payloads are served with the proper content type and precedence over HTML shells.

* **Tests**
  * Added end-to-end unit tests validating HTML shell routing, RSC payload serving, query-token forwarding, placeholder handling, legacy directory support, and failure behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/619)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->