### PR TITLE
fix(ui): auto-refresh history sidebar after a run and sort newest first

### DIFF
--- a/services/idun_agent_standalone_ui/__tests__/use-chat.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/use-chat.test.ts
@@ -1,6 +1,30 @@
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  renderHook as rtlRenderHook,
+  type RenderHookOptions,
+  act,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { AGUIEvent, RunOptions } from "@/lib/agui";
+
+// useChat now calls useQueryClient (so it can invalidate the
+// agent-sessions cache after a run lands). Every renderHook in this
+// file needs a QueryClientProvider in scope; we wrap it transparently
+// via a local renderHook helper so the existing call sites stay short.
+function renderHook<TProps, TResult>(
+  callback: (props: TProps) => TResult,
+  options?: Omit<RenderHookOptions<TProps>, "wrapper">,
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  return rtlRenderHook(callback, { ...options, wrapper });
+}
 
 // Mock the agui module so the hook never opens an SSE connection. We hand
 // it back a pending promise so `send()` resolves only when we explicitly

--- a/services/idun_agent_standalone_ui/components/chat/HistorySidebar.tsx
+++ b/services/idun_agent_standalone_ui/components/chat/HistorySidebar.tsx
@@ -90,7 +90,14 @@ export function HistorySidebar({
     enabled: canListHistory,
   });
 
-  const items = data ?? [];
+  // Sort by lastUpdateTime descending so the newest conversation lands at
+  // the top. The engine's /agent/sessions endpoint returns insertion order
+  // (LangGraph checkpointer order), which buries a new row at the bottom.
+  const items = (data ?? []).slice().sort((a, b) => {
+    const ta = a.lastUpdateTime ?? 0;
+    const tb = b.lastUpdateTime ?? 0;
+    return tb - ta;
+  });
 
   const [ssoInfo, setSsoInfo] = useState<SsoInfo | null>(null);
   useEffect(() => {

--- a/services/idun_agent_standalone_ui/lib/use-chat.ts
+++ b/services/idun_agent_standalone_ui/lib/use-chat.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   type AGUIEvent,
@@ -330,6 +331,7 @@ function applyEvent(
 }
 
 export function useChat(threadId: string) {
+  const queryClient = useQueryClient();
   const [messages, setMessages] = useState<Message[]>([]);
   const [events, setEvents] = useState<ChatEvent[]>([]);
   const [status, setStatus] = useState<Status>("idle");
@@ -475,9 +477,20 @@ export function useChat(threadId: string) {
               : m,
           ),
         );
+        // A fresh thread becomes a session row on the backend when the
+        // checkpointer commits the run. The SSE stream sometimes closes
+        // a few ms before that commit lands (especially with aiosqlite
+        // WAL), so a single invalidation here races and the new row is
+        // missing about 5 out of 6 times. Fire one invalidation now and
+        // two retries on a short backoff to cover the commit window.
+        const refreshSessions = () =>
+          queryClient.invalidateQueries({ queryKey: ["agent-sessions"] });
+        refreshSessions();
+        window.setTimeout(refreshSessions, 250);
+        window.setTimeout(refreshSessions, 1000);
       }
     },
-    [threadId],
+    [threadId, queryClient],
   );
 
   const stop = useCallback(() => {


### PR DESCRIPTION
## Summary

Two small UX fixes on the chat history sidebar:

- **Auto-refresh after a run lands.** `useChat`'s `send()` now invalidates the `agent-sessions` query in its `finally`, with two short-backoff retries (250ms, 1s) to cover the window where the SSE stream closes before the LangGraph checkpointer commits the new thread row.
- **Newest first.** `HistorySidebar` sorts by `lastUpdateTime` descending. The engine's `/agent/sessions` endpoint returns insertion order, which buried new conversations at the bottom.

Previously the user had to refresh the page to see a new conversation, and even then it appeared at the bottom of the list.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test -- --run __tests__/use-chat.test.ts` — 10 passed (added a local QueryClientProvider wrapper to renderHook since `useChat` now calls `useQueryClient`).
- [x] Manual: chat in the assistant, observe new conversation appears at the top of the sidebar without a page refresh.

## Notes for reviewers

- Other failing test files on develop (`__tests__/api/client.test.ts`, `__tests__/api/health.test.ts`, `__tests__/api/mcp.test.ts`, `__tests__/api/onboarding.test.ts`) are pre-existing; verified against `origin/develop` before this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat session history is now sorted chronologically, displaying the most recent conversations prominently at the top for convenient access and better organization.

* **Bug Fixes**
  * Session list now automatically refreshes after sending messages to maintain accurate synchronization with the backend.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/621)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->