### PR TITLE
feat(traces): auto-attach Google GenAI instrumentor for Gemini cache-bucket capture

### DIFF
--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -82,6 +82,7 @@ dependencies = [
     "openinference-instrumentation-langchain>=0.1.13,<2.0.0",
     "openinference-instrumentation-vertexai>=0.1.0,<2.0.0",
     "openinference-instrumentation-google-adk>=0.1.0,<2.0.0",
+"openinference-instrumentation-google-genai>=0.1.0,<2.0.0",
     "openinference-instrumentation-mcp>=1.0.0,<2.0.0",
     "opentelemetry-api>=1.30,<2.0",
     "opentelemetry-sdk>=1.30,<2.0",

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/bootstrap.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/bootstrap.py
@@ -172,6 +172,55 @@ async def attach_trace_pipeline(app: FastAPI) -> None:
     app.state.trace_instrumentor_status = instrumentor_status
     app.state.trace_instrumentor_message = instrumentor_message
 
+    # Best-effort Gemini detail capture. ``langchain-google-genai`` (the
+    # path most operators reach Gemini through) doesn't fill OpenInference
+    # ``llm.token_count.prompt_details.cache_read`` / ``.cache_write`` —
+    # see ``infrastructure/traces/_attrs.py`` for the runtime warning.
+    # The dedicated ``openinference-instrumentation-google-genai``
+    # instruments the underlying ``google-genai`` SDK and emits a child
+    # span with the missing detail buckets, giving cost dashboards
+    # accurate cache-hit numbers without operator action.
+    #
+    # Gated on the same OTel-bypassing branch as LangChainInstrumentor:
+    # the GCP Trace / Phoenix handlers install their own instrumentors
+    # and we don't want to double-wrap there. Silent best-effort because
+    # this is enrichment, not a primary capture path — a dep conflict
+    # leaves the existing warning loop intact instead of degrading the
+    # /_health surface.
+    if not providers or all(p in _OTEL_BYPASSING_PROVIDERS for p in providers):
+        try:
+            from openinference.instrumentation.google_genai import (
+                GoogleGenAIInstrumentor,
+            )
+
+            genai_instrumentor = GoogleGenAIInstrumentor()
+            genai_conflict_check = getattr(
+                genai_instrumentor, "_check_dependency_conflicts", None
+            )
+            genai_conflict = (
+                genai_conflict_check() if callable(genai_conflict_check) else None
+            )
+            if genai_conflict is not None:
+                logger.warning(
+                    "trace pipeline: GoogleGenAIInstrumentor dependency "
+                    "conflict — Gemini detail buckets will fall back to "
+                    "the LangChain capture: %s",
+                    genai_conflict,
+                )
+            else:
+                otel_lifecycle.attach_instrumentor(genai_instrumentor)
+                logger.info("trace pipeline: self-installed GoogleGenAIInstrumentor")
+        except ImportError:
+            logger.debug(
+                "trace pipeline: openinference.instrumentation.google_genai not "
+                "installed; Gemini detail buckets unavailable"
+            )
+        except Exception:  # noqa: BLE001 — telemetry must never block
+            logger.exception(
+                "trace pipeline: GoogleGenAIInstrumentor install failed; "
+                "continuing without Gemini detail buckets"
+            )
+
     # 5. Reuse the previously-built exporter when present so its
     #    bounded queue (and any buffered spans) survive reload.
     exporter = getattr(app.state, "trace_exporter", None)

--- a/libs/idun_agent_standalone/tests/integration/test_trace_bootstrap.py
+++ b/libs/idun_agent_standalone/tests/integration/test_trace_bootstrap.py
@@ -188,8 +188,12 @@ async def test_attach_trace_pipeline_surfaces_instrumentor_dependency_conflict(
 
         assert app.state.trace_instrumentor_status == "dependency_conflict"
         assert "langchain_core" in (app.state.trace_instrumentor_message or "")
-        # The bootstrap must skip attach entirely on conflict.
-        assert attach_calls == []
+        # The bootstrap must skip the LangChainInstrumentor attach on
+        # conflict. The Gemini-detail GoogleGenAIInstrumentor runs from
+        # the same gate as a best-effort enrichment; its attach (or
+        # absence in the test env) is independent of the LangChain
+        # conflict so we only assert LangChain wasn't installed.
+        assert not any(isinstance(c, LangChainInstrumentor) for c in attach_calls)
         # Writer + exporter still spawn — the failure is per-instrumentor,
         # not per-pipeline. (Some operator paths run alternative
         # instrumentors via env or observability provider; the writer
@@ -197,6 +201,144 @@ async def test_attach_trace_pipeline_surfaces_instrumentor_dependency_conflict(
         assert isinstance(app.state.trace_exporter, StandaloneSpanExporter)
     finally:
         monkeypatch.setattr(_ol, "attach_instrumentor", original_attach)
+        if getattr(app.state, "trace_writer_task", None) is not None:
+            await app.state.trace_writer_task.stop()
+        if getattr(app.state, "trace_retention_task", None) is not None:
+            await app.state.trace_retention_task.stop()
+
+
+@pytest.mark.asyncio
+async def test_attach_trace_pipeline_attaches_genai_instrumentor_alongside_langchain(
+    sessionmaker_factory, monkeypatch
+):
+    """No-provider case attaches both LangChain and GoogleGenAI instrumentors.
+
+    The Gemini-detail capture relies on the dedicated
+    ``openinference-instrumentation-google-genai`` package wrapping the
+    ``google-genai`` SDK directly — ``langchain-google-genai`` doesn't
+    fill ``llm.token_count.prompt_details.cache_read`` / ``.cache_write``
+    on its own (see ``infrastructure/traces/_attrs.py``). The bootstrap
+    must auto-attach the GenAI instrumentor alongside LangChain so cost
+    dashboards get accurate cache numbers without operator action.
+    """
+    from idun_agent_engine.observability import otel_lifecycle as _ol
+    from openinference.instrumentation.google_genai import GoogleGenAIInstrumentor
+    from openinference.instrumentation.langchain import LangChainInstrumentor
+
+    attach_calls: list[object] = []
+    original_attach = _ol.attach_instrumentor
+
+    def _track(inst):
+        attach_calls.append(inst)
+        original_attach(inst)
+
+    monkeypatch.setattr(_ol, "attach_instrumentor", _track)
+
+    app = FastAPI()
+    app.state.sessionmaker = sessionmaker_factory
+    app.state.engine_config = None  # no provider → self-install path
+
+    try:
+        await attach_trace_pipeline(app)
+
+        assert any(
+            isinstance(c, LangChainInstrumentor) for c in attach_calls
+        ), f"LangChain instrumentor missing from {attach_calls}"
+        assert any(
+            isinstance(c, GoogleGenAIInstrumentor) for c in attach_calls
+        ), f"GenAI instrumentor missing from {attach_calls}"
+    finally:
+        if getattr(app.state, "trace_writer_task", None) is not None:
+            await app.state.trace_writer_task.stop()
+        if getattr(app.state, "trace_retention_task", None) is not None:
+            await app.state.trace_retention_task.stop()
+
+
+@pytest.mark.asyncio
+async def test_attach_trace_pipeline_skips_genai_when_otel_provider_active(
+    sessionmaker_factory, monkeypatch
+):
+    """Active OTel-installing provider (Phoenix/GCP) skips self-install path.
+
+    Those provider handlers already register their own instrumentors;
+    self-installing both LangChain and GoogleGenAI on top would create
+    duplicate spans. The gate is the same as the existing LangChain
+    self-install — we just verify GenAI honours it too.
+    """
+    from idun_agent_engine.observability import otel_lifecycle as _ol
+    from openinference.instrumentation.google_genai import GoogleGenAIInstrumentor
+    from openinference.instrumentation.langchain import LangChainInstrumentor
+
+    attach_calls: list[object] = []
+    monkeypatch.setattr(
+        _ol, "attach_instrumentor", lambda inst: attach_calls.append(inst)
+    )
+
+    class _ObservabilityEntry:
+        enabled = True
+        provider = "PHOENIX"  # not in _OTEL_BYPASSING_PROVIDERS
+
+    class _Cfg:
+        observability = [_ObservabilityEntry()]
+
+    app = FastAPI()
+    app.state.sessionmaker = sessionmaker_factory
+    app.state.engine_config = _Cfg()
+
+    try:
+        await attach_trace_pipeline(app)
+
+        assert not any(
+            isinstance(c, LangChainInstrumentor) for c in attach_calls
+        ), "LangChain attached despite Phoenix provider being active"
+        assert not any(
+            isinstance(c, GoogleGenAIInstrumentor) for c in attach_calls
+        ), "GenAI attached despite Phoenix provider being active"
+    finally:
+        if getattr(app.state, "trace_writer_task", None) is not None:
+            await app.state.trace_writer_task.stop()
+        if getattr(app.state, "trace_retention_task", None) is not None:
+            await app.state.trace_retention_task.stop()
+
+
+@pytest.mark.asyncio
+async def test_attach_trace_pipeline_handles_genai_dep_conflict(
+    sessionmaker_factory, monkeypatch, caplog
+):
+    """GenAI dep conflict logs a warning but never blocks the pipeline.
+
+    Best-effort enrichment: a conflict on the optional GenAI
+    instrumentor must not flip the primary ``trace_instrumentor_status``
+    (LangChain remains the source-of-truth for /_health) and must not
+    surface to the operator dashboard.
+    """
+    from openinference.instrumentation.google_genai import GoogleGenAIInstrumentor
+
+    fake_conflict = "requested: google-genai>=1.0 but found: google-genai 0.5.0"
+    monkeypatch.setattr(
+        GoogleGenAIInstrumentor,
+        "_check_dependency_conflicts",
+        lambda self: fake_conflict,
+        raising=False,
+    )
+
+    app = FastAPI()
+    app.state.sessionmaker = sessionmaker_factory
+    app.state.engine_config = None
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            await attach_trace_pipeline(app)
+
+        # LangChain still attached cleanly — its health field reflects that.
+        assert app.state.trace_instrumentor_status == "ok"
+        # The GenAI conflict surfaced as a warning log, not as an error
+        # that affects the primary status surface.
+        assert any(
+            "GoogleGenAIInstrumentor dependency conflict" in rec.message
+            for rec in caplog.records
+        ), "expected GenAI conflict warning to be logged"
+    finally:
         if getattr(app.state, "trace_writer_task", None) is not None:
             await app.state.trace_writer_task.stop()
         if getattr(app.state, "trace_retention_task", None) is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -1754,6 +1754,7 @@ dependencies = [
     { name = "mcp" },
     { name = "openinference-instrumentation" },
     { name = "openinference-instrumentation-google-adk" },
+    { name = "openinference-instrumentation-google-genai" },
     { name = "openinference-instrumentation-guardrails" },
     { name = "openinference-instrumentation-langchain" },
     { name = "openinference-instrumentation-mcp" },
@@ -1831,6 +1832,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0.0,<2.0.0" },
     { name = "openinference-instrumentation", specifier = ">=0.1.0,<2.0.0" },
     { name = "openinference-instrumentation-google-adk", specifier = ">=0.1.0,<2.0.0" },
+    { name = "openinference-instrumentation-google-genai", specifier = ">=0.1.0,<2.0.0" },
     { name = "openinference-instrumentation-guardrails", specifier = ">=0.1.0,<2.0.0" },
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.13,<2.0.0" },
     { name = "openinference-instrumentation-mcp", specifier = ">=1.0.0,<2.0.0" },
@@ -2858,6 +2860,23 @@ wheels = [
 ]
 
 [[package]]
+name = "openinference-instrumentation-google-genai"
+version = "0.1.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/99/af8bf7da3e261ead43cc3e481cd56963118b5d106353e48af1721b419eeb/openinference_instrumentation_google_genai-0.1.16.tar.gz", hash = "sha256:dae3b9ae128be86fa3cc2bac94bbf41391fb7d20936aefb296ec0594707e77c5", size = 146916, upload-time = "2026-04-22T00:39:25.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/69/3283ee2ddbd1a5f9fe733c55a57c37c66e6b710e23ccb0c88f74cc011632/openinference_instrumentation_google_genai-0.1.16-py3-none-any.whl", hash = "sha256:1ee1ec5f9735f4cacff57ceb8bdf6116e95066b008e903140d5c538429c27474", size = 31579, upload-time = "2026-04-22T00:39:23.984Z" },
+]
+
+[[package]]
 name = "openinference-instrumentation-guardrails"
 version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
@@ -2945,11 +2964,11 @@ wheels = [
 
 [[package]]
 name = "openinference-semantic-conventions"
-version = "0.1.27"
+version = "0.1.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b4/cf/7c0ea344b99ecdb9f55cb5287ecb6a6ad68e6098df32728691fa7846f112/openinference_semantic_conventions-0.1.27.tar.gz", hash = "sha256:db0b1bbc1cd66f8108b17f972976fa1833413a01967ff930e2707a77e0f66bd3", size = 12744, upload-time = "2026-03-04T08:38:56.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/6b/9ed67f9ce8c92436b297207abde730800b00bdec7e114f71b8dfe91cd26b/openinference_semantic_conventions-0.1.29.tar.gz", hash = "sha256:bbeb6472777a45a574169894bb9c4d80c6832a8befd32ab238cb875438ce1044", size = 12959, upload-time = "2026-04-22T00:39:27.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/b4/1c218ed1e68c8fbd68f37258ce40f908cdad86ee9d38b12c48c9e4c4e030/openinference_semantic_conventions-0.1.27-py3-none-any.whl", hash = "sha256:3871fd2cc9d203bdb444ab66ff2ba9bdbf1013dc48c64c5700dd449d47b338c5", size = 10430, upload-time = "2026-03-04T08:38:56.166Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/45ad1b95315b5563baa7338c8e8088bb1af66905c46e1bd1fe6ecbe30ea8/openinference_semantic_conventions-0.1.29-py3-none-any.whl", hash = "sha256:f45e0b1cf79fe407af4722bcf391a01565f0878c95be3ebcc9382245d0367cc5", size = 10582, upload-time = "2026-04-22T00:39:27.066Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the Gemini-detail capture gap surfaced by the `_attrs.py` warning:

```
WARNI [idun_agent_standalone.infrastructure.traces._attrs] Gemini span captured via langchain-google-genai has no detail buckets; recommend openinference-instrumentation-google-genai for richer capture
```

`langchain-google-genai` (the path most operators reach Gemini through) doesn't fill OpenInference `llm.token_count.prompt_details.cache_read` / `.cache_write`. The dedicated `openinference-instrumentation-google-genai` instrumentor wraps the underlying `google-genai` SDK and emits a child span with the missing buckets. This PR ships the dep and auto-attaches the instrumentor in the same OTel-bypassing self-install gate as `LangChainInstrumentor`, so cost dashboards get accurate cache numbers without operator action.

## Design

- **Dep**: `openinference-instrumentation-google-genai>=0.1.0,<2.0.0` added to `libs/idun_agent_engine/pyproject.toml`. uv.lock regenerated (pulls v0.1.16 + bumps `openinference-semantic-conventions` 0.1.27 → 0.1.29 transitively).
- **Gate**: same `_OTEL_BYPASSING_PROVIDERS` branch as the existing `LangChainInstrumentor` self-install — fires when no observability provider is configured OR only Langfuse/LangSmith are active. Phoenix and GCP Trace install their own instrumentors and would double-wrap, so they correctly skip.
- **Best-effort**: a dep conflict or missing install logs at warning/debug but does **not** flip the primary `trace_instrumentor_status` field that drives `/_health`. LangChain remains the source-of-truth for the operator dashboard; GenAI is enrichment.
- **Double-instrumentation**: LangChain wraps the LangChain API call, GenAI wraps the inner `google-genai` SDK call. The two spans nest (parent: LangChain LLM span, child: GenAI generation span). The detail buckets land on the child where they were missing before.

## What could break

- **Phoenix / GCP Trace users**: no behavior change — those providers fall outside the `_OTEL_BYPASSING_PROVIDERS` gate and the GenAI self-install branch is skipped.
- **Operators with a `google-genai` version conflict against the instrumentor**: same fallback as before (Gemini calls captured via LangChain only, the `_attrs.py` warning continues to fire). Logged at WARNING; no engine boot regression.
- **Install footprint**: one additional dep on the engine wheel.

## Test plan

- [x] 3 new integration tests added to `test_trace_bootstrap.py`:
  - `test_attach_trace_pipeline_attaches_genai_instrumentor_alongside_langchain` — happy path
  - `test_attach_trace_pipeline_skips_genai_when_otel_provider_active` — Phoenix provider blocks self-install
  - `test_attach_trace_pipeline_handles_genai_dep_conflict` — dep conflict logs warning, doesn't break LangChain status
- [x] Existing dep-conflict test (`test_attach_trace_pipeline_surfaces_instrumentor_dependency_conflict`) updated to allow the new GenAI attach call when LangChain has a conflict (the gate runs both branches independently).
- [x] `uv run pytest libs/idun_agent_standalone/tests/integration -k trace` — 31/31 pass.
- [x] `ruff check` — clean.
- [ ] Manual: rebuild the wheel + reinstall in a test env running an ADK+Gemini agent. Watch the trace pipeline — the warning at `_attrs.py:42` should stop firing (or fire only on first-call edge cases), and cost dashboards should populate cache-bucket columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability and tracing support for Google Gemini API calls through automatic instrumentation.
  * Implemented graceful error handling to ensure trace pipeline initialization completes successfully even when dependencies are unavailable or conflicting.

* **Tests**
  * Added integration tests to verify correct instrumentation attachment behavior across different observability configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/622)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->