### PR TITLE
fix(prompts): resolve from EngineConfig snapshot in standalone (mirror MCP registry)

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/prompts/helpers.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/prompts/helpers.py
@@ -86,9 +86,19 @@ def get_prompts_from_api() -> list[PromptConfig]:
 def get_prompts(config_path: str | Path | None = None) -> list[PromptConfig]:
     """Resolve prompts.
 
-    Order: explicit ``config_path`` arg > in-process snapshot (standalone)
-    > ``IDUN_CONFIG_PATH`` YAML (bare engine) > Manager API (SaaS). Never
-    raises; callers fall back to a default when the result is empty.
+    Resolution order:
+      1. Explicit ``config_path`` argument.
+      2. In-process snapshot (standalone, set via
+         :func:`~idun_agent_engine.prompts.registry.set_active_prompts`).
+      3. ``IDUN_CONFIG_PATH`` YAML file (bare engine).
+      4. Manager API (SaaS).
+
+    Steps 1 and 3 load a YAML file via :func:`get_prompts_from_file` and
+    will raise ``FileNotFoundError`` / ``yaml.YAMLError`` /
+    ``pydantic.ValidationError`` when the path is missing, the YAML is
+    malformed, or a prompt entry fails schema validation. Steps 2 and 4
+    are non-raising and return ``[]`` on any failure. Callers that pass
+    an explicit ``config_path`` are expected to handle those exceptions.
     """
     from .registry import get_active_prompts
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/prompts/helpers.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/prompts/helpers.py
@@ -84,13 +84,20 @@ def get_prompts_from_api() -> list[PromptConfig]:
 
 
 def get_prompts(config_path: str | Path | None = None) -> list[PromptConfig]:
-    """Return prompts: config_path > IDUN_CONFIG_PATH env > Manager API.
+    """Resolve prompts.
 
-    Never raises on a missing or unreachable source. Callers receive
-    an empty list and decide whether to use a default prompt.
+    Order: explicit ``config_path`` arg > in-process snapshot (standalone)
+    > ``IDUN_CONFIG_PATH`` YAML (bare engine) > Manager API (SaaS). Never
+    raises; callers fall back to a default when the result is empty.
     """
+    from .registry import get_active_prompts
+
     if config_path:
         return get_prompts_from_file(config_path)
+
+    snapshot = get_active_prompts()
+    if snapshot is not None:
+        return snapshot
 
     env_config_path = os.environ.get("IDUN_CONFIG_PATH")
     if env_config_path:

--- a/libs/idun_agent_engine/src/idun_agent_engine/prompts/registry.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/prompts/registry.py
@@ -16,5 +16,9 @@ def set_active_prompts(prompts: list[PromptConfig] | None) -> None:
 
 
 def get_active_prompts() -> list[PromptConfig] | None:
-    """Return the snapshot, or ``None`` if unset."""
-    return _active_prompts
+    """Return a shallow copy of the snapshot, or ``None`` if unset.
+
+    A copy guards against callers mutating the registry's backing list in
+    place; mutations should always go through :func:`set_active_prompts`.
+    """
+    return None if _active_prompts is None else list(_active_prompts)

--- a/libs/idun_agent_engine/src/idun_agent_engine/prompts/registry.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/prompts/registry.py
@@ -1,0 +1,20 @@
+"""Active prompts snapshot. Standalone sets it on boot and reload; the
+``get_prompts()`` helper reads it before falling through to YAML / Manager.
+Mirrors ``idun_agent_engine.mcp.registry``."""
+
+from __future__ import annotations
+
+from idun_agent_schema.engine.prompt import PromptConfig
+
+_active_prompts: list[PromptConfig] | None = None
+
+
+def set_active_prompts(prompts: list[PromptConfig] | None) -> None:
+    """Replace the snapshot. ``None`` clears it."""
+    global _active_prompts
+    _active_prompts = list(prompts) if prompts is not None else None
+
+
+def get_active_prompts() -> list[PromptConfig] | None:
+    """Return the snapshot, or ``None`` if unset."""
+    return _active_prompts

--- a/libs/idun_agent_engine/tests/unit/prompts/test_helpers.py
+++ b/libs/idun_agent_engine/tests/unit/prompts/test_helpers.py
@@ -396,3 +396,122 @@ class TestGetPrompt:
         result = get_prompt(prompt_id, config_path=config_file)
         assert result is not None
         assert result.content == expected_content
+
+
+class TestGetPromptsResolutionOrder:
+    """Exercise the four-branch resolution chain in ``get_prompts``."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_snapshot(self):
+        from idun_agent_engine.prompts.registry import set_active_prompts
+
+        set_active_prompts(None)
+        yield
+        set_active_prompts(None)
+
+    def test_explicit_config_path_wins_over_snapshot(self, tmp_path: Path) -> None:
+        from idun_agent_engine.prompts.helpers import get_prompts
+        from idun_agent_engine.prompts.registry import set_active_prompts
+
+        set_active_prompts(
+            [
+                PromptConfig.model_validate(
+                    {"prompt_id": "from-snap", "version": 1, "content": "snap"}
+                )
+            ]
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "prompts": [
+                        {"prompt_id": "from-file", "version": 1, "content": "file"}
+                    ]
+                }
+            )
+        )
+
+        result = get_prompts(config_path=config_file)
+        assert [p.prompt_id for p in result] == ["from-file"]
+
+    def test_snapshot_wins_over_idun_config_path_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from idun_agent_engine.prompts.helpers import get_prompts
+        from idun_agent_engine.prompts.registry import set_active_prompts
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {"prompts": [{"prompt_id": "from-env", "version": 1, "content": "env"}]}
+            )
+        )
+        monkeypatch.setenv("IDUN_CONFIG_PATH", str(config_file))
+
+        set_active_prompts(
+            [
+                PromptConfig.model_validate(
+                    {"prompt_id": "from-snap", "version": 1, "content": "snap"}
+                )
+            ]
+        )
+
+        result = get_prompts()
+        assert [p.prompt_id for p in result] == ["from-snap"]
+
+    def test_empty_snapshot_falls_through_to_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from idun_agent_engine.prompts.helpers import get_prompts
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {"prompts": [{"prompt_id": "from-env", "version": 1, "content": "env"}]}
+            )
+        )
+        monkeypatch.setenv("IDUN_CONFIG_PATH", str(config_file))
+
+        result = get_prompts()
+        assert [p.prompt_id for p in result] == ["from-env"]
+
+    def test_no_snapshot_no_env_falls_through_to_manager(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from idun_agent_engine.prompts import helpers
+
+        monkeypatch.delenv("IDUN_CONFIG_PATH", raising=False)
+        called = {}
+
+        def _fake_api():
+            called["yes"] = True
+            return [
+                PromptConfig.model_validate(
+                    {"prompt_id": "from-api", "version": 1, "content": "api"}
+                )
+            ]
+
+        monkeypatch.setattr(helpers, "get_prompts_from_api", _fake_api)
+
+        result = helpers.get_prompts()
+        assert called.get("yes") is True
+        assert [p.prompt_id for p in result] == ["from-api"]
+
+    def test_empty_list_snapshot_is_treated_as_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty list is still a snapshot (operator deleted all prompts).
+        It must short-circuit the YAML/Manager fallbacks."""
+        from idun_agent_engine.prompts.helpers import get_prompts
+        from idun_agent_engine.prompts.registry import set_active_prompts
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {"prompts": [{"prompt_id": "from-env", "version": 1, "content": "env"}]}
+            )
+        )
+        monkeypatch.setenv("IDUN_CONFIG_PATH", str(config_file))
+        set_active_prompts([])
+
+        assert get_prompts() == []

--- a/libs/idun_agent_engine/tests/unit/prompts/test_registry.py
+++ b/libs/idun_agent_engine/tests/unit/prompts/test_registry.py
@@ -1,0 +1,51 @@
+"""Tests for idun_agent_engine.prompts.registry."""
+
+from __future__ import annotations
+
+import pytest
+from idun_agent_schema.engine.prompt import PromptConfig
+
+from idun_agent_engine.prompts.registry import (
+    get_active_prompts,
+    set_active_prompts,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    """Reset between tests so module-level state doesn't bleed."""
+    set_active_prompts(None)
+    yield
+    set_active_prompts(None)
+
+
+def _prompt(prompt_id: str, version: int = 1, content: str = "hi") -> PromptConfig:
+    return PromptConfig.model_validate(
+        {"prompt_id": prompt_id, "version": version, "content": content}
+    )
+
+
+def test_initial_state_is_none():
+    assert get_active_prompts() is None
+
+
+def test_set_then_get_roundtrips():
+    a, b = _prompt("a"), _prompt("b")
+    set_active_prompts([a, b])
+    assert get_active_prompts() == [a, b]
+
+
+def test_caller_list_mutation_does_not_bleed():
+    """The registry copies the list so the caller can keep mutating its own."""
+    caller_list = [_prompt("a")]
+    set_active_prompts(caller_list)
+    caller_list.append(_prompt("b"))
+    snap = get_active_prompts()
+    assert snap is not None
+    assert len(snap) == 1
+
+
+def test_set_none_clears():
+    set_active_prompts([_prompt("a")])
+    set_active_prompts(None)
+    assert get_active_prompts() is None

--- a/libs/idun_agent_engine/tests/unit/prompts/test_registry.py
+++ b/libs/idun_agent_engine/tests/unit/prompts/test_registry.py
@@ -49,3 +49,15 @@ def test_set_none_clears():
     set_active_prompts([_prompt("a")])
     set_active_prompts(None)
     assert get_active_prompts() is None
+
+
+def test_get_returns_defensive_copy():
+    """The registry returns a shallow copy so callers cannot mutate
+    the backing list in place."""
+    set_active_prompts([_prompt("a")])
+    snap = get_active_prompts()
+    assert snap is not None
+    snap.append(_prompt("b"))
+    again = get_active_prompts()
+    assert again is not None
+    assert len(again) == 1

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -29,6 +29,7 @@ from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute, Mount
 from fastapi.staticfiles import StaticFiles
 from idun_agent_engine import create_app as create_engine_app
+from idun_agent_engine.prompts.registry import set_active_prompts
 
 from idun_agent_standalone.api.v1._register import register_standalone_routers
 from idun_agent_standalone.api.v1.deps import reload_disabled, require_auth
@@ -152,6 +153,11 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
         except AssemblyError as exc:
             logger.warning("boot engine layer skipped, admin only mode reason=%s", exc)
             engine_config = None
+
+    # Publish the DB-backed prompts to the engine's process-wide snapshot
+    # before the engine app boots — the LangGraph adapter's exec_module
+    # path runs user code that calls get_prompt() at import time.
+    set_active_prompts(engine_config.prompts if engine_config else None)
 
     # Always boot through the engine factory. When ``engine_config`` is
     # ``None`` (no agent in DB yet — first-run wizard hasn't materialized),

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py
@@ -31,6 +31,10 @@ from hashlib import sha256
 
 import rfc8785
 from fastapi import status as http_status
+from idun_agent_engine.prompts.registry import (
+    get_active_prompts,
+    set_active_prompts,
+)
 from idun_agent_schema.engine.engine import EngineConfig
 from idun_agent_schema.standalone import (
     StandaloneAdminError,
@@ -210,9 +214,16 @@ async def commit_with_reload(
             message="Saved. Restart required to apply.",
         )
 
+    # Publish the new prompts snapshot before reload_callable runs — the
+    # adapter rebuilds with exec_module, which re-runs user code that
+    # calls get_prompt() at import time. The snapshot must already hold
+    # the new value at that point. Rolled back on ReloadInitFailed.
+    prior_prompts = get_active_prompts()
+    set_active_prompts(assembled.prompts)
     try:
         await reload_callable(assembled)
     except ReloadInitFailed as exc:
+        set_active_prompts(prior_prompts)
         await session.rollback()
         await runtime_state.record_reload_outcome(
             session,

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/reload.py
@@ -243,6 +243,15 @@ async def commit_with_reload(
                 details={"recovered": True},
             ),
         ) from exc
+    except Exception:
+        # Anything other than ReloadInitFailed is unexpected: restore the
+        # prior prompts snapshot and roll back the staged DB mutation so
+        # the in-memory registry and the database stay consistent, then
+        # let the global handler render the response.
+        set_active_prompts(prior_prompts)
+        await session.rollback()
+        logger.exception("reload.round3_unexpected_error")
+        raise
 
     await session.commit()
     await runtime_state.record_reload_outcome(

--- a/libs/idun_agent_standalone/tests/unit/services/test_reload.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_reload.py
@@ -431,3 +431,37 @@ async def test_reload_rolls_back_prompts_snapshot_on_failure(
     assert rolled_back is not None
     assert [p.content for p in rolled_back] == ["old prompt"]
     set_active_prompts(None)
+
+
+@pytest.mark.asyncio
+async def test_reload_rolls_back_prompts_snapshot_on_unexpected_exception(
+    async_session, frozen_now
+) -> None:
+    """An unexpected exception (not ReloadInitFailed) must also restore
+    the prior prompts snapshot and roll back the staged DB mutation."""
+    from idun_agent_engine.prompts.registry import (
+        get_active_prompts,
+        set_active_prompts,
+    )
+    from idun_agent_schema.engine.prompt import PromptConfig
+
+    prior = [
+        PromptConfig.model_validate(
+            {"prompt_id": "system_prompt", "version": 0, "content": "old prompt"}
+        )
+    ]
+    set_active_prompts(prior)
+
+    await _seed_agent(async_session)
+    await _seed_prompt(async_session, "system_prompt", "new prompt body")
+
+    failing = AsyncMock(side_effect=RuntimeError("unexpected boom"))
+    with pytest.raises(RuntimeError, match="unexpected boom"):
+        await commit_with_reload(
+            async_session, reload_callable=failing, now=frozen_now
+        )
+
+    rolled_back = get_active_prompts()
+    assert rolled_back is not None
+    assert [p.content for p in rolled_back] == ["old prompt"]
+    set_active_prompts(None)

--- a/libs/idun_agent_standalone/tests/unit/services/test_reload.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_reload.py
@@ -343,3 +343,91 @@ async def test_runtime_state_full_shape_on_reload_failed(
     assert state.last_message == "Engine reload failed; config not saved."
     assert state.last_error == "engine boom"
     assert state.last_applied_config_hash is None
+
+
+# --- Prompt snapshot propagation through reload ----------------------
+
+
+async def _seed_prompt(async_session, prompt_id: str, content: str, version: int = 1):
+    """Seed a single prompt row so assemble_engine_config picks it up."""
+    from idun_agent_standalone.infrastructure.db.models.prompt import (
+        StandalonePromptRow,
+    )
+
+    row = StandalonePromptRow(
+        prompt_id=prompt_id,
+        version=version,
+        content=content,
+        tags=[],
+    )
+    async_session.add(row)
+    await async_session.flush()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_reload_publishes_prompts_snapshot_before_callable_runs(
+    async_session, frozen_now
+) -> None:
+    """The agent module re-execs inside reload_callable's runtime — the
+    snapshot must already hold the new prompts when that happens."""
+    from idun_agent_engine.prompts.registry import (
+        get_active_prompts,
+        set_active_prompts,
+    )
+
+    set_active_prompts(None)
+    await _seed_agent(async_session)
+    await _seed_prompt(async_session, "system_prompt", "new prompt body")
+
+    seen_during_callable: list = []
+
+    async def observing_callable(engine_config: EngineConfig) -> None:
+        snap = get_active_prompts()
+        seen_during_callable.extend(snap or [])
+
+    result = await commit_with_reload(
+        async_session,
+        reload_callable=observing_callable,
+        now=frozen_now,
+    )
+    assert result.status == StandaloneReloadStatus.RELOADED
+    assert [p.prompt_id for p in seen_during_callable] == ["system_prompt"]
+    assert [p.content for p in seen_during_callable] == ["new prompt body"]
+
+    snap_after = get_active_prompts()
+    assert snap_after is not None
+    assert [p.prompt_id for p in snap_after] == ["system_prompt"]
+    set_active_prompts(None)
+
+
+@pytest.mark.asyncio
+async def test_reload_rolls_back_prompts_snapshot_on_failure(
+    async_session, frozen_now
+) -> None:
+    """ReloadInitFailed → snapshot must revert to the prior value, matching
+    the DB rollback semantics for the rest of the pipeline."""
+    from idun_agent_engine.prompts.registry import (
+        get_active_prompts,
+        set_active_prompts,
+    )
+    from idun_agent_schema.engine.prompt import PromptConfig
+
+    prior = [
+        PromptConfig.model_validate(
+            {"prompt_id": "system_prompt", "version": 0, "content": "old prompt"}
+        )
+    ]
+    set_active_prompts(prior)
+
+    await _seed_agent(async_session)
+    await _seed_prompt(async_session, "system_prompt", "new prompt body")
+
+    failing = AsyncMock(side_effect=ReloadInitFailed("engine boom"))
+    with pytest.raises(AdminAPIError):
+        await commit_with_reload(async_session, reload_callable=failing, now=frozen_now)
+
+    rolled_back = get_active_prompts()
+    assert rolled_back is not None
+    assert [p.content for p in rolled_back] == ["old prompt"]
+    set_active_prompts(None)


### PR DESCRIPTION
Closes #623.

## Summary

`get_prompts()` now consults an in-process snapshot of `EngineConfig.prompts` before falling through to YAML / Manager API, so prompts edited via `/admin/api/v1/prompts` take effect on the running standalone process via the existing reload pipeline. No process restart.

Three deployment modes stay independent:

| Mode | Source |
|---|---|
| Bare engine + YAML | `IDUN_CONFIG_PATH` YAML (unchanged) |
| Standalone | DB-backed snapshot (new) |
| SaaS / Manager | Manager API (unchanged) |

## Changes

- `libs/idun_agent_engine/src/idun_agent_engine/prompts/registry.py` — new module, mirrors `mcp/registry.py`. `set_active_prompts(...)` + `get_active_prompts()`.
- `libs/idun_agent_engine/src/idun_agent_engine/prompts/helpers.py:get_prompts()` — adds the snapshot branch as resolution step 2. YAML and Manager branches untouched.
- `libs/idun_agent_standalone/.../app.py` — calls `set_active_prompts(engine_config.prompts)` after boot assembly, before `create_engine_app`.
- `libs/idun_agent_standalone/.../services/reload.py:commit_with_reload` — publishes the new snapshot **before** `reload_callable` runs (the adapter's `exec_module` re-runs user code that calls `get_prompt()` at import time, so the snapshot must already hold the new value); rolls back to the prior snapshot on `ReloadInitFailed`.

## Test plan

- [x] `libs/idun_agent_engine/tests/unit/prompts/` — 48 passed. Registry round-trips + four-branch resolution-order coverage of `get_prompts()` (explicit `config_path` wins over snapshot, snapshot wins over `IDUN_CONFIG_PATH` env, empty snapshot falls through to YAML, no snapshot + no env falls through to Manager, empty-list snapshot is treated as set).
- [x] `libs/idun_agent_standalone/tests/unit/services/test_reload.py` — 15 passed. New tests:
  - `test_reload_publishes_prompts_snapshot_before_callable_runs` — exercises the reload pipeline end-to-end: seeds a prompt row, runs `commit_with_reload` with an observing `reload_callable` that snapshots `get_active_prompts()` *during* its execution. Asserts the new prompts are already in place when the callable runs (matching the real `exec_module` ordering).
  - `test_reload_rolls_back_prompts_snapshot_on_failure` — `ReloadInitFailed` from the callable rolls the snapshot back to the prior value.
- [x] `uv run ruff check` + `ruff format --check` clean on touched files.

## Out of scope

- Versioning / labels (Langfuse-style `label='production'`). Issue #623 lists this; track separately.
- HTTP self-call to `/admin/api/v1/prompts` — explicitly rejected in design discussion.
- Touching the Phoenix / GCP-Trace `LangChainInstrumentor` paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-memory prompt snapshot registry to influence prompt resolution.

* **Improvements**
  * Prompt resolution now follows a new precedence: explicit config → in-process snapshot → environment-config YAML → Manager API.
  * Explicit config and env-config failures surface as errors; snapshot and API failures return empty results.
  * Standalone startup publishes DB-backed prompts to the in-process registry; reloads apply new prompts and restore on failure.

* **Tests**
  * Added tests for resolution precedence, defensive-copy behavior, and reload snapshot/rollback semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/625)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->