### PR TITLE
fix(ui): tool calls render args + result instead of "null" (#629 workarounds)

### DIFF
--- a/services/idun_agent_standalone_ui/__tests__/copy-button.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/copy-button.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CopyButton } from "@/components/common/CopyButton";
+
+describe("CopyButton", () => {
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("copies a string value verbatim", () => {
+    render(<CopyButton value="hello" />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("pretty-prints an object value", () => {
+    render(<CopyButton value={{ a: 1 }} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      JSON.stringify({ a: 1 }, null, 2),
+    );
+  });
+
+  it("falls back to String(...) when JSON.stringify returns undefined", () => {
+    render(<CopyButton value={undefined} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("undefined");
+  });
+
+  it("falls back to String(...) when JSON.stringify throws (circular ref)", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    render(<CopyButton value={circular} />);
+    expect(() => fireEvent.click(screen.getByRole("button"))).not.toThrow();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    const argument = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0];
+    expect(typeof argument).toBe("string");
+  });
+
+  it("falls back to String(...) when JSON.stringify throws (BigInt)", () => {
+    render(<CopyButton value={1n} />);
+    expect(() => fireEvent.click(screen.getByRole("button"))).not.toThrow();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("1");
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/copy-button.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/copy-button.test.tsx
@@ -4,7 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CopyButton } from "@/components/common/CopyButton";
 
 describe("CopyButton", () => {
-  const originalClipboard = navigator.clipboard;
+  // Capture the full property descriptor (not just the value) so the
+  // afterEach restore preserves getter/setter semantics that jsdom may
+  // set up for `navigator.clipboard`. Replacing only `.value` would
+  // leak a modified data descriptor across tests.
+  const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    "clipboard",
+  );
 
   beforeEach(() => {
     Object.defineProperty(navigator, "clipboard", {
@@ -14,10 +21,15 @@ describe("CopyButton", () => {
   });
 
   afterEach(() => {
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: originalClipboard,
-    });
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(
+        navigator,
+        "clipboard",
+        originalClipboardDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
     vi.restoreAllMocks();
   });
 

--- a/services/idun_agent_standalone_ui/__tests__/use-chat.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/use-chat.test.ts
@@ -446,4 +446,194 @@ describe("useChat", () => {
       expect(assistant.text).toBe("streamed answer");
     }
   });
+
+  it("captures tool result from TOOL_CALL_RESULT and leaves END alone empty", async () => {
+    // Regression: earlier builds fabricated `result: "null"` from a
+    // missing TOOL_CALL_END.result, causing every tool call to render
+    // a `null` body. ag_ui_langgraph actually emits the result on a
+    // separate TOOL_CALL_RESULT event with the real content.
+    const { runAgent } = await import("@/lib/agui");
+    const { useChat } = await import("@/lib/use-chat");
+
+    const script: AGUIEvent[] = [
+      { type: "RUN_STARTED" },
+      {
+        type: "TOOL_CALL_START",
+        toolCallId: "tc-1",
+        toolCallName: "search_idun_platform",
+      },
+      {
+        type: "TOOL_CALL_ARGS",
+        toolCallId: "tc-1",
+        delta: '{"query": "guardrails"}',
+      },
+      { type: "TOOL_CALL_END", toolCallId: "tc-1" },
+      {
+        type: "TOOL_CALL_RESULT",
+        toolCallId: "tc-1",
+        content: "doc body about guardrails",
+      },
+      { type: "RUN_FINISHED" },
+    ];
+
+    (runAgent as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (opts: RunOptions) => {
+        for (const event of script) {
+          opts.onEvent(event);
+        }
+      },
+    );
+
+    const { result } = renderHook(() => useChat("thread-tool"));
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant",
+    );
+    if (assistant && assistant.role === "assistant") {
+      expect(assistant.toolCalls).toHaveLength(1);
+      const tc = assistant.toolCalls[0];
+      expect(tc.id).toBe("tc-1");
+      expect(tc.name).toBe("search_idun_platform");
+      expect(tc.args).toBe('{"query": "guardrails"}');
+      expect(tc.done).toBe(true);
+      expect(tc.result).toBe("doc body about guardrails");
+    }
+  });
+
+  it("workaround #629: extracts args from TOOL_CALL_START rawEvent when no ARGS event follows", async () => {
+    // ag_ui_langgraph emits TOOL_CALL_START and returns without a
+    // TOOL_CALL_ARGS event for Gemini's atomic tool calls. The args sit
+    // on the raw chunk — pull them out at START time so the row body
+    // isn't empty.
+    const { runAgent } = await import("@/lib/agui");
+    const { useChat } = await import("@/lib/use-chat");
+
+    const script: AGUIEvent[] = [
+      { type: "RUN_STARTED" },
+      {
+        type: "TOOL_CALL_START",
+        toolCallId: "tc-atomic",
+        toolCallName: "search_idun_platform",
+        rawEvent: {
+          data: {
+            chunk: {
+              tool_calls: [
+                {
+                  name: "search_idun_platform",
+                  args: { query: "guardrails" },
+                  id: "tc-atomic",
+                },
+              ],
+            },
+          },
+        },
+      },
+      { type: "TOOL_CALL_END", toolCallId: "tc-atomic" },
+      { type: "RUN_FINISHED" },
+    ];
+
+    (runAgent as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (opts: RunOptions) => {
+        for (const event of script) {
+          opts.onEvent(event);
+        }
+      },
+    );
+
+    const { result } = renderHook(() => useChat("thread-atomic"));
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant",
+    );
+    if (assistant && assistant.role === "assistant") {
+      const tc = assistant.toolCalls[0];
+      expect(tc.args).toBe('{"query":"guardrails"}');
+    }
+  });
+
+  it("workaround #629: attaches TOOL_CALL_RESULT to latest unresolved call when ids mismatch", async () => {
+    // ag_ui_langgraph emits TOOL_CALL_RESULT with LangGraph's run_id
+    // as tool_call_id, not the LLM's. Fall back to the most recent
+    // tool call without a result so the content lands somewhere.
+    const { runAgent } = await import("@/lib/agui");
+    const { useChat } = await import("@/lib/use-chat");
+
+    const script: AGUIEvent[] = [
+      { type: "RUN_STARTED" },
+      {
+        type: "TOOL_CALL_START",
+        toolCallId: "llm-id-abc",
+        toolCallName: "search_idun_platform",
+      },
+      { type: "TOOL_CALL_END", toolCallId: "llm-id-abc" },
+      {
+        type: "TOOL_CALL_RESULT",
+        toolCallId: "langgraph-run-xyz",
+        content: "doc body about guardrails",
+      },
+      { type: "RUN_FINISHED" },
+    ];
+
+    (runAgent as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (opts: RunOptions) => {
+        for (const event of script) {
+          opts.onEvent(event);
+        }
+      },
+    );
+
+    const { result } = renderHook(() => useChat("thread-mismatch"));
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant",
+    );
+    if (assistant && assistant.role === "assistant") {
+      const tc = assistant.toolCalls[0];
+      expect(tc.id).toBe("llm-id-abc");
+      expect(tc.result).toBe("doc body about guardrails");
+    }
+  });
+
+  it("leaves result undefined when only TOOL_CALL_END fires (no result event)", async () => {
+    const { runAgent } = await import("@/lib/agui");
+    const { useChat } = await import("@/lib/use-chat");
+
+    const script: AGUIEvent[] = [
+      { type: "RUN_STARTED" },
+      { type: "TOOL_CALL_START", toolCallId: "tc-2", toolCallName: "noop" },
+      { type: "TOOL_CALL_END", toolCallId: "tc-2" },
+      { type: "RUN_FINISHED" },
+    ];
+
+    (runAgent as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (opts: RunOptions) => {
+        for (const event of script) {
+          opts.onEvent(event);
+        }
+      },
+    );
+
+    const { result } = renderHook(() => useChat("thread-noresult"));
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant",
+    );
+    if (assistant && assistant.role === "assistant") {
+      const tc = assistant.toolCalls[0];
+      expect(tc.done).toBe(true);
+      expect(tc.result).toBeUndefined();
+    }
+  });
 });

--- a/services/idun_agent_standalone_ui/__tests__/use-chat.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/use-chat.test.ts
@@ -603,6 +603,96 @@ describe("useChat", () => {
     }
   });
 
+  it("matches the right tool_calls entry by id when a chunk carries multiple tool calls", async () => {
+    // Regression: previously the reducer always read tool_calls[0],
+    // which attached the wrong args when the LLM emitted multiple
+    // parallel tool calls in a single chunk. We now match by id.
+    const { runAgent } = await import("@/lib/agui");
+    const { useChat } = await import("@/lib/use-chat");
+
+    const script: AGUIEvent[] = [
+      { type: "RUN_STARTED" },
+      {
+        type: "TOOL_CALL_START",
+        toolCallId: "tc-second",
+        toolCallName: "lookup_b",
+        rawEvent: {
+          data: {
+            chunk: {
+              tool_calls: [
+                { name: "lookup_a", args: { q: "first" }, id: "tc-first" },
+                { name: "lookup_b", args: { q: "second" }, id: "tc-second" },
+              ],
+            },
+          },
+        },
+      },
+      { type: "TOOL_CALL_END", toolCallId: "tc-second" },
+      { type: "RUN_FINISHED" },
+    ];
+
+    (runAgent as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (opts: RunOptions) => {
+        for (const event of script) {
+          opts.onEvent(event);
+        }
+      },
+    );
+
+    const { result } = renderHook(() => useChat("thread-multi-toolcall"));
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant",
+    );
+    if (assistant && assistant.role === "assistant") {
+      const tc = assistant.toolCalls[0];
+      // Args must come from the entry whose id matched the START event.
+      expect(tc.args).toBe('{"q":"second"}');
+    }
+  });
+
+  it("serialises a structured TOOL_CALL_RESULT.content instead of producing [object Object]", async () => {
+    // Regression: `String(e.content)` coerced object payloads to
+    // "[object Object]" before the row body ever rendered. We now
+    // JSON.stringify non-string content with a defensive fallback.
+    const { runAgent } = await import("@/lib/agui");
+    const { useChat } = await import("@/lib/use-chat");
+
+    const structured = { hits: 2, items: ["a", "b"] };
+    const script: AGUIEvent[] = [
+      { type: "RUN_STARTED" },
+      { type: "TOOL_CALL_START", toolCallId: "tc-3", toolCallName: "search" },
+      { type: "TOOL_CALL_END", toolCallId: "tc-3" },
+      { type: "TOOL_CALL_RESULT", toolCallId: "tc-3", content: structured },
+      { type: "RUN_FINISHED" },
+    ];
+
+    (runAgent as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (opts: RunOptions) => {
+        for (const event of script) {
+          opts.onEvent(event);
+        }
+      },
+    );
+
+    const { result } = renderHook(() => useChat("thread-structured-result"));
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant",
+    );
+    if (assistant && assistant.role === "assistant") {
+      const tc = assistant.toolCalls[0];
+      expect(tc.result).toBe(JSON.stringify(structured, null, 2));
+      expect(tc.result).not.toContain("[object Object]");
+    }
+  });
+
   it("leaves result undefined when only TOOL_CALL_END fires (no result event)", async () => {
     const { runAgent } = await import("@/lib/agui");
     const { useChat } = await import("@/lib/use-chat");

--- a/services/idun_agent_standalone_ui/components/chat/MessageView.tsx
+++ b/services/idun_agent_standalone_ui/components/chat/MessageView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { CopyButton } from "@/components/common/CopyButton";
 import type { Message } from "@/lib/agui";
 import { type ThemeConfig, getRuntimeConfig } from "@/lib/runtime-config";
 import { ReasoningPanel } from "./ReasoningPanel";
@@ -31,8 +32,11 @@ export function MessageView({ m }: Props) {
   if (m.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="max-w-[78%] rounded-2xl rounded-tr-md bg-foreground px-4 py-2.5 text-[15.5px] leading-snug text-background shadow-sm">
-          {m.text}
+        <div className="flex max-w-[78%] flex-col items-end gap-1">
+          <div className="rounded-2xl rounded-tr-md bg-foreground px-4 py-2.5 text-[15.5px] leading-snug text-background shadow-sm">
+            {m.text}
+          </div>
+          <CopyButton value={m.text} label="Copy message" />
         </div>
       </div>
     );
@@ -94,10 +98,19 @@ export function MessageView({ m }: Props) {
         />
 
         {m.text && (
-          <div className="prose-chat max-w-none text-[16px] leading-[1.65] text-foreground">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.text}</ReactMarkdown>
-            {m.streaming && (
-              <span className="ml-0.5 inline-block h-4 w-2 animate-pulse bg-foreground/60 align-middle" />
+          <div>
+            <div className="prose-chat max-w-none text-[16px] leading-[1.65] text-foreground">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.text}</ReactMarkdown>
+              {m.streaming && (
+                <span className="ml-0.5 inline-block h-4 w-2 animate-pulse bg-foreground/60 align-middle" />
+              )}
+            </div>
+            {!m.streaming && (
+              <CopyButton
+                value={m.text}
+                label="Copy message"
+                className="mt-1"
+              />
             )}
           </div>
         )}

--- a/services/idun_agent_standalone_ui/components/chat/ToolCallRow.tsx
+++ b/services/idun_agent_standalone_ui/components/chat/ToolCallRow.tsx
@@ -3,6 +3,7 @@
 import { useId, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { CopyButton } from "@/components/common/CopyButton";
 import type { ToolCall } from "@/lib/agui";
 import { oneLiner, parseArgs } from "./ReasoningPanel";
 
@@ -75,38 +76,70 @@ export function ToolCallRow({ n, call }: Props) {
         <div id={bodyId} className="border-t border-border">
           {parsed.code !== undefined ? (
             parsed.code ? (
-              <SyntaxHighlighter
-                language="python"
-                style={codeStyle as Record<string, Record<string, unknown>>}
-                PreTag="div"
-              >
-                {parsed.code}
-              </SyntaxHighlighter>
+              <div className="relative">
+                <SyntaxHighlighter
+                  language="python"
+                  style={codeStyle as Record<string, Record<string, unknown>>}
+                  PreTag="div"
+                >
+                  {parsed.code}
+                </SyntaxHighlighter>
+                <CopyButton
+                  value={parsed.code}
+                  label="Copy code"
+                  className="absolute right-2 top-2 bg-card/80 backdrop-blur"
+                />
+              </div>
             ) : (
               <div className="bg-foreground px-4 py-2 font-mono text-[11px] text-muted-foreground">
                 …
               </div>
             )
           ) : (
-            <pre className="chat-code overflow-x-auto bg-canvas px-3 py-2 text-foreground/80">
-              <code>
-                {typeof parsed.obj === "string"
-                  ? parsed.obj
-                  : JSON.stringify(parsed.obj, null, 2)}
-              </code>
-            </pre>
+            <div className="relative">
+              <pre className="chat-code overflow-x-auto bg-canvas px-3 py-2 pr-16 text-foreground/80">
+                <code>
+                  {typeof parsed.obj === "string"
+                    ? parsed.obj
+                    : JSON.stringify(parsed.obj, null, 2)}
+                </code>
+              </pre>
+              <CopyButton
+                value={
+                  typeof parsed.obj === "string"
+                    ? parsed.obj
+                    : JSON.stringify(parsed.obj, null, 2)
+                }
+                label="Copy arguments"
+                className="absolute right-2 top-2"
+              />
+            </div>
           )}
           {(call.result || call.error) && (
             <div className="border-t border-border px-3 py-2">
               {call.error && (
-                <pre className="chat-code mb-2 overflow-x-auto rounded bg-rose-50 px-2 py-1.5 text-rose-800">
-                  {call.error}
-                </pre>
+                <div className="relative mb-2">
+                  <pre className="chat-code overflow-x-auto rounded bg-rose-50 px-2 py-1.5 pr-16 text-rose-800">
+                    {call.error}
+                  </pre>
+                  <CopyButton
+                    value={call.error}
+                    label="Copy error"
+                    className="absolute right-1.5 top-1.5"
+                  />
+                </div>
               )}
               {call.result && (
-                <pre className="chat-code max-h-56 overflow-auto rounded bg-canvas px-2 py-1.5 text-foreground/80">
-                  {call.result}
-                </pre>
+                <div className="relative">
+                  <pre className="chat-code max-h-56 overflow-auto rounded bg-canvas px-2 py-1.5 pr-16 text-foreground/80">
+                    {call.result}
+                  </pre>
+                  <CopyButton
+                    value={call.result}
+                    label="Copy result"
+                    className="absolute right-1.5 top-1.5"
+                  />
+                </div>
               )}
             </div>
           )}

--- a/services/idun_agent_standalone_ui/components/common/CopyButton.tsx
+++ b/services/idun_agent_standalone_ui/components/common/CopyButton.tsx
@@ -39,8 +39,22 @@ export function CopyButton({
   }, []);
 
   const handleClick = useCallback(() => {
-    const text =
-      typeof value === "string" ? value : JSON.stringify(value, null, 2);
+    // `JSON.stringify` can return `undefined` (e.g. a bare `undefined` /
+    // function / symbol input) or throw on `BigInt` and circular
+    // references. Either case would call `clipboard.writeText(undefined)`
+    // or crash this handler before the `.catch` runs, so we serialise
+    // defensively and fall back to a `String(...)` coercion.
+    let text: string;
+    if (typeof value === "string") {
+      text = value;
+    } else {
+      try {
+        const serialized = JSON.stringify(value, null, 2);
+        text = serialized ?? String(value);
+      } catch {
+        text = String(value);
+      }
+    }
     if (typeof navigator !== "undefined" && navigator.clipboard) {
       navigator.clipboard
         .writeText(text)

--- a/services/idun_agent_standalone_ui/components/common/CopyButton.tsx
+++ b/services/idun_agent_standalone_ui/components/common/CopyButton.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  /** Text or value to copy. Non-strings are JSON-stringified. */
+  value: unknown;
+  /** Accessible label for screen readers. Defaults to "Copy to clipboard". */
+  label?: string;
+  /** Optional class overrides on the button. */
+  className?: string;
+  /** Show the inline "Copied" text alongside the icon (default true). */
+  showText?: boolean;
+};
+
+/**
+ * Small ghost-style copy button. Swaps to a check + "Copied" for 1.5s on
+ * success. Fails silently when the clipboard API rejects (sandboxed
+ * iframes, vitest jsdom) so callers don't have to guard.
+ */
+export function CopyButton({
+  value,
+  label = "Copy to clipboard",
+  className,
+  showText = true,
+}: Props) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleClick = useCallback(() => {
+    const text =
+      typeof value === "string" ? value : JSON.stringify(value, null, 2);
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          setCopied(true);
+          if (timerRef.current !== null) clearTimeout(timerRef.current);
+          timerRef.current = setTimeout(() => {
+            setCopied(false);
+            timerRef.current = null;
+          }, 1500);
+        })
+        .catch(() => {
+          // Swallow — sandboxed envs, vitest jsdom. Don't crash the host.
+        });
+    }
+  }, [value]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={label}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground transition hover:bg-card hover:text-foreground",
+        className,
+      )}
+    >
+      {copied ? (
+        <>
+          <CheckIcon className="size-3" />
+          {showText && "Copied"}
+        </>
+      ) : (
+        <>
+          <CopyIcon className="size-3" />
+          {showText && "Copy"}
+        </>
+      )}
+    </button>
+  );
+}

--- a/services/idun_agent_standalone_ui/lib/use-chat.ts
+++ b/services/idun_agent_standalone_ui/lib/use-chat.ts
@@ -126,7 +126,21 @@ function applyEvent(
 
     // — Tool call lifecycle -----------------------------------
     case "TOOL_CALL_START":
-    case "ToolCallStart":
+    case "ToolCallStart": {
+      // Workaround for #629: when the LLM returns a tool call atomically
+      // (Gemini and other non-streaming paths), ag_ui_langgraph emits
+      // TOOL_CALL_START and returns without a follow-up TOOL_CALL_ARGS.
+      // The args are sitting on the raw chunk — pull them out so the
+      // row body isn't empty.
+      let initialArgs = "";
+      const raw = e.rawEvent as
+        | { data?: { chunk?: { tool_calls?: Array<{ args?: unknown }> } } }
+        | undefined;
+      const rawArgs = raw?.data?.chunk?.tool_calls?.[0]?.args;
+      if (rawArgs !== undefined && rawArgs !== null) {
+        initialArgs =
+          typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs);
+      }
       updateLatestAssistant((m) =>
         m.role === "assistant"
           ? {
@@ -138,13 +152,14 @@ function applyEvent(
                   name: String(
                     e.toolCallName ?? e.tool_call_name ?? "tool",
                   ),
-                  args: "",
+                  args: initialArgs,
                 },
               ],
             }
           : m,
       );
       break;
+    }
     case "TOOL_CALL_ARGS":
     case "ToolCallArgs":
       updateLatestAssistant((m) =>
@@ -168,17 +183,41 @@ function applyEvent(
               ...m,
               toolCalls: m.toolCalls.map((tc) =>
                 tc.id === String(e.toolCallId ?? e.tool_call_id ?? "")
-                  ? {
-                      ...tc,
-                      result: JSON.stringify(e.result ?? null),
-                      done: true,
-                    }
+                  ? { ...tc, done: true }
                   : tc,
               ),
             }
           : m,
       );
       break;
+    case "TOOL_CALL_RESULT":
+    case "ToolCallResult": {
+      // Workaround for #629: ag_ui_langgraph emits TOOL_CALL_RESULT with
+      // LangGraph's run_id as tool_call_id, not the LLM's call id. Match
+      // by id when possible; otherwise attach to the most recent tool
+      // call without a result.
+      const incomingId = String(e.toolCallId ?? e.tool_call_id ?? "");
+      const content = String(e.content ?? "");
+      updateLatestAssistant((m) => {
+        if (m.role !== "assistant") return m;
+        const exact = m.toolCalls.find((tc) => tc.id === incomingId);
+        const fallbackIndex = exact
+          ? -1
+          : (() => {
+              for (let i = m.toolCalls.length - 1; i >= 0; i--) {
+                if (m.toolCalls[i].result === undefined) return i;
+              }
+              return -1;
+            })();
+        return {
+          ...m,
+          toolCalls: m.toolCalls.map((tc, i) =>
+            tc === exact || i === fallbackIndex ? { ...tc, result: content } : tc,
+          ),
+        };
+      });
+      break;
+    }
 
     // — Thinking lifecycle ------------------------------------
     case "THINKING_START":

--- a/services/idun_agent_standalone_ui/lib/use-chat.ts
+++ b/services/idun_agent_standalone_ui/lib/use-chat.ts
@@ -44,6 +44,19 @@ const PLAN_STEPS = new Set(["planner", "analyst"]);
  * closure for the duration of a single live run. */
 type SnapshotRef = { current: string | null };
 
+/** Shape of the raw chunk attached to AG-UI tool-call events by
+ * ag_ui_langgraph. Used as the lossy escape hatch for issue #629 where
+ * TOOL_CALL_START arrives without a follow-up TOOL_CALL_ARGS; the args are
+ * still present on the original LangChain chunk. Inline at the AG-UI/JSON
+ * boundary — keep this type narrow and call out new fields explicitly. */
+type RawToolCallChunk = {
+  data?: {
+    chunk?: {
+      tool_calls?: Array<{ args?: unknown; name?: string; id?: string }>;
+    };
+  };
+};
+
 /**
  * Apply a single AG-UI event to the chat state.
  *
@@ -127,15 +140,14 @@ function applyEvent(
     // — Tool call lifecycle -----------------------------------
     case "TOOL_CALL_START":
     case "ToolCallStart": {
-      // Workaround for #629: when the LLM returns a tool call atomically
-      // (Gemini and other non-streaming paths), ag_ui_langgraph emits
-      // TOOL_CALL_START and returns without a follow-up TOOL_CALL_ARGS.
-      // The args are sitting on the raw chunk — pull them out so the
-      // row body isn't empty.
+      // TODO(idun-engine): #629 — workaround until ag_ui_langgraph emits
+      // TOOL_CALL_ARGS for atomic (non-streaming) tool calls. When the LLM
+      // returns a tool call atomically (Gemini and other non-streaming
+      // paths), TOOL_CALL_START arrives without a follow-up
+      // TOOL_CALL_ARGS; the args are still on the raw chunk, so we pull
+      // them out so the row body isn't empty.
       let initialArgs = "";
-      const raw = e.rawEvent as
-        | { data?: { chunk?: { tool_calls?: Array<{ args?: unknown }> } } }
-        | undefined;
+      const raw = e.rawEvent as RawToolCallChunk | undefined;
       const rawArgs = raw?.data?.chunk?.tool_calls?.[0]?.args;
       if (rawArgs !== undefined && rawArgs !== null) {
         initialArgs =
@@ -192,10 +204,11 @@ function applyEvent(
       break;
     case "TOOL_CALL_RESULT":
     case "ToolCallResult": {
-      // Workaround for #629: ag_ui_langgraph emits TOOL_CALL_RESULT with
-      // LangGraph's run_id as tool_call_id, not the LLM's call id. Match
-      // by id when possible; otherwise attach to the most recent tool
-      // call without a result.
+      // TODO(idun-engine): #629 — workaround until ag_ui_langgraph
+      // forwards the LLM's tool_call_id on TOOL_CALL_RESULT. Today it
+      // emits LangGraph's run_id instead, so we match by id when
+      // possible and otherwise attach to the most recent tool call
+      // without a result.
       const incomingId = String(e.toolCallId ?? e.tool_call_id ?? "");
       const content = String(e.content ?? "");
       updateLatestAssistant((m) => {

--- a/services/idun_agent_standalone_ui/lib/use-chat.ts
+++ b/services/idun_agent_standalone_ui/lib/use-chat.ts
@@ -148,7 +148,24 @@ function applyEvent(
       // them out so the row body isn't empty.
       let initialArgs = "";
       const raw = e.rawEvent as RawToolCallChunk | undefined;
-      const rawArgs = raw?.data?.chunk?.tool_calls?.[0]?.args;
+      const toolCalls = raw?.data?.chunk?.tool_calls ?? [];
+      const incomingStartId = String(e.toolCallId ?? e.tool_call_id ?? "");
+      const incomingStartName = String(
+        e.toolCallName ?? e.tool_call_name ?? "",
+      );
+      // Match the corresponding entry by id (preferred) or name; only
+      // fall back to index 0 when the chunk has a single tool call. A
+      // bare [0] would attach the wrong args when the LLM emitted
+      // multiple tool calls in one chunk.
+      const matched =
+        (incomingStartId &&
+          toolCalls.find((tc) => String(tc.id ?? "") === incomingStartId)) ||
+        (incomingStartName &&
+          toolCalls.find(
+            (tc) => String(tc.name ?? "") === incomingStartName,
+          )) ||
+        (toolCalls.length === 1 ? toolCalls[0] : undefined);
+      const rawArgs = matched?.args;
       if (rawArgs !== undefined && rawArgs !== null) {
         initialArgs =
           typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs);
@@ -210,7 +227,25 @@ function applyEvent(
       // possible and otherwise attach to the most recent tool call
       // without a result.
       const incomingId = String(e.toolCallId ?? e.tool_call_id ?? "");
-      const content = String(e.content ?? "");
+      // Serialise structured content so the row body shows the actual
+      // payload instead of "[object Object]". `String({})` would coerce
+      // an object literal to that placeholder, which is what reaches
+      // the UI today when a tool returns a JSON blob; stringify when we
+      // can, fall back to String(...) for circular refs / BigInt.
+      const rawContent = e.content;
+      let content: string;
+      if (typeof rawContent === "string") {
+        content = rawContent;
+      } else if (rawContent === undefined || rawContent === null) {
+        content = "";
+      } else {
+        try {
+          const serialised = JSON.stringify(rawContent, null, 2);
+          content = serialised ?? String(rawContent);
+        } catch {
+          content = String(rawContent);
+        }
+      }
       updateLatestAssistant((m) => {
         if (m.role !== "assistant") return m;
         const exact = m.toolCalls.find((tc) => tc.id === incomingId);


### PR DESCRIPTION
Closes part of #629.

## Summary

Live `idun-assistant` (Gemini + MCP) chat showed `null` under every tool call. Root cause: two upstream bugs in `ag_ui_langgraph` (CopilotKit's LangGraph → AG-UI bridge) that the UI wasn't compensating for.

1. **TOOL_CALL_ARGS event never fires** for atomic tool calls (the LLM returns the full call in one chunk — Gemini's pattern). The args are on the raw chunk attached to `TOOL_CALL_START`, but `ag_ui_langgraph` returns before emitting an ARGS event.
2. **TOOL_CALL_RESULT.tool_call_id ≠ TOOL_CALL_START.tool_call_id** — the result event carries LangGraph's internal run_id, so result-to-call matching by id silently drops content. The UI then synthesised a phantom `"null"` from the missing result.

Live evidence captured against the running agent (`POST /agent/run`):
```
TOOL_CALL_START   toolCallId=f9c62e39-...   (args sit on rawEvent.chunk.tool_calls[0].args)
TOOL_CALL_END     toolCallId=f9c62e39-...
TOOL_CALL_RESULT  toolCallId=019e18a0-...   (different id, content="Title: Guardrails...")
```

## Changes

`services/idun_agent_standalone_ui/lib/use-chat.ts`:
- `TOOL_CALL_START` now reads `rawEvent.data.chunk.tool_calls[0].args` and seeds the row's args field. Handles both `string` and `dict` shapes from upstream.
- `TOOL_CALL_END` no longer fabricates `result: "null"` from a missing field; result stays `undefined` until a real `TOOL_CALL_RESULT` arrives.
- Added a `TOOL_CALL_RESULT` handler. Match by id first; on mismatch (the upstream bug), fall back to the most recent tool call without a result.

Both workarounds carry inline comments referencing the upstream bug and #629 so they're easy to remove when the upstream fix lands.

## Test plan

- [x] `pnpm test -- --run __tests__/use-chat.test.ts` — 14 passed, including:
  - Result captured from TOOL_CALL_RESULT (happy path with matching ids).
  - Result undefined when only TOOL_CALL_END fires (no fabricated null).
  - Args extracted from TOOL_CALL_START rawEvent when no ARGS event follows.
  - Result attached to latest unresolved call when TOOL_CALL_RESULT id mismatches START's id.
- [x] `pnpm typecheck` clean.
- [x] Manual smoke against `idun-assistant`: tool call rows now show args body (`{"query": "guardrails"}` etc.) and full result content from MCP tools.

## Known limitation (out of scope, tracked in #629)

Tool-call cards don't survive a page refresh — session hydration is text-only by design (`_lc_messages_to_session` drops `ToolMessage`). Two follow-up options if we want it: localStorage cache, or fetch from `/admin/api/v1/traces` on hydrate. Neither in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable Copy button for messages, tool-call args/results/errors, and code/JSON blocks for easy copying with transient "Copied" feedback.

* **Bug Fixes**
  * More robust tool-call handling: initial args are captured when omitted and results attach reliably even in non-standard event sequences.

* **Tests**
  * Added regression and edge-case tests covering tool-call sequencing and Copy button behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/630)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->