### PR TITLE
docs(readme): document the bundled-install model (FIX 05 / L9-NEW1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ cd my-agent && idun serve
 
 Open [http://localhost:8000](http://localhost:8000). Chat with your agent, then explore the admin at [/admin](http://localhost:8000/admin) and traces at [/admin/traces](http://localhost:8000/admin/traces).
 
+> **What `pip install idun-agent-engine` delivers.** A single wheel that bundles three Python packages: the engine SDK (`idun_agent_engine`), the standalone CLI + admin REST + chat / admin / traces UIs (`idun_agent_standalone`), and the Pydantic config schemas (`idun_agent_schema`). The `idun` command that lands on your `$PATH` after install (`idun setup`, `idun serve`, `idun init`, `idun hash-password`, `idun agent serve`) is provided by the bundled standalone — it is NOT a separately published package. You will not see `idun-agent-standalone` in this wheel's declared dependencies on PyPI because it ships as a co-installed package directory inside the wheel, not as a transitive dep. See [docs.idunplatform.com/architecture](https://docs.idunplatform.com/architecture) for the full layering.
+
 ## What's inside
 
 <table>
@@ -184,6 +186,28 @@ flowchart LR
 ---
 
 ## Configuration
+
+### Components in this install
+
+After `pip install idun-agent-engine`, your `$PATH` and `site-packages` contain:
+
+| Module | Distributed via | Purpose |
+|---|---|---|
+| `idun_agent_engine` | declared in `requires_dist` | FastAPI app factory, MCP registry, observability, guardrails wiring |
+| `idun_agent_schema` | declared in `requires_dist` | Pydantic config models for `config.yaml` |
+| `idun_agent_standalone` | **co-bundled in the engine wheel** | `idun` CLI, admin REST under `/admin/api/v1/`, chat / admin / traces UIs at `/`, `/admin/`, `/admin/traces/` |
+| `idun` (console script) | `[project.scripts] idun = "idun_agent_standalone.cli:main"` | Subcommands: `setup`, `serve`, `init`, `hash-password`, `agent serve` |
+
+The bundled-install model means **you do not need to `pip install idun-agent-standalone` separately** — it isn't published. To verify your install carries everything:
+
+```bash
+python -c "import idun_agent_engine, idun_agent_standalone, idun_agent_schema; print('all 3 modules importable')"
+idun --help
+```
+
+Both checks are smoke-tested in the release pipeline before any wheel is published.
+
+### YAML reference
 
 Every agent is configured through a single YAML file. Here is a complete example with all features enabled:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,17 @@ cd my-agent && idun serve
 
 Open [http://localhost:8000](http://localhost:8000). Chat with your agent, then explore the admin at [/admin](http://localhost:8000/admin) and traces at [/admin/traces](http://localhost:8000/admin/traces).
 
-> **What `pip install idun-agent-engine` delivers.** A single wheel that bundles three Python packages: the engine SDK (`idun_agent_engine`), the standalone CLI + admin REST + chat / admin / traces UIs (`idun_agent_standalone`), and the Pydantic config schemas (`idun_agent_schema`). The `idun` command that lands on your `$PATH` after install (`idun setup`, `idun serve`, `idun init`, `idun hash-password`, `idun agent serve`) is provided by the bundled standalone — it is NOT a separately published package. You will not see `idun-agent-standalone` in this wheel's declared dependencies on PyPI because it ships as a co-installed package directory inside the wheel, not as a transitive dep. See [docs.idunplatform.com/architecture](https://docs.idunplatform.com/architecture) for the full layering.
+> **What `pip install idun-agent-engine` delivers**
+>
+> A single wheel that bundles three Python packages:
+>
+> - **`idun_agent_engine`** — the engine SDK (FastAPI app factory, MCP registry, observability, guardrails).
+> - **`idun_agent_standalone`** — the `idun` CLI, the admin REST API, and the chat / admin / traces UIs.
+> - **`idun_agent_schema`** — the Pydantic config schemas.
+>
+> The `idun` command on your `$PATH` (`setup`, `serve`, `init`, `hash-password`, `agent serve`) is provided by the bundled standalone — it is not a separately published package. You won't see `idun-agent-standalone` in the engine's declared PyPI dependencies because it ships co-installed inside the wheel, not as a transitive dep.
+>
+> See [docs.idunplatform.com/architecture](https://docs.idunplatform.com/architecture) for the full layering.
 
 ## What's inside
 


### PR DESCRIPTION
## Summary

- Adds a callout under **Quick start** explaining that `pip install idun-agent-engine` ships three Python packages in a single wheel — `idun_agent_engine`, `idun_agent_standalone` (CLI + admin REST + UIs), `idun_agent_schema` — and that `idun-agent-standalone` is absent from the wheel's declared deps because it's co-bundled, not a transitive dep.
- Adds a **Components in this install** subsection under **Configuration** with a table of the three modules, the `idun` console-script entry point with all five subcommands (`setup`, `serve`, `init`, `hash-password`, `agent serve`), and the two-line smoke check that the release pipeline already runs.
- Links to `docs.idunplatform.com/architecture` for the deeper layering doc (already exists at `docs/architecture.mdx`).

README only — +24 lines, no code changes.

## Why

The demo-idun-engine L9 postmortem caught an adopter looking up the engine wheel on PyPI, seeing only `idun-agent-schema` in `requires_dist`, and concluding "standalone must be a separate install" — a misdiagnosis chain that consumed a full day of programmatic-boot workaround plus two full reworks. One paragraph in the README would have prevented every step of it.

Tracking task: [`tasks/before-release-11-05-2026/05-document-bundled-install/FIX.md`](https://github.com/Idun-Group/idun-dev/blob/main/tasks/before-release-11-05-2026/05-document-bundled-install/FIX.md)
FINDINGS reference: L9-NEW1 (🟠 — MUST FIX before 0.6.0)

## Departures from FIX.md

- **Skipped Diff C** (tagline change on line 34). The existing Architecture section (README lines 127–142) plus the two new callouts already document the bundle; rewriting the central marketing tagline is left to the team.
- **Skipped the optional `docs/architecture.md` stub** — `docs/architecture.mdx` already exists and explains the layering. Linked to the hosted version at `docs.idunplatform.com/architecture` for consistency with how the README links to `docs.idunplatform.com/configuration` (line 244).
- **Added `idun agent serve`** to the subcommand list — FIX.md missed this subcommand group; it exists in `libs/idun_agent_standalone/src/idun_agent_standalone/cli.py:290`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified installation notes: the single pip package bundles the engine SDK, the CLI/UI package, and the schema package; the CLI/UI package is included inside the wheel and is not separately published.
  * Added a "Components in this install" section describing what's provided, where UIs/APIs mount, available subcommands, and quick verification commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/632)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->