### PR TITLE
docs: note TestPyPI dev-snapshot JSON metadata gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ cd my-agent && idun serve
 
 Open [http://localhost:8000](http://localhost:8000). Chat with your agent, then explore the admin at [/admin](http://localhost:8000/admin) and traces at [/admin/traces](http://localhost:8000/admin/traces).
 
+> Installing a TestPyPI dev snapshot? Its JSON metadata can come back with `entry_points: null` and a partial `requires_dist`. The wheel still bundles `idun_agent_standalone` and `idun_agent_schema`, so trust the wheel. Public PyPI releases (0.6.0+) are not affected. To check what you got:
+>
+> ```bash
+> python -c "import idun_agent_engine, idun_agent_standalone, idun_agent_schema"
+> idun --help
+> ```
+
 ## What's inside
 
 <table>

--- a/libs/idun_agent_engine/CHANGELOG.md
+++ b/libs/idun_agent_engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- README note for TestPyPI dev snapshots: the JSON metadata can show `entry_points: null` and a partial `requires_dist`, but the wheel still bundles `idun_agent_standalone` and `idun_agent_schema`. Includes a post-install check. Public PyPI releases (0.6.0+) are not affected.
+
 ### Removed
 
 - Haystack agent adapter, `HaystackAgentConfig` schema, and the `langfuse-haystack` runtime dependency. Migrate Haystack agents to LangGraph or ADK.


### PR DESCRIPTION
## Summary

- Adds a short blockquote in the root `README.md` (just after Quick start) explaining that TestPyPI's JSON metadata can come back with `entry_points: null` and a partial `requires_dist` for engine dev snapshots, while the wheel itself still bundles `idun_agent_standalone` and `idun_agent_schema`. Public PyPI releases (0.6.0+) are not affected.
- Adds a one-line post-install check (`python -c "import idun_agent_engine, idun_agent_standalone, idun_agent_schema"` + `idun --help`).
- Logs a matching `[Unreleased] / Documentation` entry in `libs/idun_agent_engine/CHANGELOG.md`.

Closes L9-NEW2 from `idun-dev/tasks/before-release-11-05-2026/09-testpypi-metadata/FIX.md` (Approach A — document the limitation, recommended for 0.6.x). Approach B (root-causing the indexer gap) is deferred to 0.7.

Origin: the demo-idun-engine lab burned a full day misdiagnosing the install model after reading TestPyPI's incomplete JSON. See [`demo-idun-engine/docs/learnings/09-postmortem-standalone-bundled.md`](https://github.com/Idun-Group/demo-idun-engine/blob/main/docs/learnings/09-postmortem-standalone-bundled.md).


## Notes for reviewer

- Doc-only PR, no code change. CI lint/test should be unaffected.
- The FIX.md's "Concrete diff" intended this note to slot inside fix 05's "Components in this install" section. Fix 05 has not landed yet (worktree exists but no commits), so the note is placed standalone after Quick start. If fix 05 lands first, this note can be relocated inside that section in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for TestPyPI dev snapshot installations, clarifying that potential incomplete metadata does not affect bundled packages.
  * Included verification steps for post-installation confirmation.
  * Clarified that public PyPI releases (0.6.0+) are unaffected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/633)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->