### PR TITLE
ci(socket): add Socket security gates on PRs and publish workflows

### DIFF
--- a/.github/workflows/publish_engine_testpypi.yml
+++ b/.github/workflows/publish_engine_testpypi.yml
@@ -6,6 +6,12 @@ on:
       - '**'  # Trigger on all branches and all commits
 
 jobs:
+  socket-scan:
+    name: Socket security gate
+    uses: ./.github/workflows/socket-scan-reusable.yml
+    secrets:
+      SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+
   build-and-validate:
     name: Build and validate engine package
     runs-on: ubuntu-latest
@@ -124,7 +130,7 @@ jobs:
   publish-testpypi:
     name: Publish engine to TestPyPI (best effort)
     runs-on: ubuntu-latest
-    needs: build-and-validate
+    needs: [socket-scan, build-and-validate]
     continue-on-error: true
     permissions:
       contents: read

--- a/.github/workflows/publish_schema_testpypi.yml
+++ b/.github/workflows/publish_schema_testpypi.yml
@@ -6,6 +6,12 @@ on:
       - '**'  # Trigger on all branches and all commits
 
 jobs:
+  socket-scan:
+    name: Socket security gate
+    uses: ./.github/workflows/socket-scan-reusable.yml
+    secrets:
+      SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+
   build-and-validate:
     name: Build and validate schema package
     runs-on: ubuntu-latest
@@ -92,7 +98,7 @@ jobs:
   publish-testpypi:
     name: Publish schema to TestPyPI (best effort)
     runs-on: ubuntu-latest
-    needs: build-and-validate
+    needs: [socket-scan, build-and-validate]
     continue-on-error: true
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,37 @@ on:
         description: "Tag to release (e.g. v0.6.0). Required for manual dispatch."
         required: true
         type: string
+      skip_socket:
+        description: "Bypass Socket security gate. Use only when Socket is down or a known false positive blocks a hotfix."
+        required: false
+        default: false
+        type: boolean
 
 env:
   PYTHON_VERSION: "3.12"
 
 jobs:
   # ============================================================================
+  # Job 0: Socket security gate (release-published always runs it;
+  #        workflow_dispatch can bypass with skip_socket=true).
+  # ============================================================================
+  socket-scan:
+    name: Socket security gate
+    if: github.event_name != 'workflow_dispatch' || inputs.skip_socket != true
+    uses: ./.github/workflows/socket-scan-reusable.yml
+    with:
+      ref: ${{ inputs.tag || github.ref }}
+    secrets:
+      SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+
+  # ============================================================================
   # Job 1: Publish Schema to PyPI
   # ============================================================================
   publish-schema:
     name: Publish Schema to PyPI
     runs-on: ubuntu-latest
+    needs: socket-scan
+    if: always() && (needs.socket-scan.result == 'success' || needs.socket-scan.result == 'skipped')
     permissions:
       contents: read
       id-token: write # For trusted publishing
@@ -80,7 +100,8 @@ jobs:
   publish-engine:
     name: Publish Engine to PyPI
     runs-on: ubuntu-latest
-    needs: publish-schema
+    needs: [socket-scan, publish-schema]
+    if: always() && needs.publish-schema.result == 'success' && (needs.socket-scan.result == 'success' || needs.socket-scan.result == 'skipped')
     permissions:
       contents: read
       id-token: write # For trusted publishing

--- a/.github/workflows/socket-scan-reusable.yml
+++ b/.github/workflows/socket-scan-reusable.yml
@@ -15,15 +15,16 @@ jobs:
   scan:
     name: Socket full-repo scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/socket-scan-reusable.yml
+++ b/.github/workflows/socket-scan-reusable.yml
@@ -1,0 +1,41 @@
+name: Socket release-gate scan (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to scan (tag, branch, or SHA). Defaults to the caller's ref."
+        required: false
+        type: string
+    secrets:
+      SOCKET_SECURITY_API_KEY:
+        required: true
+
+jobs:
+  scan:
+    name: Socket full-repo scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Socket CLI
+        run: pip install socketsecurity --upgrade
+
+      - name: Run Socket Security scan (full repo, fail on policy violations)
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          socketcli \
+            --target-path "$GITHUB_WORKSPACE" \
+            --scm github \
+            --pr-number 0

--- a/.github/workflows/socket-security.yml
+++ b/.github/workflows/socket-security.yml
@@ -15,17 +15,19 @@ concurrency:
 jobs:
   socket-security:
     name: Socket dependency scan
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       issues: write
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/socket-security.yml
+++ b/.github/workflows/socket-security.yml
@@ -1,0 +1,49 @@
+name: Socket Security
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: socket-scan-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  socket-security:
+    name: Socket dependency scan
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Socket CLI
+        run: pip install socketsecurity --upgrade
+
+      - name: Run Socket Security scan
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=0
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER=${{ github.event.issue.number }}
+          fi
+          socketcli \
+            --target-path "$GITHUB_WORKSPACE" \
+            --scm github \
+            --pr-number "$PR_NUMBER"


### PR DESCRIPTION
## Summary

Adds two-layer supply-chain protection backed by Socket.dev so we catch malicious dependencies both at PR time and right before any publish (PyPI + TestPyPI).

- **PR/push gate** (`socket-security.yml`) — Socket's recommended workflow; runs on `pull_request`, `push`, and `issue_comment`; comments findings on PRs.
- **Reusable release gate** (`socket-scan-reusable.yml`) — `workflow_call`, full-repo Socket scan; used as a hard `needs:` gate by every publish workflow.
- **`release.yml`** — `publish-schema` and `publish-engine` now require `socket-scan`. A `skip_socket` `workflow_dispatch` input lets us bypass during a Socket outage or known false positive, but cannot be set on `release: published` runs (auditable manual-only escape hatch).
- **`publish_engine_testpypi.yml` / `publish_schema_testpypi.yml`** — `publish-testpypi` now `needs: [socket-scan, build-and-validate]`.

`SOCKET_SECURITY_API_KEY` repo secret is already set. Failure policy is governed by Socket org settings, not hardcoded CLI flags, so policy lives in one place (the Socket dashboard).

## Test plan

- [ ] This PR itself triggers `socket-security.yml` — confirm the job runs and posts a comment.
- [ ] This PR triggers `socket-scan` inside `publish_engine_testpypi.yml` and `publish_schema_testpypi.yml` — confirm both pass before `publish-testpypi` runs.
- [ ] Manually dispatch `release.yml` with `skip_socket=true` on a test tag and confirm the gate is skipped (don't actually publish).
- [ ] Confirm the next `release: published` event runs `socket-scan` and that `skip_socket` cannot bypass it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated Socket Security scanning as a required gate in release and publish pipelines; publishing now waits for scans and build/validation.
  * Security scans run automatically on pushes, pull requests, issue comments, and release workflows.

* **New Features**
  * Introduced a reusable Socket scan workflow and a manual release option to skip the scan when triggering a release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/634)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->