### PR TITLE
fix(engine): surface agent_ready on /health (L10-1 / FIX 02)

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
@@ -74,18 +74,33 @@ async def _reload_auth_dep(request: Request) -> None:
 
 @base_router.get("/health")
 def health_check(request: Request):
-    """Health check endpoint for monitoring and load balancers."""
+    """Health check endpoint for monitoring and load balancers.
+
+    Returns ``status: "ok"`` only when an agent is registered and
+    ``/agent/*`` will accept requests. Returns ``status: "degraded"`` with
+    ``agent_ready: false`` when no agent is configured — e.g. standalone
+    admin-only mode after an ``assemble_engine_config`` error, or the
+    pre-onboarding wizard state. When ``app.state.boot_error`` is set by
+    the standalone's assembly failure handler, it is surfaced as ``reason``
+    so operators can diagnose without grepping logs.
+    """
     agent = getattr(request.app.state, "agent", None)
     configuration = getattr(agent, "configuration", None)
     agent_name = getattr(configuration, "name", None)
+    agent_ready = agent is not None
+    boot_error = getattr(request.app.state, "boot_error", None)
     # TODO: return managed agent UUID (from manager API response) for stronger
     # identity validation. Currently agent_name is the only shared identifier.
-    return {
-        "status": "ok",
+    response: dict[str, object] = {
+        "status": "ok" if agent_ready else "degraded",
         "service": "idun-agent-engine",
         "version": __version__,
+        "agent_ready": agent_ready,
         "agent_name": agent_name,
     }
+    if boot_error:
+        response["reason"] = boot_error
+    return response
 
 
 @base_router.post("/reload")

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
@@ -3,6 +3,7 @@
 import inspect
 import logging
 import os
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
@@ -30,7 +31,7 @@ class HealthResponse(BaseModel):
     so the field stays absent (not ``null``) on the happy path.
     """
 
-    status: str
+    status: Literal["ok", "degraded"]
     service: str
     version: str
     agent_ready: bool

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
@@ -22,6 +22,22 @@ class ReloadRequest(BaseModel):
     path: str | None = None
 
 
+class HealthResponse(BaseModel):
+    """Response shape for ``/health``.
+
+    ``reason`` is only emitted when an assembly failure handler set
+    ``app.state.boot_error``; the route uses ``response_model_exclude_unset``
+    so the field stays absent (not ``null``) on the happy path.
+    """
+
+    status: str
+    service: str
+    version: str
+    agent_ready: bool
+    agent_name: str | None
+    reason: str | None = None
+
+
 async def _reload_auth_dep(request: Request) -> None:
     """Resolve the optional /reload auth dependency from app state.
 
@@ -72,8 +88,12 @@ async def _reload_auth_dep(request: Request) -> None:
     return None
 
 
-@base_router.get("/health")
-def health_check(request: Request):
+@base_router.get(
+    "/health",
+    response_model=HealthResponse,
+    response_model_exclude_unset=True,
+)
+def health_check(request: Request) -> HealthResponse:
     """Health check endpoint for monitoring and load balancers.
 
     Returns ``status: "ok"`` only when an agent is registered and
@@ -91,7 +111,7 @@ def health_check(request: Request):
     boot_error = getattr(request.app.state, "boot_error", None)
     # TODO: return managed agent UUID (from manager API response) for stronger
     # identity validation. Currently agent_name is the only shared identifier.
-    response: dict[str, object] = {
+    fields: dict[str, object] = {
         "status": "ok" if agent_ready else "degraded",
         "service": "idun-agent-engine",
         "version": __version__,
@@ -99,8 +119,8 @@ def health_check(request: Request):
         "agent_name": agent_name,
     }
     if boot_error:
-        response["reason"] = boot_error
-    return response
+        fields["reason"] = str(boot_error)
+    return HealthResponse(**fields)
 
 
 @base_router.post("/reload")

--- a/libs/idun_agent_engine/tests/unit/core/test_app_factory.py
+++ b/libs/idun_agent_engine/tests/unit/core/test_app_factory.py
@@ -34,7 +34,9 @@ class TestAppFactoryConfigSources:
 
         response = client.get("/health")
         assert response.status_code == 200
-        assert response.json()["status"] == "ok"
+        # No lifespan ran (TestClient used without `with`), so no agent is
+        # registered on app.state and /health correctly reports degraded.
+        assert response.json()["status"] == "degraded"
 
         assert app.state.engine_config.server.api.port == 8888
         assert app.state.engine_config.agent.config.name == "YAML Test Agent"
@@ -129,7 +131,9 @@ class TestAppFactoryRoutes:
 
         resp = client.get("/health")
         assert resp.status_code == 200
-        assert resp.json().get("status") == "ok"
+        # No lifespan (TestClient used without `with`), so app.state.agent is
+        # never set — /health reports degraded by design (see FIX 02 / L10-1).
+        assert resp.json().get("status") == "degraded"
 
         resp = client.get("/")
         assert resp.status_code == 200

--- a/libs/idun_agent_engine/tests/unit/core/test_app_factory_unconfigured.py
+++ b/libs/idun_agent_engine/tests/unit/core/test_app_factory_unconfigured.py
@@ -52,14 +52,18 @@ class TestUnconfiguredBoot:
         assert "/reload" in paths
 
     def test_unconfigured_app_returns_200_on_health(self) -> None:
-        """``/health`` works regardless of agent configuration — it is
-        the load-balancer's reachability signal."""
+        """``/health`` stays reachable on the unconfigured/wizard path —
+        the load-balancer's reachability signal — but reports degraded so
+        monitoring can distinguish a wedged service from a healthy one
+        (FIX 02 / L10-1).
+        """
         app = create_app()
         with TestClient(app) as client:
             response = client.get("/health")
             assert response.status_code == 200
             body = response.json()
-            assert body["status"] == "ok"
+            assert body["status"] == "degraded"
+            assert body["agent_ready"] is False
             assert body["agent_name"] is None  # No agent yet
 
     def test_unconfigured_app_returns_503_on_agent_run(self) -> None:

--- a/libs/idun_agent_engine/tests/unit/server/routers/test_base.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/test_base.py
@@ -1,0 +1,104 @@
+"""Unit tests for the base router — covers /health agent-ready signaling.
+
+Origin: FIX 02 in idun-dev/tasks/before-release-11-05-2026/02-health-agent-ready/.
+Finding L10-1: /health returned status=ok even when the engine booted in
+admin-only mode and every /agent/* call returned 503. The only signal was
+agent_name=null. These tests pin the explicit agent_ready: bool + degraded
+status contract so monitoring probes can detect the broken state.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from idun_agent_engine.server.routers.base import base_router
+
+
+def _build_app(
+    *,
+    agent: object | None = None,
+    boot_error: str | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(base_router)
+    app.state.agent = agent
+    if boot_error is not None:
+        app.state.boot_error = boot_error
+    return app
+
+
+class _Agent:
+    """Minimal stand-in for a configured agent on app.state."""
+
+    def __init__(self, name: str) -> None:
+        self.configuration = type("Configuration", (), {"name": name})()
+
+
+@pytest.fixture
+def app_without_agent() -> FastAPI:
+    """Engine booted but no agent was configured — admin-only/wizard state."""
+    return _build_app(agent=None)
+
+
+@pytest.fixture
+def app_with_configured_agent() -> FastAPI:
+    """Engine booted with an agent registered on app.state — happy path."""
+    return _build_app(agent=_Agent(name="demo-agent"))
+
+
+@pytest.fixture
+def app_with_boot_error() -> FastAPI:
+    """Standalone assembly failed; FIX 03 surfaces the reason on app.state."""
+    return _build_app(
+        agent=None,
+        boot_error="Guardrail conversion failed: GUARDRAILS_API_KEY missing",
+    )
+
+
+def test_health_reports_degraded_when_no_agent(app_without_agent: FastAPI) -> None:
+    """L10-1 regression: /health must NOT claim 'ok' while /agent/* will 503.
+
+    This was the headline finding of the demo-idun-engine L10 postmortem:
+    operators saw status=ok on a service whose /agent/* was wedged at 503.
+    """
+    client = TestClient(app_without_agent)
+
+    resp = client.get("/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["agent_ready"] is False
+    assert body["agent_name"] is None
+
+
+def test_health_reports_ok_when_agent_configured(
+    app_with_configured_agent: FastAPI,
+) -> None:
+    """Happy path: a registered agent flips status=ok and surfaces its name."""
+    client = TestClient(app_with_configured_agent)
+
+    resp = client.get("/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["agent_ready"] is True
+    assert body["agent_name"] == "demo-agent"
+    # `reason` is only present in degraded responses.
+    assert "reason" not in body
+
+
+def test_health_surfaces_boot_error_as_reason(app_with_boot_error: FastAPI) -> None:
+    """When the standalone records why assembly failed, /health echoes it."""
+    client = TestClient(app_with_boot_error)
+
+    resp = client.get("/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["agent_ready"] is False
+    assert "guardrail" in body["reason"].lower()

--- a/libs/idun_agent_engine/tests/unit/server/test_routes_run.py
+++ b/libs/idun_agent_engine/tests/unit/server/test_routes_run.py
@@ -168,7 +168,10 @@ class TestHealthRoute:
             assert "version" in data
 
     def test_health_returns_null_agent_name_before_init(self):
-        """GET /health returns null agent_name when no agent is loaded."""
+        """GET /health reports degraded + agent_ready=false when no agent
+        is loaded. The endpoint must give monitoring an unambiguous signal
+        that /agent/* will 503 — see FIX 02 / L10-1.
+        """
         from fastapi import FastAPI
 
         from idun_agent_engine.server.routers.base import base_router
@@ -180,7 +183,8 @@ class TestHealthRoute:
             response = client.get("/health")
             assert response.status_code == 200
             data = response.json()
-            assert data["status"] == "ok"
+            assert data["status"] == "degraded"
+            assert data["agent_ready"] is False
             assert data["agent_name"] is None
 
 

--- a/libs/idun_agent_standalone/tests/integration/test_unconfigured_boot.py
+++ b/libs/idun_agent_standalone/tests/integration/test_unconfigured_boot.py
@@ -105,10 +105,11 @@ async def test_standalone_unconfigured_boot_serves_health_and_admin(empty_db_set
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        # /health works
         response = await client.get("/health")
         assert response.status_code == 200, response.text
-        assert response.json()["status"] == "ok"
+        body = response.json()
+        assert body["status"] == "degraded"
+        assert body["agent_ready"] is False
 
         # /admin/api/v1/agent returns 404 (no agent row) — that is the
         # wizard-not-yet-materialized signal the SPA's chat root reads to


### PR DESCRIPTION
## Summary

- `/health` flips `status: "ok"` → `"degraded"` and adds explicit `agent_ready: bool` when `app.state.agent` is None. Optional `reason` echoes `app.state.boot_error` (to be written by FIX 03).
- Fixes L10-1: operators shipped wedged services against a green probe because `/health` returned `status: "ok"` even when `assemble_engine_config` failed and every `/agent/*` returned 503.
- Five existing tests pinned the old buggy contract; updated to the new shape.

## Why

Headline finding of the [demo-idun-engine L10 postmortem](https://github.com/Idun-Group/demo-idun-engine/blob/main/docs/learnings/10-untested-deployment-and-endpoint-misdiagnosis.md): monitoring probes can't currently distinguish a healthy engine from one in admin-only fallback. The only existing signal was `agent_name: null` — opaque, easy to overlook.

## Backward compatibility

Additive. `status`, `agent_name`, `service`, `version` all still present. Callers that expect `status == "ok"` to mean "service is up" will start seeing `degraded` when the agent failed to register — that is the entire point of the fix. Ops note for probes: accept both `ok` and `degraded`, or treat `degraded` as page-worthy.

## Test plan

- [x] `uv run pytest libs/idun_agent_engine/tests` — **577 passed, 17 skipped**
- [x] `cd libs/idun_agent_standalone && uv run pytest` — **522 passed, 12 skipped**
- [x] `uv run ruff check` on touched files — clean
- [x] `uv run mypy libs/idun_agent_engine/src/.../base.py` — only pre-existing `_reload_auth_dep` error (confirmed via stash, untouched on develop)
- [x] Manual repro against a running standalone with the agent row deleted: `/health` returns `{"status":"degraded","agent_ready":false,"agent_name":null,...}`; admin panel still works.

## Refs

- `idun-dev/tasks/before-release-11-05-2026/02-health-agent-ready/FIX.md`
- FINDINGS.md L10-1 (MUST FIX before 0.6.0)
- Unblocks FIX 03 (`app.state.boot_error` writer in standalone) which lights up the `reason` field this PR exposes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Health endpoint now returns a structured payload including service/version, agent readiness, agent name, and optional boot-error reason; reports "ok" when agent is ready and "degraded" otherwise.
* **Tests**
  - Updated and added unit/integration tests to assert degraded state when no agent is configured and to validate agent_ready, agent_name, and boot-error behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/636)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->