### PR TITLE
chore(security): SHA-pin actions, dep-audit job, SECURITY.md hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,13 @@ updates:
           - "version-update:semver-major"
 
   - package-ecosystem: "npm"
-    directory: "/services/idun_agent_web"
+    directory: "/services/idun_agent_standalone_ui"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
     groups:
-      web-all:
+      standalone-ui-all:
         patterns:
           - "*"
     ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: false
 
@@ -40,15 +40,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: false
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Clone idun-dev plugin
         env:
@@ -85,7 +85,7 @@ jobs:
             $RUNNER_TEMP/idun-dev
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
         with:
           enable-cache: true
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: Comment on PR if drift
         if: steps.drift.outcome == 'failure' && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: guidelines-drift
           message: |
@@ -132,7 +132,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0      # full history for the diff
 
@@ -158,7 +158,7 @@ jobs:
         # NOTE: anthropics/claude-code-action@v1 has no `system_prompt_file`
         # input; the agent prompt is concatenated into `prompt` instead, and
         # the action posts its own sticky PR comment via `use_sticky_comment`.
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,3 +177,65 @@ jobs:
             ---
             _This check is **advisory** in v1. Run `/review-pr` locally to
             iterate. Findings here do not block merge._
+
+  security-audit:
+    name: Dependency vulnerability audit (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          enable-cache: false
+
+      - name: Export resolved Python requirements
+        run: |
+          uv export --no-dev --no-hashes --no-emit-workspace > requirements-audit.txt
+          echo "Exported $(wc -l < requirements-audit.txt) locked Python dependencies."
+
+      - name: Run pip-audit
+        run: |
+          uv tool run --from pip-audit pip-audit \
+            --requirement requirements-audit.txt \
+            --vulnerability-service osv \
+            --desc on \
+            --strict \
+          | tee pip-audit-report.txt
+          echo "::warning::See pip-audit-report.txt for Python dependency findings."
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+
+      - name: Run pnpm audit on standalone UI
+        working-directory: services/idun_agent_standalone_ui
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm audit --audit-level=high --json | tee ../../pnpm-audit-report.json || true
+          echo "::warning::See pnpm-audit-report.json for npm dependency findings."
+
+      - name: Upload audit reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dependency-audit-reports
+          path: |
+            pip-audit-report.txt
+            pnpm-audit-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-real-llm.yml
+++ b/.github/workflows/e2e-real-llm.yml
@@ -70,20 +70,20 @@ jobs:
       # but matches the conftest's explicit override).
       GOOGLE_GENAI_USE_VERTEXAI: "false"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Install workspace dependencies
         run: uv sync --group dev
@@ -124,20 +124,20 @@ jobs:
       # Admin REST guardrail-add scenario also needs Guardrails Hub.
       GUARDRAILS_API_KEY: ${{ secrets.GUARDRAILS_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Install workspace dependencies
         run: uv sync --group dev
@@ -156,7 +156,7 @@ jobs:
           uv run guardrails hub install hub://guardrails/ban_list
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-traces-${{ github.run_id }}
           path: services/idun_agent_standalone_ui/test-results/

--- a/.github/workflows/publish_engine_testpypi.yml
+++ b/.github/workflows/publish_engine_testpypi.yml
@@ -23,25 +23,25 @@ jobs:
       artifact_name: engine-validation-bundle-${{ steps.versions.outputs.engine_dev_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"
@@ -119,7 +119,7 @@ jobs:
           idun hash-password --help
 
       - name: Upload validation artifact bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: engine-validation-bundle-${{ steps.versions.outputs.engine_dev_version }}
           path: |
@@ -136,25 +136,25 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/publish_schema_testpypi.yml
+++ b/.github/workflows/publish_schema_testpypi.yml
@@ -22,15 +22,15 @@ jobs:
       artifact_name: schema-dist-${{ steps.version.outputs.dev_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
 
@@ -89,7 +89,7 @@ jobs:
           python -c "import idun_agent_schema; print(idun_agent_schema.__file__)"
 
       - name: Upload schema distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: schema-dist-${{ steps.version.outputs.dev_version }}
           path: libs/idun_agent_schema/dist/*
@@ -104,17 +104,17 @@ jobs:
       contents: read
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
 
       - name: Download schema distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ needs.build-and-validate.outputs.artifact_name }}
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,17 +46,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
 
@@ -88,7 +88,7 @@ jobs:
         run: uvx twine check libs/idun_agent_schema/dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: libs/idun_agent_schema/dist/
           verbose: true
@@ -108,27 +108,27 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"
@@ -207,7 +207,7 @@ jobs:
           idun hash-password --help
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: libs/idun_agent_engine/dist/
           verbose: true

--- a/.github/workflows/standalone-ci.yml
+++ b/.github/workflows/standalone-ci.yml
@@ -43,8 +43,8 @@ jobs:
           --health-timeout 3s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install --no-cache-dir uv
@@ -60,11 +60,11 @@ jobs:
       run:
         working-directory: services/idun_agent_standalone_ui
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"
@@ -76,12 +76,12 @@ jobs:
   docker-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"
@@ -130,15 +130,15 @@ jobs:
     name: Wheel install smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install --no-cache-dir uv
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"
@@ -164,15 +164,15 @@ jobs:
       run:
         working-directory: services/idun_agent_standalone_ui
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install --no-cache-dir uv
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"

--- a/SECURITY-INCIDENT-RESPONSE.md
+++ b/SECURITY-INCIDENT-RESPONSE.md
@@ -1,0 +1,157 @@
+# Security Incident Response
+
+Operational runbook for rotating credentials and recovering from a supply-chain
+or credential-exposure incident in `idun-agent-platform`. Intended for
+maintainers with admin access to the GitHub org, PyPI, and TestPyPI.
+
+For *reporting* a vulnerability, see [`SECURITY.md`](SECURITY.md). This document
+covers what we do after a report comes in or after a compromise is detected.
+
+## Inventory of long-lived secrets
+
+These are the secrets and tokens whose compromise would let an attacker
+publish malicious packages, leak user data, or impersonate the build system.
+Every entry must have an owner and a rotation procedure.
+
+| Secret | Used by | Storage | Rotation owner |
+| --- | --- | --- | --- |
+| `TEST_PYPI_API_TOKEN` | `.github/workflows/publish_engine_testpypi.yml`, `publish_schema_testpypi.yml` | GitHub Actions org secret | Maintainers |
+| PyPI **trusted publisher** (OIDC) | `.github/workflows/release.yml` | TestPyPI/PyPI project settings (no token; OIDC config only) | Maintainers |
+| `GUARDRAILS_API_KEY` | `ci.yml`, `e2e-real-llm.yml`, `standalone-ci.yml` | GitHub Actions secret | Maintainers + Guardrails AI |
+| `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` | `ci.yml` test job | GitHub Actions secret | Maintainers |
+| `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY` | `e2e-real-llm.yml` | GitHub Actions secret | Maintainers |
+| `IDUN_DEV_READ_TOKEN` | `ci.yml` guidelines-check job | GitHub Actions secret | Maintainers |
+| `ANTHROPIC_API_KEY` | `ci.yml` guidelines-review job | GitHub Actions secret | Maintainers |
+| `CODECOV_TOKEN` | (if/when re-enabled) | GitHub Actions secret | Maintainers |
+
+GitHub Actions `GITHUB_TOKEN` is not listed — it is scoped per-workflow by
+GitHub and revoked automatically at job end. Workflows that need extra
+permissions request them explicitly via `permissions:` blocks.
+
+## Severity tiers
+
+| Tier | Trigger | Time to act |
+| --- | --- | --- |
+| **P0 — Active compromise** | Confirmed malicious package on (Test)PyPI, leaked publish token in public logs, attacker-controlled commit on `main`/`develop`, compromised maintainer account | Within 1 hour |
+| **P1 — Credible threat** | Secret exposed in a private log/screenshot, suspected hijack of a pinned action, credentials shared in plaintext | Within 4 hours |
+| **P2 — Hygiene** | Routine rotation, expiring token, contributor offboarding | Within 30 days |
+
+## P0 / P1 response (in order)
+
+### Step 1 — Halt the bleed
+
+1. **Disable the affected workflow.** GitHub → repo → Actions → select workflow
+   → ⋯ → *Disable workflow*. Do this before rotating, so a hijacked secret
+   can't be re-used by an in-flight run.
+2. **Cancel running workflow runs.** Actions tab → cancel anything in progress
+   that uses the secret. Confirm `Wait for pending jobs to complete` is *not*
+   selected.
+3. **Yank malicious releases.** If a compromised version was already published
+   to PyPI: `pip index versions idun-agent-engine` to confirm, then file an
+   [admin removal request](https://pypi.org/help/#admin-removal) via the PyPI
+   security contact. PyPI does not allow self-service deletion of a published
+   version, but maintainers can mark it yanked from the project page (Manage →
+   Releases → Yank). Yanking does not remove the artifact but prevents new
+   `pip install` resolutions from picking it.
+
+### Step 2 — Rotate the credential
+
+Rotate in this exact order: revoke first, then mint, then update the secret store.
+
+| Credential | Revoke | Mint replacement | Update secret store |
+| --- | --- | --- | --- |
+| `TEST_PYPI_API_TOKEN` | TestPyPI → Account settings → API tokens → *Remove* | TestPyPI → API tokens → *Add API token* (scope: project) | GitHub → repo Settings → Secrets and variables → Actions → edit `TEST_PYPI_API_TOKEN` |
+| PyPI trusted publisher (OIDC) | PyPI project → Settings → Publishing → *remove* the GitHub workflow entry | Re-add the workflow entry under the **new** workflow filename / job environment | No secret to update — OIDC handshake is handled at action runtime |
+| `GUARDRAILS_API_KEY` | Guardrails AI dashboard → *Revoke key* | Same dashboard → *New key* | GitHub Actions secret |
+| Langfuse keys | Langfuse → Settings → API keys → *Delete* | Same panel → *Create key* | GitHub Actions secret |
+| Model provider keys (OpenAI, Google, Anthropic, Gemini) | Each provider's console → revoke | Same console → mint new key | GitHub Actions secret |
+| `IDUN_DEV_READ_TOKEN` | `idun-dev` repo Settings → tokens → revoke | Same → mint new (scope: `read:contents`) | GitHub Actions secret |
+
+When a publish token has been used to push a malicious package, **also**
+rotate the maintainer account password for the affected registry, enable a
+hardware second factor if not already on, and audit the account's session
+history.
+
+### Step 3 — Investigate scope
+
+1. Pull workflow run logs (GitHub UI, *Re-run* dropdown → *View raw logs*)
+   and check for `Set up env` / `Print env` debug output that may have
+   echoed the secret.
+2. List recent runs that used the credential:
+   `gh run list --workflow=publish_engine_testpypi.yml --limit 50 --json conclusion,createdAt,headSha`.
+   Any successful run between the compromise window and the rotation timestamp
+   is a candidate for forensics.
+3. If a third-party GitHub Action was the entry point (the LiteLLM pattern):
+   - Confirm the SHA pin in our workflow against the action's release page
+     and Git history. A mismatched tag → SHA mapping means the tag was
+     rewritten upstream.
+   - Open an issue on the action's repo if confirmed.
+   - File a GitHub Support ticket if the action was distributed via the
+     Marketplace.
+
+### Step 4 — Re-enable
+
+1. Confirm the rotated secret in a dry-run job before re-enabling production
+   publish workflows. The `--dry-run` flag on `uv publish` validates the
+   token without uploading.
+2. Re-enable the workflow.
+3. Tag a deliberate test release on TestPyPI to confirm the pipeline is green.
+
+### Step 5 — Communicate
+
+1. Open a **GitHub Security Advisory** describing the incident, affected
+   versions, and the fix release. Use the `idun-agent-platform` repo for
+   advisories that span multiple published packages.
+2. Notify users via the changelog and (if downstream impact) a Discord/Slack
+   announcement.
+3. If a published wheel was malicious, contact PyPI security
+   (security@pypi.org) so they can flag the file in the index.
+4. Credit the reporter in the advisory if they consented (see SECURITY.md).
+
+### Step 6 — Post-incident review
+
+Write a brief post-mortem in `docs/adr/` (or wherever the team consolidates
+operational decisions) covering:
+
+- Timeline of detection → containment → rotation → re-enable.
+- Root cause (where did the credential leak, or which upstream got
+  compromised).
+- What detection signal we relied on and what would have caught it sooner.
+- Concrete follow-ups (e.g. add a check, pin a SHA, narrow a token scope).
+
+## P2 — Routine rotation
+
+Rotate every 90 days, or sooner if a maintainer with access leaves the team.
+Follow Step 2 above without the urgency of the rest of the runbook.
+
+A rotation log entry should be appended below.
+
+## Detection signals
+
+These are the signals we monitor to catch compromises early:
+
+- **GitHub Dependabot alerts** — `.github/dependabot.yml` configures weekly
+  scans of `pip`, `npm`, and `github-actions`. Critical alerts page the
+  maintainers.
+- **Socket Security org-side scanning** — full scans of every repo branch,
+  with policy gating at `error` level. Webhook configured to surface
+  newly-published packages with malware indicators in our dependency tree.
+- **`security-audit` CI job** — `pip-audit` + `pnpm audit` run on every PR
+  (`.github/workflows/ci.yml`). Currently advisory; will be ratcheted to
+  blocking after a stabilization period.
+- **Gitleaks pre-commit hook** — scans for accidentally committed secrets in
+  the local working tree. Configured in `.pre-commit-config.yaml`.
+- **GitHub Actions audit log** — Settings → Audit log; filter
+  `action:workflows.disable` and `action:secrets.update` for unexpected entries.
+
+## When in doubt
+
+Treat a suspicious event as P1 until you have evidence otherwise. The cost of
+rotating a credential and re-running CI is hours; the cost of letting a
+compromised token live is unbounded.
+
+## Rotation log
+
+| Date | Credential | Reason | Operator |
+| --- | --- | --- | --- |
+| _initial_ | — | runbook created | maintainers |

--- a/SECURITY-INCIDENT-RESPONSE.md
+++ b/SECURITY-INCIDENT-RESPONSE.md
@@ -130,8 +130,8 @@ A rotation log entry should be appended below.
 
 These are the signals we monitor to catch compromises early:
 
-- **GitHub Dependabot alerts** — `.github/dependabot.yml` configures weekly
-  scans of `pip`, `npm`, and `github-actions`. Critical alerts page the
+- **GitHub Dependabot alerts** — `.github/dependabot.yml` configures monthly
+  scans of `uv` (Python), `npm`, and `github-actions`. Critical alerts page the
   maintainers.
 - **Socket Security org-side scanning** — full scans of every repo branch,
   with policy gating at `error` level. Webhook configured to surface

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,19 +2,99 @@
 
 ## Reporting a vulnerability
 
-If you believe you have found a security vulnerability, **please report it privately**.
+If you believe you have found a security vulnerability in `idun-agent-platform`,
+the `idun-agent-engine` SDK, or any related Idun-published package
+(`idun-agent-schema`, `idun-agent-standalone`), **please report it privately**.
 
-- Email: contact@idun-group.com
+- **Preferred:** open a private report via
+  [GitHub Security Advisories](https://github.com/Idun-Group/idun-agent-platform/security/advisories/new).
+  This keeps the details confidential until a fix ships.
+- **Fallback:** email `contact@idun-group.com` with a description of the issue,
+  steps to reproduce, and any relevant logs or screenshots.
 
-Please include:
+**Please do not** open a public GitHub issue, discussion, or PR that
+describes an unpatched vulnerability.
 
-- A clear description of the issue and potential impact
-- Steps to reproduce (proof-of-concept if possible)
-- Affected component(s) (Engine / Manager / Web / CLI)
-- Any relevant logs, stack traces, or screenshots
+When you report, please include:
 
-We will acknowledge receipt as soon as possible and work with you on a fix and disclosure timeline.
+- A clear description of the issue and potential impact.
+- Steps to reproduce (proof-of-concept if possible).
+- Affected component(s): Engine SDK / Standalone runtime / Schema / Web UI / CLI.
+- The version(s) of `idun-agent-engine` / `idun-agent-schema` you are running
+  (`pip show idun-agent-engine`), and the Python version.
+- Any relevant logs, stack traces, or screenshots.
+
+## Response commitments
+
+- **Acknowledge** your report within **2 business days**.
+- **Triage and assess** severity within **5 business days**.
+- **Ship a fix** within **7 days** for critical vulnerabilities (CVSS ≥ 9.0)
+  and within **30 days** for high-severity issues (CVSS 7.0–8.9), assuming
+  the report contains enough detail to reproduce.
+- **Coordinate disclosure** with the reporter before any public announcement.
+  Embargo windows are negotiable for complex issues.
+
+## What counts as a security issue
+
+The following are explicitly in scope:
+
+- **Supply-chain attacks** — compromised dependencies, typosquatting, malicious
+  packages in our published wheel's transitive tree, or hijacked GitHub Actions
+  used by our CI.
+- **Credential exposure** — API keys, OIDC tokens, or session secrets leaked
+  through logs, error responses, telemetry, traces, or build artifacts.
+- **Remote code execution (RCE)** — any path that lets an attacker execute
+  arbitrary code on a host running the engine, the standalone runtime, or
+  the bundled admin UI.
+- **Sandbox / isolation escape** — bypassing guardrails or the agent boundary
+  to access the host filesystem, network, or environment variables that the
+  agent was not configured to reach.
+- **Authentication / authorization bypass** — circumventing the OIDC validator,
+  basic-auth gate, or session middleware on `/agent/*` and `/admin/*` routes.
+- **Injection** — prompt injection paths that bypass configured guardrails,
+  SQL injection via the admin REST surface, or YAML/Jinja injection in the
+  configuration loader.
+- **DoS through resource exhaustion** when triggerable by a single
+  unauthenticated request (e.g. an unbounded LLM call from an open endpoint).
+
+Out of scope (please file a regular issue instead):
+
+- Findings on dependencies' own websites or docs.
+- Theoretical risks without a demonstrated impact path.
+- Best-practice deviations that don't have an exploit path
+  (e.g. "you should add HSTS" with no concrete attack scenario).
+- Vulnerabilities in user-provided agent code or third-party agents loaded
+  via `graph_definition` — those are the operator's responsibility.
 
 ## Supported versions
 
-Security fixes are applied to the latest released versions of the project.
+Security fixes are applied to:
+
+- The **latest released minor** of `idun-agent-engine` and
+  `idun-agent-schema` on PyPI.
+- The current `main` branch.
+
+Older versions receive fixes on a best-effort basis when the upgrade path
+is non-trivial. Pre-release / `dev*` versions published to TestPyPI are not
+covered.
+
+## Why this policy exists
+
+LLM tooling sits in the critical path between user input and model output.
+Recent supply-chain incidents in adjacent projects
+(notably the LiteLLM 1.82.7/1.82.8 compromise via a hijacked GitHub Action)
+have shown that dependency integrity is a non-negotiable part of shipping
+agent infrastructure. We treat supply-chain hardening and credential hygiene
+as first-class concerns and welcome reports that strengthen them.
+
+## Credit
+
+Reporters who follow responsible disclosure will be credited by name (or handle)
+in the resulting GitHub Security Advisory and the CHANGELOG entry for the fix
+release, unless they prefer to remain anonymous.
+
+## Related operational docs
+
+- [`SECURITY-INCIDENT-RESPONSE.md`](SECURITY-INCIDENT-RESPONSE.md) —
+  contributor-facing runbook for rotating publish tokens, revoking compromised
+  credentials, and recovering from a supply-chain incident.


### PR DESCRIPTION
## Summary

Supply-chain hardening prompted by the LiteLLM 1.82.7/1.82.8 compromise (Apr 2026) and the parallel response from guardrails-ai/guardrails#1451. **No application code or dependency versions are touched** — only CI configuration and security documentation.

Three focused commits:

### 1. `ci(security): SHA-pin every GitHub Action across all workflows`

Replace 66 `actions/<x>@v<n>` tag refs with full commit SHAs and a trailing `# v<n>` comment, across `ci.yml`, `e2e-real-llm.yml`, `standalone-ci.yml`, `publish_engine_testpypi.yml`, `publish_schema_testpypi.yml`, and `release.yml`. Closes the exact vector that hit LiteLLM: an attacker rewriting Git tags on a third-party action repo. SHA pins cannot be rewritten upstream. Dependabot's `github-actions` ecosystem updates both the SHA and the comment atomically when a new release ships.

Unchanged: `setup-uv@v3` in the guidelines-check job stays at v3 (the rest of the file uses v6). Version-bumping that ref is out of scope for this PR.

### 2. `ci(security): add dep-audit job, fix Dependabot npm path`

- New `security-audit` job in `ci.yml`: runs `pip-audit` (OSV vuln service) on the uv-exported requirements tree and `pnpm audit --audit-level=high` on the standalone UI lockfile. Non-blocking (`continue-on-error: true`) so it surfaces findings as CI warnings + an uploaded `dependency-audit-reports` artifact while the team picks a triage cadence.
- Repoint Dependabot's npm ecosystem at `services/idun_agent_standalone_ui`. Previously pointed at the deleted `services/idun_agent_web` — the frontend had been receiving **zero** automated dependency updates since the standalone migration. Group renamed `web-all` → `standalone-ui-all`.

### 3. `docs(security): expand SECURITY.md, add incident-response runbook`

`SECURITY.md`:
- GitHub Security Advisories as preferred reporting channel; email kept as fallback.
- Explicit response SLAs (2 days ack / 5 days triage / 7 days fix for CVSS ≥ 9.0 / 30 days for 7.0–8.9).
- Scope: supply chain, RCE, sandbox escape, auth bypass, injection, unauth DoS. Plus an out-of-scope list so triage rejections are grounded.
- Credit policy and rationale.

New `SECURITY-INCIDENT-RESPONSE.md` (repo root — not auto-published by Mintlify):
- Inventory of every long-lived secret with owner + rotation procedure (`TEST_PYPI_API_TOKEN`, Guardrails / Langfuse / model-provider keys, `IDUN_DEV_READ_TOKEN`, `ANTHROPIC_API_KEY`, OIDC trusted publisher).
- P0 / P1 / P2 severity ladder with concrete time-to-act SLAs.
- Step-by-step response runbook: halt → rotate → investigate → re-enable → communicate → post-mortem. Each step gives the exact CLI / GitHub UI path.
- Detection-signal catalogue (Dependabot, Socket Security, this PR's `security-audit` job, Gitleaks, GH audit log).

## Out of scope (deliberately deferred)

- **Migrating TestPyPI publishing to OIDC trusted publishing** — the secret `TEST_PYPI_API_TOKEN` still exists in `publish_engine_testpypi.yml` and `publish_schema_testpypi.yml`. `release.yml` is already on trusted publishing (`id-token: write`). Worth a separate PR.
- **Dependabot cadence tuning** (monthly → weekly, PR limit, semver-major ignore) — separate decision.
- **Pre-commit hook for SHA pin enforcement** (`pinact` / `zizmor`) — see explanation in chat, separate PR if you want it.

## Test plan

- [x] All `.github/workflows/*.yml` files YAML-parse cleanly (verified locally with `python -c "yaml.safe_load(...)"`)
- [x] No `uses: <action>@v<n>` refs remain across workflows (`grep` returns no matches; 66/66 are SHA-pinned)
- [ ] First CI run on this branch turns the `security-audit` job green (or surfaces findings as warnings without blocking)
- [ ] Dependabot picks up the new npm path on the next scheduled scan and opens any pending PRs against `services/idun_agent_standalone_ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded security policy with private reporting workflow, scope definitions, supported-version info, and response timelines
  * Added a detailed security incident response runbook

* **Chores**
  * Pinned CI/CD actions to specific commit SHAs to harden supply-chain security
  * Added a security-audit job to surface dependency vulnerabilities
  * Updated dependency update configuration to target the standalone UI directory and group updates accordingly

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/638)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->