### PR TITLE
fix(engine): make guardrails-ai an optional extra to unblock PyPI quarantine

### DIFF
--- a/.github/workflows/e2e-real-llm.yml
+++ b/.github/workflows/e2e-real-llm.yml
@@ -86,7 +86,12 @@ jobs:
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Install workspace dependencies
-        run: uv sync --group dev
+        # ``--all-extras`` pulls in the engine's ``[guardrails]`` optional
+        # extra so the ``guardrails`` CLI is available for the
+        # pre-install step below. The extra became opt-in once PyPI
+        # quarantined ``guardrails-ai`` (see #642 / #643); e2e jobs are
+        # the one place we want it installed.
+        run: uv sync --group dev --all-extras
 
       - name: Pre-install Guardrails Hub validators
         # Bootstraps ~/.guardrailsrc (the CLI's auth file) and eagerly
@@ -140,7 +145,12 @@ jobs:
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Install workspace dependencies
-        run: uv sync --group dev
+        # ``--all-extras`` pulls in the engine's ``[guardrails]`` optional
+        # extra so the ``guardrails`` CLI is available for the
+        # pre-install step below. The extra became opt-in once PyPI
+        # quarantined ``guardrails-ai`` (see #642 / #643); e2e jobs are
+        # the one place we want it installed.
+        run: uv sync --group dev --all-extras
 
       - name: Pre-install Guardrails Hub validators
         # admin-edit-and-reload.spec.ts adds a BAN_LIST guardrail via

--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -64,9 +64,14 @@ dependencies = [
     "ag-ui-langgraph==0.0.25",
     "ag-ui-adk>=0.3.4,<0.6.0",
     "copilotkit==0.1.78",
-    # Guardrails and security
-    "guardrails-ai==0.9.2",
-    "openinference-instrumentation-guardrails>=0.1.0,<2.0.0",
+    # Security
+    # guardrails-ai + openinference-instrumentation-guardrails moved to the
+    # ``guardrails`` optional extra below. The PyPI ``guardrails-ai`` project
+    # was quarantined for a security incident, which made the engine wheel
+    # uninstallable from PyPI for every consumer — including those who never
+    # configure guardrails. Keeping it optional decouples the engine's
+    # install path from upstream quarantine status. Install with
+    # ``pip install 'idun-agent-engine[guardrails]'`` to opt in.
     "openinference-instrumentation>=0.1.0,<2.0.0",
     "PyJWT[crypto]>=2.9.0,<3.0.0",
     "cryptography>=46.0.3,<48.0.0",
@@ -110,6 +115,15 @@ dependencies = [
     "apscheduler>=3.10,<4",
     "rfc8785>=0.1,<1",
     "sentencepiece>=0.2.1,<1",
+]
+
+[project.optional-dependencies]
+# Opt-in guardrails support. Kept out of the default install so the engine
+# wheel does not depend on a single upstream package's availability on PyPI.
+# Install with: pip install 'idun-agent-engine[guardrails]'
+guardrails = [
+    "guardrails-ai==0.9.2",
+    "openinference-instrumentation-guardrails>=0.1.0,<2.0.0",
 ]
 
 [project.scripts]

--- a/libs/idun_agent_engine/src/idun_agent_engine/guardrails/guardrails_hub/guardrails_hub.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/guardrails/guardrails_hub/guardrails_hub.py
@@ -38,11 +38,18 @@ def _require_guardrails_ai() -> None:
     installable when the upstream PyPI project is quarantined. Surfacing
     the install hint at the point of use is friendlier than letting a
     deep ``ModuleNotFoundError`` propagate from the internal hub import.
+
+    The catch is narrowed to ``ModuleNotFoundError`` whose ``name`` is
+    exactly ``"guardrails"`` so transitive import failures inside an
+    installed guardrails-ai (e.g. a broken sub-dep) bubble up unmasked
+    rather than being rewritten as "the extra is missing".
     """
     try:
         import guardrails  # noqa: F401
-    except ImportError as exc:
-        raise ImportError(_GUARDRAILS_EXTRA_HINT) from exc
+    except ModuleNotFoundError as exc:
+        if exc.name == "guardrails":
+            raise ImportError(_GUARDRAILS_EXTRA_HINT) from exc
+        raise
 
 
 def get_guard_instance(name: GuardrailConfigId) -> type[Validator]:

--- a/libs/idun_agent_engine/src/idun_agent_engine/guardrails/guardrails_hub/guardrails_hub.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/guardrails/guardrails_hub/guardrails_hub.py
@@ -1,13 +1,18 @@
 """Guardrails."""
 
+from __future__ import annotations
+
 import logging
 import os
+from typing import TYPE_CHECKING
 
-from guardrails import Validator
 from idun_agent_schema.engine.guardrails import Guardrail as GuardrailSchema
 from idun_agent_schema.engine.guardrails_v2 import GuardrailConfigId
 
 from ..base import BaseGuardrail
+
+if TYPE_CHECKING:
+    from guardrails import Validator
 
 PII_ENTITY_MAP = {
     "Email": "EMAIL_ADDRESS",
@@ -19,9 +24,31 @@ PII_ENTITY_MAP = {
 
 logger = logging.getLogger(__name__)
 
+_GUARDRAILS_EXTRA_HINT = (
+    "guardrails-ai is required to use Guardrails Hub validators but is not "
+    "installed. Install the optional extra: "
+    "`pip install 'idun-agent-engine[guardrails]'`."
+)
+
+
+def _require_guardrails_ai() -> None:
+    """Raise a clear ImportError when ``guardrails`` is unavailable.
+
+    The dependency moved to an optional extra so the engine wheel stays
+    installable when the upstream PyPI project is quarantined. Surfacing
+    the install hint at the point of use is friendlier than letting a
+    deep ``ModuleNotFoundError`` propagate from the internal hub import.
+    """
+    try:
+        import guardrails  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(_GUARDRAILS_EXTRA_HINT) from exc
+
 
 def get_guard_instance(name: GuardrailConfigId) -> type[Validator]:
     """Returns a map of guard type -> guard instance."""
+    _require_guardrails_ai()
+
     if name == GuardrailConfigId.BAN_LIST:
         from guardrails.hub import BanList
 
@@ -75,6 +102,10 @@ class GuardrailsHubGuard(BaseGuardrail):
     """Class for managing guardrails from `guardrailsai`'s hub."""
 
     def __init__(self, config: GuardrailSchema, position: str) -> None:
+        # Surface a friendly install hint before any internal guardrails-ai
+        # import is reached during setup/validate.
+        _require_guardrails_ai()
+
         super().__init__(config)
 
         self.guard_id = self._guardrail_config.config_id

--- a/libs/idun_agent_engine/tests/conftest.py
+++ b/libs/idun_agent_engine/tests/conftest.py
@@ -7,6 +7,7 @@ Fixtures are designed to be composable and easy to customize for specific test n
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from collections.abc import AsyncGenerator, Callable, Generator
 from typing import Any
@@ -27,6 +28,16 @@ def pytest_sessionstart(session):
     api_key = os.getenv("GUARDRAILS_API_KEY")
     if not api_key:
         print("GUARDRAILS_API_KEY not set, skipping guardrails setup")
+        return
+
+    # guardrails-ai ships as an optional extra of idun-agent-engine. When the
+    # extra is not installed the CLI is absent — skip Hub install rather than
+    # crashing the entire session in pytest_sessionstart.
+    if shutil.which("guardrails") is None:
+        print(
+            "guardrails CLI not on PATH (optional extra not installed); "
+            "skipping guardrails setup"
+        )
         return
 
     try:

--- a/libs/idun_agent_engine/tests/unit/guardrails/test_optional_dep.py
+++ b/libs/idun_agent_engine/tests/unit/guardrails/test_optional_dep.py
@@ -1,0 +1,84 @@
+"""Tests for the optional ``guardrails-ai`` install path.
+
+The dependency lives in the ``guardrails`` optional extra of
+``idun-agent-engine``. Importing the engine — and any of its guardrails
+submodules — must succeed regardless of whether the extra is installed.
+Only the point of use must raise, and the error must point operators at
+the install command.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+_MODULE = "idun_agent_engine.guardrails.guardrails_hub.guardrails_hub"
+
+
+def _reload_module() -> object:
+    """Re-import the hub module under the current ``sys.modules`` patches."""
+    sys.modules.pop(_MODULE, None)
+    sys.modules.pop("idun_agent_engine.guardrails.guardrails_hub", None)
+    return importlib.import_module(_MODULE)
+
+
+@pytest.mark.unit
+def test_hub_module_imports_without_guardrails_ai(monkeypatch):
+    """The hub module must load even when ``guardrails`` is unavailable.
+
+    Operators who never configure guardrails should be able to install
+    the base engine wheel and import any submodule. The class symbol
+    must still exist after the reload — the absence of the optional
+    dependency only matters at construction time.
+    """
+    # Make ``import guardrails`` fail for the duration of this test.
+    monkeypatch.setitem(sys.modules, "guardrails", None)
+
+    module = _reload_module()
+
+    assert hasattr(module, "GuardrailsHubGuard")
+    assert hasattr(module, "_require_guardrails_ai")
+
+
+@pytest.mark.unit
+def test_require_guardrails_ai_raises_clear_error(monkeypatch):
+    """``_require_guardrails_ai`` must point at the optional extra.
+
+    A bare ``ModuleNotFoundError`` from a deep internal import leaves
+    operators guessing. The wrapper converts it into an actionable
+    install hint.
+    """
+    monkeypatch.setitem(sys.modules, "guardrails", None)
+
+    module = _reload_module()
+
+    with pytest.raises(ImportError, match=r"idun-agent-engine\[guardrails\]"):
+        module._require_guardrails_ai()
+
+
+@pytest.mark.unit
+def test_engine_package_does_not_import_guardrails_ai():
+    """Importing ``idun_agent_engine`` must not pull in ``guardrails-ai``.
+
+    The top-level package public API (``create_app``, ``run_server``,
+    ``ConfigBuilder``, ``BaseAgent``, ``get_prompt``) is reachable
+    without touching the guardrails hub. Regressing this would mean
+    every consumer of the engine wheel transitively depends on the
+    optional extra, defeating the split.
+    """
+    # Clear the cached engine import so the assertion reflects a cold
+    # import path rather than whatever fixtures already loaded.
+    for name in list(sys.modules):
+        if name == "idun_agent_engine" or name.startswith("idun_agent_engine."):
+            del sys.modules[name]
+    sys.modules.pop("guardrails", None)
+
+    importlib.import_module("idun_agent_engine")
+
+    assert "guardrails" not in sys.modules, (
+        "Importing idun_agent_engine transitively imported the optional "
+        "guardrails-ai package. Move the offending import behind a "
+        "TYPE_CHECKING guard or push it into the function that uses it."
+    )

--- a/libs/idun_agent_engine/tests/unit/guardrails/test_optional_dep.py
+++ b/libs/idun_agent_engine/tests/unit/guardrails/test_optional_dep.py
@@ -4,11 +4,13 @@ The dependency lives in the ``guardrails`` optional extra of
 ``idun-agent-engine``. Importing the engine — and any of its guardrails
 submodules — must succeed regardless of whether the extra is installed.
 Only the point of use must raise, and the error must point operators at
-the install command.
+the install command — without masking transitive import failures inside
+an installed guardrails-ai package.
 """
 
 from __future__ import annotations
 
+import builtins
 import importlib
 import sys
 
@@ -24,6 +26,28 @@ def _reload_module() -> object:
     return importlib.import_module(_MODULE)
 
 
+def _patch_import(monkeypatch, raises: BaseException) -> None:
+    """Make ``import guardrails`` raise ``raises``; pass others through.
+
+    Mirrors the real "module not installed" failure mode: a true
+    ``ModuleNotFoundError`` with ``name`` set, raised by the import
+    system itself. ``sys.modules[name] = None`` produces a generic
+    ``ImportError`` without ``.name`` and would not exercise the
+    narrowed catch in ``_require_guardrails_ai``.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "guardrails" or name.startswith("guardrails."):
+            raise raises
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    # Drop any cached entry so the hook actually runs on next import.
+    for cached in [m for m in list(sys.modules) if m.startswith("guardrails")]:
+        monkeypatch.delitem(sys.modules, cached, raising=False)
+
+
 @pytest.mark.unit
 def test_hub_module_imports_without_guardrails_ai(monkeypatch):
     """The hub module must load even when ``guardrails`` is unavailable.
@@ -33,8 +57,10 @@ def test_hub_module_imports_without_guardrails_ai(monkeypatch):
     must still exist after the reload — the absence of the optional
     dependency only matters at construction time.
     """
-    # Make ``import guardrails`` fail for the duration of this test.
-    monkeypatch.setitem(sys.modules, "guardrails", None)
+    _patch_import(
+        monkeypatch,
+        ModuleNotFoundError("No module named 'guardrails'", name="guardrails"),
+    )
 
     module = _reload_module()
 
@@ -48,14 +74,46 @@ def test_require_guardrails_ai_raises_clear_error(monkeypatch):
 
     A bare ``ModuleNotFoundError`` from a deep internal import leaves
     operators guessing. The wrapper converts it into an actionable
-    install hint.
+    install hint when the top-level ``guardrails`` package is missing.
     """
-    monkeypatch.setitem(sys.modules, "guardrails", None)
+    _patch_import(
+        monkeypatch,
+        ModuleNotFoundError("No module named 'guardrails'", name="guardrails"),
+    )
 
     module = _reload_module()
 
     with pytest.raises(ImportError, match=r"idun-agent-engine\[guardrails\]"):
         module._require_guardrails_ai()
+
+
+@pytest.mark.unit
+def test_require_guardrails_ai_does_not_mask_transitive_failure(monkeypatch):
+    """Transitive import failures inside guardrails must bubble up.
+
+    If ``guardrails-ai`` is installed but a sub-dep import breaks, the
+    operator needs the real traceback — rewriting it to "install the
+    extra" would send them on a wild goose chase. Only the case where
+    the missing module is exactly ``guardrails`` may be wrapped.
+    """
+    _patch_import(
+        monkeypatch,
+        ModuleNotFoundError(
+            "No module named 'guardrails.internal_dep'",
+            name="guardrails.internal_dep",
+        ),
+    )
+
+    module = _reload_module()
+
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        module._require_guardrails_ai()
+
+    assert excinfo.value.name == "guardrails.internal_dep"
+    # The friendly install hint must not appear — that would imply we
+    # told the operator to reinstall when the real problem lives
+    # elsewhere in the dependency graph.
+    assert "idun-agent-engine[guardrails]" not in str(excinfo.value)
 
 
 @pytest.mark.unit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,18 @@ idun-agent-schema = { workspace = true }
 idun-agent-standalone = { workspace = true }
 # Temporary workaround: the PyPI ``guardrails-ai`` project was quarantined for
 # a security incident, so the published 0.9.2 wheel is no longer resolvable.
-# Point uv at the upstream git tag so ``uv lock`` / ``uv sync`` succeed for the
-# optional ``[guardrails]`` extra of idun-agent-engine. Source overrides apply
-# only to local resolution — published engine wheels still reference
+# Point uv at the upstream git commit so ``uv lock`` / ``uv sync`` succeed for
+# the optional ``[guardrails]`` extra of idun-agent-engine. Source overrides
+# apply only to local resolution — published engine wheels still reference
 # ``guardrails-ai==0.9.2`` on PyPI, so end-users are unaffected once upstream
 # restores the project. Remove this entry when that happens.
-guardrails-ai = { git = "https://github.com/guardrails-ai/guardrails", tag = "v0.9.2" }
+#
+# ``rev`` is the peeled commit object of the annotated ``v0.9.2`` tag, pinned
+# rather than the tag name itself — tags can be moved or rewritten upstream,
+# commit SHAs cannot, so this keeps resolution reproducible and reduces
+# supply-chain risk. To refresh: ``git ls-remote --tags
+# https://github.com/guardrails-ai/guardrails | grep 'v0.9.2\^{}'``.
+guardrails-ai = { git = "https://github.com/guardrails-ai/guardrails", rev = "ee6999d84d3becdb3dbf5862ae7b893130ddacb8" }
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,14 @@ members = [
 idun-agent-engine = { workspace = true }
 idun-agent-schema = { workspace = true }
 idun-agent-standalone = { workspace = true }
+# Temporary workaround: the PyPI ``guardrails-ai`` project was quarantined for
+# a security incident, so the published 0.9.2 wheel is no longer resolvable.
+# Point uv at the upstream git tag so ``uv lock`` / ``uv sync`` succeed for the
+# optional ``[guardrails]`` extra of idun-agent-engine. Source overrides apply
+# only to local resolution — published engine wheels still reference
+# ``guardrails-ai==0.9.2`` on PyPI, so end-users are unaffected once upstream
+# restores the project. Remove this entry when that happens.
+guardrails-ai = { git = "https://github.com/guardrails-ai/guardrails", tag = "v0.9.2" }
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -1525,7 +1525,7 @@ wheels = [
 [[package]]
 name = "guardrails-ai"
 version = "0.9.2"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/guardrails-ai/guardrails?tag=v0.9.2#ee6999d84d3becdb3dbf5862ae7b893130ddacb8" }
 dependencies = [
     { name = "click" },
     { name = "diff-match-patch" },
@@ -1554,10 +1554,6 @@ dependencies = [
     { name = "tiktoken" },
     { name = "typer" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/62/2b28a8f7f9fbea06cdb76885a44ec0a5e0bad758b53d317c7039a5dfd164/guardrails_ai-0.9.2.tar.gz", hash = "sha256:4c136b7ef9ef1562098cbe91338f71fe91824cbf1393f3e5b3a0d8a393f55851", size = 170657, upload-time = "2026-03-16T18:22:00.903Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/67/b1db74bf7bd6cbbdd5e6f37880ece08e9d6a785cf955c8ba652ed43ec880/guardrails_ai-0.9.2-py3-none-any.whl", hash = "sha256:530758c544383c23f6a755670673988a5446c90596102d629cc89311a3616fb7", size = 237653, upload-time = "2026-03-16T18:22:02.116Z" },
 ]
 
 [[package]]
@@ -1735,7 +1731,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "google-adk" },
     { name = "google-cloud-logging" },
-    { name = "guardrails-ai" },
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "idun-agent-schema" },
@@ -1755,7 +1750,6 @@ dependencies = [
     { name = "openinference-instrumentation" },
     { name = "openinference-instrumentation-google-adk" },
     { name = "openinference-instrumentation-google-genai" },
-    { name = "openinference-instrumentation-guardrails" },
     { name = "openinference-instrumentation-langchain" },
     { name = "openinference-instrumentation-mcp" },
     { name = "openinference-instrumentation-vertexai" },
@@ -1777,6 +1771,12 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tavily-python" },
     { name = "uvicorn" },
+]
+
+[package.optional-dependencies]
+guardrails = [
+    { name = "guardrails-ai" },
+    { name = "openinference-instrumentation-guardrails" },
 ]
 
 [package.dev-dependencies]
@@ -1813,7 +1813,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0,<=0.134.0" },
     { name = "google-adk", specifier = ">=1.19.0,<2.0.0" },
     { name = "google-cloud-logging", specifier = ">=3.10.0,<4.0.0" },
-    { name = "guardrails-ai", specifier = "==0.9.2" },
+    { name = "guardrails-ai", marker = "extra == 'guardrails'", git = "https://github.com/guardrails-ai/guardrails?tag=v0.9.2" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "httpx-sse", specifier = ">=0.4.0,<1.0.0" },
     { name = "idun-agent-schema", editable = "libs/idun_agent_schema" },
@@ -1833,7 +1833,7 @@ requires-dist = [
     { name = "openinference-instrumentation", specifier = ">=0.1.0,<2.0.0" },
     { name = "openinference-instrumentation-google-adk", specifier = ">=0.1.0,<2.0.0" },
     { name = "openinference-instrumentation-google-genai", specifier = ">=0.1.0,<2.0.0" },
-    { name = "openinference-instrumentation-guardrails", specifier = ">=0.1.0,<2.0.0" },
+    { name = "openinference-instrumentation-guardrails", marker = "extra == 'guardrails'", specifier = ">=0.1.0,<2.0.0" },
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.13,<2.0.0" },
     { name = "openinference-instrumentation-mcp", specifier = ">=1.0.0,<2.0.0" },
     { name = "openinference-instrumentation-vertexai", specifier = ">=0.1.0,<2.0.0" },
@@ -1856,6 +1856,7 @@ requires-dist = [
     { name = "tavily-python", specifier = ">=0.7.9,<0.8.0" },
     { name = "uvicorn", specifier = ">=0.35.0,<=0.41.0" },
 ]
+provides-extras = ["guardrails"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1525,7 +1525,7 @@ wheels = [
 [[package]]
 name = "guardrails-ai"
 version = "0.9.2"
-source = { git = "https://github.com/guardrails-ai/guardrails?tag=v0.9.2#ee6999d84d3becdb3dbf5862ae7b893130ddacb8" }
+source = { git = "https://github.com/guardrails-ai/guardrails?rev=ee6999d84d3becdb3dbf5862ae7b893130ddacb8#ee6999d84d3becdb3dbf5862ae7b893130ddacb8" }
 dependencies = [
     { name = "click" },
     { name = "diff-match-patch" },
@@ -1813,7 +1813,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0,<=0.134.0" },
     { name = "google-adk", specifier = ">=1.19.0,<2.0.0" },
     { name = "google-cloud-logging", specifier = ">=3.10.0,<4.0.0" },
-    { name = "guardrails-ai", marker = "extra == 'guardrails'", git = "https://github.com/guardrails-ai/guardrails?tag=v0.9.2" },
+    { name = "guardrails-ai", marker = "extra == 'guardrails'", git = "https://github.com/guardrails-ai/guardrails?rev=ee6999d84d3becdb3dbf5862ae7b893130ddacb8" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "httpx-sse", specifier = ">=0.4.0,<1.0.0" },
     { name = "idun-agent-schema", editable = "libs/idun_agent_schema" },


### PR DESCRIPTION
## Summary

The PyPI [`guardrails-ai`](https://pypi.org/project/guardrails-ai/) project was put into quarantine for a security incident. Because `guardrails-ai==0.9.2` sat in `[project.dependencies]` of `idun-agent-engine`, the published wheel became uninstallable for **every** consumer (including those who never configure a guardrail), and our own `uv sync` / CI / deployments broke.

- Move `guardrails-ai` and `openinference-instrumentation-guardrails` into a new `[project.optional-dependencies]` extra named `guardrails`.
- Defer the previously top-level `from guardrails import Validator` import behind `TYPE_CHECKING` so the hub module loads cleanly without the extra installed.
- Add `_require_guardrails_ai()` to convert the deep `ModuleNotFoundError` into an actionable install hint at the point of use.
- Add a `[tool.uv.sources]` git override pointing `guardrails-ai` at the upstream `v0.9.2` tag so local resolution / CI keeps working while PyPI is quarantined. Source overrides apply only to workspace resolution — published wheels still reference the PyPI spec.
- Gate `conftest.pytest_sessionstart` on `shutil.which("guardrails")` so sessions without the optional extra installed no longer crash during collection.

## API impact

`pip install idun-agent-engine` works again without guardrails-ai. Users who want guardrails opt in:

```bash
pip install 'idun-agent-engine[guardrails]'
```

## Follow-up

Tracked in #643 — remove the temporary `[tool.uv.sources]` override once `guardrails-ai` is restored on PyPI.

## Test plan

- [x] New `tests/unit/guardrails/test_optional_dep.py` covers three regressions: module imports without guardrails-ai, helper raises with the install hint, `import idun_agent_engine` does not pull `guardrails` into `sys.modules`.
- [x] `uv run ruff check` passes on all changed files
- [x] `uv run pytest libs/idun_agent_engine/tests/unit/test_sanity.py libs/idun_agent_engine/tests/unit/test_guardrail_schema.py libs/idun_agent_engine/tests/unit/guardrails/` — 31 passed
- [x] `uv run pytest libs/idun_agent_engine/tests/unit/server/test_lifespan.py libs/idun_agent_engine/tests/unit/mcp/ -p no:xdist` — 80 passed
- [x] `uv lock` regenerates cleanly with the git override
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Guardrails moved to an optional extra—install with idun-agent-engine[guardrails]; reduces base install footprint.
  * Temporary local lock/source entry added to allow resolution of the optional guardrails extra.
  * CI e2e jobs now install extras so guardrails-related steps resolve.

* **Bug Fixes**
  * Missing guardrails now raises a clear, user-facing import/install error early.

* **Tests**
  * Added tests validating optional dependency handling and preventing transitively importing guardrails.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/642)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->