### PR TITLE
fix(standalone): fail loud when agent row exists but assembly raises (L10-2 / FIX 03)

### DIFF
--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -30,6 +30,7 @@ from fastapi.routing import APIRoute, Mount
 from fastapi.staticfiles import StaticFiles
 from idun_agent_engine import create_app as create_engine_app
 from idun_agent_engine.prompts.registry import set_active_prompts
+from sqlalchemy import func, select
 
 from idun_agent_standalone.api.v1._register import register_standalone_routers
 from idun_agent_standalone.api.v1.deps import reload_disabled, require_auth
@@ -38,6 +39,7 @@ from idun_agent_standalone.api.v1.openapi import OPENAPI_TAGS
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.core.security import SESSION_COOKIE_NAME
 from idun_agent_standalone.core.settings import AuthMode, StandaloneSettings
+from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
 from idun_agent_standalone.infrastructure.db.session import (
     create_db_engine,
     create_sessionmaker,
@@ -147,12 +149,36 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
         async with sessionmaker() as session:
             await ensure_admin_seeded(session, settings)
 
+    # Count agent rows first so AssemblyError can be classified.
+    # Zero rows + AssemblyError is wizard mode (intentional fall-through to
+    # admin-only). Any rows + AssemblyError is a deploy bug: a real agent was
+    # supposed to materialize, so log loudly and stash the reason on app.state
+    # for /health to surface.
+    boot_error: str | None = None
     async with sessionmaker() as session:
+        agent_count = await session.scalar(
+            select(func.count()).select_from(StandaloneAgentRow)
+        )
+        agent_count = agent_count or 0
         try:
             engine_config = await assemble_engine_config(session)
         except AssemblyError as exc:
-            logger.warning("boot engine layer skipped, admin only mode reason=%s", exc)
             engine_config = None
+            if agent_count > 0:
+                boot_error = (
+                    f"Agent assembly failed: {exc} "
+                    f"DB has {agent_count} agent row(s); "
+                    "configured agent will be unreachable."
+                )
+                logger.error("BOOT FAILED — %s", boot_error)
+                logger.error(
+                    "/agent/* will return 503 until the config is fixed and "
+                    "the engine reloaded."
+                )
+            else:
+                logger.info(
+                    "boot engine layer skipped, wizard mode reason=%s", exc
+                )
 
     # Publish the DB-backed prompts to the engine's process-wide snapshot
     # before the engine app boots — the LangGraph adapter's exec_module
@@ -184,6 +210,8 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
     app.state.settings = settings
     app.state.db_engine = db_engine
     app.state.sessionmaker = sessionmaker
+    if boot_error is not None:
+        app.state.boot_error = boot_error
     from idun_agent_standalone.services.engine_reload import (
         build_engine_reload_callable,
     )

--- a/libs/idun_agent_standalone/tests/integration/test_unconfigured_boot.py
+++ b/libs/idun_agent_standalone/tests/integration/test_unconfigured_boot.py
@@ -18,6 +18,11 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from idun_agent_standalone.app import create_standalone_app
 from idun_agent_standalone.core.settings import StandaloneSettings
+from idun_agent_standalone.infrastructure.db.models.agent import StandaloneAgentRow
+from idun_agent_standalone.infrastructure.db.session import (
+    create_db_engine,
+    create_sessionmaker,
+)
 
 
 @pytest.fixture
@@ -103,6 +108,9 @@ async def test_standalone_unconfigured_boot_serves_health_and_admin(empty_db_set
     they must work when the engine has no agent yet."""
     app = await create_standalone_app(empty_db_settings)
 
+    # Wizard mode (no agent row) must not set boot_error.
+    assert getattr(app.state, "boot_error", None) is None
+
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/health")
@@ -110,6 +118,7 @@ async def test_standalone_unconfigured_boot_serves_health_and_admin(empty_db_set
         body = response.json()
         assert body["status"] == "degraded"
         assert body["agent_ready"] is False
+        assert "reason" not in body
 
         # /admin/api/v1/agent returns 404 (no agent row) — that is the
         # wizard-not-yet-materialized signal the SPA's chat root reads to
@@ -120,3 +129,48 @@ async def test_standalone_unconfigured_boot_serves_health_and_admin(empty_db_set
         # /admin/api/v1/onboarding/scan works — wizard scanner endpoint.
         response = await client.post("/admin/api/v1/onboarding/scan")
         assert response.status_code == 200, response.text
+
+
+@pytest.fixture
+async def db_with_corrupt_agent(empty_db_settings):
+    """Seed an agent row whose ``base_engine_config`` fails Pydantic validation.
+
+    Exercises the failure-mode branch: an agent row exists (so wizard-mode
+    fall-through is wrong), but ``assemble_engine_config`` raises when
+    ``_parse_base_config`` validates the empty dict against ``EngineConfig``.
+    """
+    db_engine = create_db_engine(empty_db_settings.database_url)
+    sessionmaker = create_sessionmaker(db_engine)
+    async with sessionmaker() as session:
+        session.add(
+            StandaloneAgentRow(
+                name="Corrupt Agent",
+                base_engine_config={},
+            )
+        )
+        await session.commit()
+    await db_engine.dispose()
+    return empty_db_settings
+
+
+@pytest.mark.asyncio
+async def test_standalone_loud_failure_when_agent_row_exists_but_assembly_fails(
+    db_with_corrupt_agent,
+):
+    """When the DB has an agent row AND assembly raises, the standalone
+    must not silently fall through to admin-only mode. ``app.state.boot_error``
+    must carry the reason so ``/health`` can surface it.
+    """
+    app = await create_standalone_app(db_with_corrupt_agent)
+
+    assert app.state.boot_error is not None
+    assert "Corrupt Agent" in app.state.boot_error
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/health")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["status"] == "degraded"
+        assert body["agent_ready"] is False
+        assert body.get("reason") == app.state.boot_error

--- a/libs/idun_agent_standalone/tests/unit/test_lifespan_shutdown.py
+++ b/libs/idun_agent_standalone/tests/unit/test_lifespan_shutdown.py
@@ -60,6 +60,9 @@ async def test_lifespan_stops_trace_tasks_before_db_engine_dispose(monkeypatch):
         ) -> None:
             return None
 
+        async def scalar(self, *_a: object, **_kw: object) -> int:
+            return 0
+
     monkeypatch.setattr(
         app_module, "create_sessionmaker", lambda *a, **kw: lambda: _StubSession()
     )
@@ -140,6 +143,9 @@ async def test_lifespan_disposes_engine_when_no_trace_tasks(monkeypatch):
             tb: TracebackType | None,
         ) -> None:
             return None
+
+        async def scalar(self, *_a: object, **_kw: object) -> int:
+            return 0
 
     monkeypatch.setattr(
         app_module, "create_sessionmaker", lambda *a, **kw: lambda: _StubSession()


### PR DESCRIPTION
## Summary

- Distinguish wizard mode (zero agent rows + `AssemblyError` → INFO, fall-through to admin-only is intentional) from failure mode (agent rows present + `AssemblyError` → two `BOOT FAILED` ERROR lines, `app.state.boot_error` set so `/health` surfaces the reason).
- Pairs with #636 (already merged): that PR added `/health`'s `reason` reader; this one writes it.

## Why

Headline from the [L10 postmortem](https://github.com/Idun-Group/demo-idun-engine/blob/main/docs/learnings/10-untested-deployment-and-endpoint-misdiagnosis.md): when guardrails were configured without `GUARDRAILS_API_KEY`, the standalone caught `AssemblyError`, logged a single WARNING, and continued booting in admin-only mode. Probes saw a healthy `/health` and the failure went unnoticed.

The same fall-through is legitimately correct for the wizard's first-run flow (no agent row yet — wizard will materialize one), so we classify before logging.

## Test plan

- [x] `uv run pytest libs/idun_agent_standalone/tests` — **523 passed, 12 skipped** (was 521; +2 new tests, no regressions)
- [x] `uv run ruff check` on touched files — clean
- [x] `uv run mypy libs/idun_agent_standalone/src/idun_agent_standalone/app.py` — clean
- [x] Manual: wizard mode → `/health` returns `degraded` with no `reason`; INFO log `wizard mode reason=...`
- [x] Manual: agent row with corrupt `base_engine_config` → boot logs two `BOOT FAILED` ERROR lines, `/health` returns `degraded` + populated `reason`, `/agent/run` returns 503 `agent_not_ready`

## Refs

- `idun-dev/tasks/before-release-11-05-2026/03-standalone-fail-loud/FIX.md`
- FINDINGS.md L10-2 (MUST FIX before 0.6.0)
- Companion to #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)