### PR TITLE
chore(release): wheel-metadata guard + JSON-API note (L9-NEW2)

### DIFF
--- a/.github/workflows/publish_engine_testpypi.yml
+++ b/.github/workflows/publish_engine_testpypi.yml
@@ -100,6 +100,9 @@ jobs:
         run: |
           uv build --no-sources --wheel --out-dir dist
 
+      - name: Verify wheel metadata
+        run: bash scripts/check-wheel-metadata.sh libs/idun_agent_engine/dist/*.whl
+
       - name: Check distribution metadata
         run: |
           uvx twine check libs/idun_agent_engine/dist/*.whl libs/idun_agent_schema/dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,9 @@ jobs:
       - name: Check distribution metadata
         run: uvx twine check libs/idun_agent_engine/dist/*
 
+      - name: Verify wheel metadata
+        run: bash scripts/check-wheel-metadata.sh libs/idun_agent_engine/dist/*.whl
+
       - name: Smoke test built engine wheel
         run: |
           python -m venv /tmp/engine-prepub-venv

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ idun --help
 
 Both checks are smoke-tested in the release pipeline before any wheel is published.
 
+Heads up: `https://*.pypi.org/pypi/idun-agent-engine/<version>/json` reports `entry_points: null` and omits `idun-agent-standalone` from `requires_dist`. This is a Warehouse rendering quirk — the wheel itself still wires the `idun` console script and bundles standalone. The smoke-test commands above are the canonical way to verify a healthy install.
+
 ### YAML reference
 
 Every agent is configured through a single YAML file. Here is a complete example with all features enabled:

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ idun --help
 
 Both checks are smoke-tested in the release pipeline before any wheel is published.
 
-Heads up: `https://*.pypi.org/pypi/idun-agent-engine/<version>/json` reports `entry_points: null` and omits `idun-agent-standalone` from `requires_dist`. This is a Warehouse rendering quirk — the wheel itself still wires the `idun` console script and bundles standalone. The smoke-test commands above are the canonical way to verify a healthy install.
+Heads up: both `pypi.org` and `test.pypi.org` JSON APIs report `entry_points: null` and omit `idun-agent-standalone` from `requires_dist`. This is a Warehouse rendering quirk — the wheel itself still wires the `idun` console script and bundles standalone. The smoke-test commands above are the canonical way to verify a healthy install.
 
 ### YAML reference
 

--- a/libs/idun_agent_engine/README.md
+++ b/libs/idun_agent_engine/README.md
@@ -13,6 +13,17 @@ pip install idun-agent-engine
 - Requires Python 3.12+
 - Ships with FastAPI, Uvicorn, LangGraph, SQLite checkpointing, and optional observability hooks
 
+### A note on PyPI's JSON metadata
+
+Both TestPyPI's and public PyPI's JSON API at `/pypi/idun-agent-engine/<version>/json` report `entry_points: null` and omit `idun-agent-standalone` from `requires_dist`. This is a Warehouse rendering quirk: the wheel itself wires the `idun` console script and bundles the standalone package. To verify post-install:
+
+```bash
+python -c "import idun_agent_engine, idun_agent_standalone, idun_agent_schema"
+idun --help
+```
+
+Both commands succeed when the install is healthy.
+
 ## Quickstart
 
 ### 1) Minimal one-liner (from a YAML config)

--- a/scripts/check-wheel-metadata.sh
+++ b/scripts/check-wheel-metadata.sh
@@ -12,7 +12,11 @@ set -euo pipefail
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
-WHEEL="${1:?usage: $0 <wheel-path>}"
+# Accept exactly one positional arg. If a future `dist/*.whl` glob expands
+# to multiple files we want a loud failure here, not a silent skip of all
+# but the first.
+[[ $# -eq 1 ]] || fail "usage: $0 <wheel-path> (expected exactly 1 wheel, got $#)"
+WHEEL="$1"
 if [[ ! -f "$WHEEL" ]]; then
   fail "wheel not found: $WHEEL"
 fi
@@ -32,10 +36,17 @@ if [[ $rc -ne 0 && $rc -ne 11 ]]; then
   cat "$ERRLOG" >&2
   fail "cannot read entry_points.txt from $WHEEL (unzip exited $rc)"
 fi
+# Distinguish "no entry_points.txt in the wheel at all" (force-include missing)
+# from "entry_points.txt present but our line is missing" (CLI mis-wired).
+# The former is the more likely future regression and deserves a fix-pointing
+# message; the latter would be a content typo in [project.scripts].
+if [[ $rc -eq 11 || -z "$EP" ]]; then
+  fail "entry_points.txt not bundled in $WHEEL — check [tool.hatch.build.targets.wheel.force-include] in libs/idun_agent_engine/pyproject.toml"
+fi
 if ! grep -qE '^idun[[:space:]]*=[[:space:]]*idun_agent_standalone\.cli:main$' <<<"$EP"; then
   echo "got:" >&2
   echo "$EP" >&2
-  fail "entry_points.txt missing 'idun = idun_agent_standalone.cli:main'"
+  fail "entry_points.txt present but missing 'idun = idun_agent_standalone.cli:main' — check [project.scripts] in libs/idun_agent_engine/pyproject.toml"
 fi
 
 # 2. idun_agent_standalone is co-bundled in the wheel

--- a/scripts/check-wheel-metadata.sh
+++ b/scripts/check-wheel-metadata.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# check-wheel-metadata.sh — assert the engine wheel ships a valid
+# bundling contract: idun CLI wired to standalone, standalone
+# co-bundled, and idun-agent-schema declared as a runtime dep.
+#
+# Background: see idun-dev/tasks/before-release-11-05-2026/09-testpypi-metadata/FIX.md
+# (L9-NEW2). PyPI's JSON API renders entry_points / requires_dist
+# unreliably; the wheel itself is the canonical source. This guard
+# locks the contract at build time so a future refactor cannot break
+# the bundling silently.
+set -euo pipefail
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+WHEEL="${1:?usage: $0 <wheel-path>}"
+if [[ ! -f "$WHEEL" ]]; then
+  fail "wheel not found: $WHEEL"
+fi
+
+ERRLOG="$(mktemp)"
+trap 'rm -f "$ERRLOG"' EXIT
+
+# unzip exit codes we tolerate as "archive readable, content just empty":
+#   11 = "no matching files were found" (pattern didn't match)
+# Anything else from unzip means the archive itself is unreadable/corrupt.
+
+# 1. entry_points.txt wires the idun CLI to standalone
+rc=0
+EP="$(unzip -p "$WHEEL" '*.dist-info/entry_points.txt' 2>"$ERRLOG")" || rc=$?
+if [[ $rc -ne 0 && $rc -ne 11 ]]; then
+  echo "unzip stderr:" >&2
+  cat "$ERRLOG" >&2
+  fail "cannot read entry_points.txt from $WHEEL (unzip exited $rc)"
+fi
+if ! grep -qE '^idun[[:space:]]*=[[:space:]]*idun_agent_standalone\.cli:main$' <<<"$EP"; then
+  echo "got:" >&2
+  echo "$EP" >&2
+  fail "entry_points.txt missing 'idun = idun_agent_standalone.cli:main'"
+fi
+
+# 2. idun_agent_standalone is co-bundled in the wheel
+rc=0
+LISTING="$(unzip -l "$WHEEL" 2>"$ERRLOG")" || rc=$?
+if [[ $rc -ne 0 ]]; then
+  echo "unzip stderr:" >&2
+  cat "$ERRLOG" >&2
+  fail "cannot list contents of $WHEEL (unzip exited $rc)"
+fi
+if ! grep -q 'idun_agent_standalone/__init__\.py' <<<"$LISTING"; then
+  fail "idun_agent_standalone/__init__.py not co-bundled in wheel"
+fi
+
+# 3. METADATA declares idun-agent-schema as a runtime dep
+rc=0
+METADATA="$(unzip -p "$WHEEL" '*.dist-info/METADATA' 2>"$ERRLOG")" || rc=$?
+if [[ $rc -ne 0 && $rc -ne 11 ]]; then
+  echo "unzip stderr:" >&2
+  cat "$ERRLOG" >&2
+  fail "cannot read METADATA from $WHEEL (unzip exited $rc)"
+fi
+if ! grep -qE '^Requires-Dist:[[:space:]]*idun-agent-schema' <<<"$METADATA"; then
+  fail "METADATA missing 'Requires-Dist: idun-agent-schema'"
+fi
+
+echo "wheel metadata OK: $WHEEL"


### PR DESCRIPTION
## Summary

Addresses [L9-NEW2](https://github.com/Idun-Group/idun-dev/blob/main/tasks/before-release-11-05-2026/09-testpypi-metadata/FIX.md): both TestPyPI and public PyPI's JSON API at `/pypi/idun-agent-engine/<version>/json` report `entry_points: null` and omit `idun-agent-standalone` from `requires_dist`, even though the wheel itself wires the `idun` console script and force-includes the standalone package. This metadata gap caused a full day of misdiagnosis in `demo-idun-engine`.

Two changes:

- **README notes** (`README.md` + `libs/idun_agent_engine/README.md`) — short paragraphs explaining the Warehouse JSON quirk and pointing adopters at post-install verification commands. The engine README's PyPI page gets the full subsection; the top-level README's existing FIX 05 bundled-install section gets a one-line "Heads up" addition (verification commands already live there).
- **CI guard** (`scripts/check-wheel-metadata.sh` + workflow wiring) — asserts the engine wheel's bundling contract (`entry_points.txt` → `idun_agent_standalone.cli:main`, standalone force-include, schema runtime dep) right after `uv build` in both `publish_engine_testpypi.yml` and `release.yml`. A future refactor of `pyproject.toml` that silently breaks bundling now fails the build before reaching pip-install territory.

The investigation behind this PR is in [`idun-dev/tasks/before-release-11-05-2026/09-testpypi-metadata/FIX.md`](https://github.com/Idun-Group/idun-dev/blob/main/tasks/before-release-11-05-2026/09-testpypi-metadata/FIX.md) (idun-dev PR #45). Verified locally that the wheel is canonical; no build-pipeline fix needed.

## Commits

- `c9ac4a9f` — chore(release): add check-wheel-metadata.sh guard for engine wheel
- `f20bc9ab` — docs: note PyPI's JSON API rendering quirk for entry_points
- `d0d44e2c` — ci(testpypi): assert engine wheel metadata before publish
- `3521b7d8` — ci(release): assert engine wheel metadata before PyPI publish

## Test plan

- [ ] CI green on this branch — `publish_engine_testpypi.yml` runs the new `Verify wheel metadata` step and exits 0
- [ ] Manual local check (already verified pre-push): `(cd libs/idun_agent_engine && uv build --no-sources --wheel --out-dir /tmp/_w) && bash scripts/check-wheel-metadata.sh /tmp/_w/*.whl` prints `wheel metadata OK`
- [ ] Manual regression check (already verified pre-push, multiple ways): `zip -d` `entry_points.txt` or `idun_agent_standalone/__init__.py` out of a copy of the wheel, or feed it a corrupt non-zip file — script exits non-zero with a distinct FAIL message for each failure mode
- [ ] READMEs render correctly on GitHub — "A note on PyPI's JSON metadata" visible under engine README's Installation; "Heads up" paragraph visible under top-level README's "Components in this install"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated wheel metadata verification to CI that checks built engine wheels before publishing.

* **Documentation**
  * Clarified a PyPI metadata rendering quirk and added verification instructions to confirm the installed wheel provides the expected console script and bundled components.

* **Chores**
  * Added a command-line verification utility to validate wheel contents locally and in CI.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/646)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->