### PR TITLE
fix(standalone): return JSON 404 for unmapped /admin/api/* paths (FIX 12)

### DIFF
--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -30,11 +30,15 @@ from fastapi.routing import APIRoute, Mount
 from fastapi.staticfiles import StaticFiles
 from idun_agent_engine import create_app as create_engine_app
 from idun_agent_engine.prompts.registry import set_active_prompts
+from idun_agent_schema.standalone import StandaloneAdminError, StandaloneErrorCode
 from sqlalchemy import func, select
 
 from idun_agent_standalone.api.v1._register import register_standalone_routers
 from idun_agent_standalone.api.v1.deps import reload_disabled, require_auth
-from idun_agent_standalone.api.v1.errors import register_admin_exception_handlers
+from idun_agent_standalone.api.v1.errors import (
+    AdminAPIError,
+    register_admin_exception_handlers,
+)
 from idun_agent_standalone.api.v1.openapi import OPENAPI_TAGS
 from idun_agent_standalone.core.logging import get_logger
 from idun_agent_standalone.core.security import SESSION_COOKIE_NAME
@@ -267,6 +271,24 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
     app.openapi_tags = OPENAPI_TAGS
     admin_auth = [Depends(require_auth)]
     register_standalone_routers(app, admin_auth=admin_auth)
+
+    # Catch-all 404 for unmapped /admin/api/* paths. StaticFiles(html=True)
+    # mounted at / below would otherwise return the SPA index.html for these
+    # paths, which trips anything probing the REST surface (curl, Postman,
+    # OpenAPI clients) into JSON-parsing HTML.
+    @app.api_route(
+        "/admin/api/{rest_of_path:path}",
+        methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+        include_in_schema=False,
+    )
+    async def _admin_api_not_found(rest_of_path: str) -> None:
+        raise AdminAPIError(
+            status_code=404,
+            error=StandaloneAdminError(
+                code=StandaloneErrorCode.NOT_FOUND,
+                message=f"No admin API endpoint at /admin/api/{rest_of_path}",
+            ),
+        )
 
     ui_dir = _resolve_ui_dir(settings)
     if ui_dir is not None:

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -276,10 +276,16 @@ async def create_standalone_app(settings: StandaloneSettings) -> FastAPI:
     # mounted at / below would otherwise return the SPA index.html for these
     # paths, which trips anything probing the REST surface (curl, Postman,
     # OpenAPI clients) into JSON-parsing HTML.
+    #
+    # Gated by require_auth for the same reason as the concrete admin
+    # routers: under password mode, an unauthenticated 401 on real routes
+    # and an unauthenticated 404 here would let a probe enumerate the
+    # admin REST surface without credentials.
     @app.api_route(
         "/admin/api/{rest_of_path:path}",
         methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
         include_in_schema=False,
+        dependencies=admin_auth,
     )
     async def _admin_api_not_found(rest_of_path: str) -> None:
         raise AdminAPIError(

--- a/libs/idun_agent_standalone/tests/integration/standalone/test_admin_api_404.py
+++ b/libs/idun_agent_standalone/tests/integration/standalone/test_admin_api_404.py
@@ -10,7 +10,14 @@ caller doing ``JSON.parse`` on the response.
 
 from __future__ import annotations
 
+import asyncio
+from pathlib import Path
+
+import pytest
 from httpx import ASGITransport, AsyncClient
+from idun_agent_standalone.app import create_standalone_app
+from idun_agent_standalone.core.settings import AuthMode, StandaloneSettings
+from idun_agent_standalone.db.migrate import upgrade_head
 
 
 async def test_unmapped_admin_api_returns_json_404(standalone):
@@ -34,13 +41,62 @@ async def test_unmapped_admin_api_v2_also_404s(standalone):
     assert response.headers["content-type"].startswith("application/json")
 
 
-async def test_admin_spa_still_serves_html(standalone):
-    """``/admin/`` (the SPA root) is not shadowed by the API catch-all."""
-    transport = ASGITransport(app=standalone)
+async def test_admin_spa_still_serves_html(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """``/admin/`` (the SPA root) is not shadowed by the API catch-all.
+
+    Provisions a stub ``index.html`` and points ``IDUN_UI_DIR`` at it so
+    ``_resolve_ui_dir`` returns a real directory and ``StaticFiles`` is
+    mounted at ``/`` (matching production, where the wheel ships with a
+    bundled SPA). Without this stub, clean CI has no built UI and the
+    test would only exercise the unmounted-static path, never proving
+    the catch-all leaves the SPA root reachable.
+    """
+    db_path = tmp_path / "standalone.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    await asyncio.to_thread(upgrade_head)
+    monkeypatch.setenv("IDUN_ADMIN_AUTH_MODE", AuthMode.NONE.value)
+
+    ui_dir = tmp_path / "ui"
+    ui_dir.mkdir()
+    (ui_dir / "index.html").write_text("<!doctype html><title>stub</title>")
+    # StaticFiles(html=True) maps /admin/ to <ui_dir>/admin/index.html — the
+    # bundled Next.js export ships a per-route index.html; mirror that here.
+    (ui_dir / "admin").mkdir()
+    (ui_dir / "admin" / "index.html").write_text(
+        "<!doctype html><title>admin</title>"
+    )
+    monkeypatch.setenv("IDUN_UI_DIR", str(ui_dir))
+
+    settings = StandaloneSettings()
+    app = await create_standalone_app(settings)
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/admin/")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html")
+    finally:
+        await app.state.db_engine.dispose()
+
+
+async def test_unmapped_admin_api_under_password_mode_requires_auth(
+    standalone_password,
+):
+    """Unauth probes can't tell mapped from unmapped admin paths.
+
+    Regression for the route-enumeration leak: if the catch-all skipped
+    ``require_auth``, an unauthenticated caller would see ``401`` for
+    every real admin route and ``404`` for unmapped ones, mapping the
+    REST surface without credentials. Both must return ``401``.
+    """
+    transport = ASGITransport(app=standalone_password)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/admin/")
-    assert response.status_code == 200
-    assert response.headers["content-type"].startswith("text/html")
+        real = await client.get("/admin/api/v1/agent")
+        unmapped = await client.get("/admin/api/v1/nonexistent")
+    assert real.status_code == 401
+    assert unmapped.status_code == 401
 
 
 async def test_real_admin_route_is_not_shadowed(standalone):

--- a/libs/idun_agent_standalone/tests/integration/standalone/test_admin_api_404.py
+++ b/libs/idun_agent_standalone/tests/integration/standalone/test_admin_api_404.py
@@ -1,0 +1,61 @@
+"""Unmapped paths under ``/admin/api/`` must return a JSON 404 envelope.
+
+Without an explicit catch-all, ``StaticFiles(directory=ui_dir, html=True)``
+mounted at ``/`` falls back to ``index.html`` for paths it doesn't know
+about — so probes against ``/admin/api/v1/<typo>`` would see the chat UI
+HTML bundle instead of a structured 404. That masks routing misses as
+"page exists, blank" and trips OpenAPI clients, curl debugging, and any
+caller doing ``JSON.parse`` on the response.
+"""
+
+from __future__ import annotations
+
+from httpx import ASGITransport, AsyncClient
+
+
+async def test_unmapped_admin_api_returns_json_404(standalone):
+    """A typo'd admin API path returns 404 with the admin error envelope."""
+    transport = ASGITransport(app=standalone)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/nonexistent")
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert body["error"]["code"] == "not_found"
+    assert "/admin/api/v1/nonexistent" in body["error"]["message"]
+
+
+async def test_unmapped_admin_api_v2_also_404s(standalone):
+    """The catch-all covers any ``/admin/api/`` subpath, not just v1."""
+    transport = ASGITransport(app=standalone)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v2/something")
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+
+
+async def test_admin_spa_still_serves_html(standalone):
+    """``/admin/`` (the SPA root) is not shadowed by the API catch-all."""
+    transport = ASGITransport(app=standalone)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+
+
+async def test_real_admin_route_is_not_shadowed(standalone):
+    """A concrete admin route resolves to its own handler, not the catch-all.
+
+    With no agent row seeded, ``/admin/api/v1/agent`` returns 404 via the
+    real router's not-found path. The catch-all would have produced the
+    same status code but a different envelope (``code="not_found"`` with a
+    path-bearing message). Asserting on the real router's message proves
+    declaration order is preserving concrete routes ahead of the wildcard.
+    """
+    transport = ASGITransport(app=standalone)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/admin/api/v1/agent")
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"]["code"] == "not_found"
+    assert "nonexistent" not in body["error"]["message"].lower()

--- a/libs/idun_agent_standalone/tests/integration/standalone/test_admin_api_404.py
+++ b/libs/idun_agent_standalone/tests/integration/standalone/test_admin_api_404.py
@@ -47,10 +47,9 @@ async def test_real_admin_route_is_not_shadowed(standalone):
     """A concrete admin route resolves to its own handler, not the catch-all.
 
     With no agent row seeded, ``/admin/api/v1/agent`` returns 404 via the
-    real router's not-found path. The catch-all would have produced the
-    same status code but a different envelope (``code="not_found"`` with a
-    path-bearing message). Asserting on the real router's message proves
-    declaration order is preserving concrete routes ahead of the wildcard.
+    real router's not-found path. The catch-all uses a distinctive
+    ``"No admin API endpoint at ..."`` template, so asserting that string
+    is absent fails iff the wildcard shadowed the concrete route.
     """
     transport = ASGITransport(app=standalone)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -58,4 +57,4 @@ async def test_real_admin_route_is_not_shadowed(standalone):
     assert response.status_code == 404
     body = response.json()
     assert body["error"]["code"] == "not_found"
-    assert "nonexistent" not in body["error"]["message"].lower()
+    assert "No admin API endpoint at" not in body["error"]["message"]


### PR DESCRIPTION
## Summary

Add a catch-all ``/admin/api/{rest:path}`` route between the real admin routers and the ``StaticFiles`` mount so unmapped admin API paths return a structured JSON 404 instead of the SPA's ``index.html``.

## Why

``StaticFiles(directory=ui_dir, html=True)`` mounted at ``/`` falls back to ``index.html`` for any path it doesn't recognize. ``/admin/api/v1/<typo>`` therefore returned ``text/html`` to API probes, which confuses curl/Postman debugging and trips OpenAPI client generators walking the API surface. Found during the L11 browser walkthrough.

## How

Concrete admin routes win over ``{rest_of_path:path}`` at the same depth in FastAPI's routing, so existing endpoints keep their handlers. The catch-all raises ``AdminAPIError`` to reuse the existing ``{"error": {...}}`` envelope and stable ``not_found`` code rather than emitting a one-off shape.

```bash
$ curl -s http://localhost:8000/admin/api/v1/typo | jq
{
  "error": {
    "code": "not_found",
    "message": "No admin API endpoint at /admin/api/v1/typo"
  }
}
```

## Test plan

- [x] ``uv run pytest libs/idun_agent_standalone/tests`` — **527 passed, 12 skipped** (+4 new tests, no regressions)
- [x] ``uv run ruff check`` on touched files — clean
- [x] ``uv run mypy libs/idun_agent_standalone/src/idun_agent_standalone/app.py`` — clean
- [x] Manual: ``/admin/api/v1/typo`` → JSON 404 envelope; ``/admin/`` → SPA HTML 200; ``/admin/api/v1/agent`` (no agent seeded) → real router's 404, not the catch-all

## Refs

- ``idun-dev/tasks/before-release-11-05-2026/12-admin-api-404/FIX.md``
- FINDINGS.md L11-33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unmapped /admin/api/ endpoints now return a structured JSON 404 (no longer serve SPA HTML).
  * Admin API catch-all does not shadow concrete admin routes.

* **Tests**
  * Added integration tests validating JSON 404 for unmapped /admin/api/ (v1 and v2).
  * Tests confirm admin SPA still serves HTML at /admin/.
  * Tests verify auth-mode returns 401 for protected admin endpoints and does not leak route existence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/647)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->