### PR TITLE
feat(scanner): detect langgraph agents built via known factories + CompiledStateGraph annotations

### DIFF
--- a/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py
@@ -43,11 +43,21 @@ _SKIP_DIRS = frozenset(
 _MAX_DEPTH = 4
 _MAX_FILE_BYTES = 1_000_000  # 1 MB
 
-_LANGGRAPH_IMPORT_RE = re.compile(r"(?m)^\s*(from\s+langgraph[\s.]|import\s+langgraph)")
+_LANGGRAPH_IMPORT_RE = re.compile(
+    r"(?m)^\s*("
+    r"from\s+langgraph[\s.]|import\s+langgraph"
+    r"|from\s+deepagents[\s.]|import\s+deepagents"
+    r")"
+)
 _ADK_IMPORT_RE = re.compile(r"(?m)^\s*(from\s+google\.adk|import\s+google\.adk)")
 _ADK_AGENT_CLASSES = frozenset(
     {"Agent", "LlmAgent", "SequentialAgent", "ParallelAgent", "LoopAgent"}
 )
+
+_LANGGRAPH_FACTORY_EXPORTS: dict[str, frozenset[str]] = {
+    "langgraph.prebuilt": frozenset({"create_react_agent"}),
+    "deepagents": frozenset({"create_deep_agent"}),
+}
 
 
 def _is_skipped(name: str) -> bool:
@@ -133,6 +143,9 @@ def _detect_in_source(rel_path: str, abs_path: Path) -> list[DetectedAgent]:
     state_graph_bindings: set[str] = set()
     compiled_from_binding: set[str] = set()
     lg_builder_funcs: set[str] = set()
+    factory_names: frozenset[str] = frozenset()
+    if has_lg:
+        factory_names = _collect_factory_names(module)
 
     # First pass: collect StateGraph bindings so we can resolve `.compile()`.
     for stmt in module.body:
@@ -149,12 +162,13 @@ def _detect_in_source(rel_path: str, abs_path: Path) -> list[DetectedAgent]:
     # Pre-pass: collect same-module functions that return a LangGraph
     # (compiled or bare). This lets us resolve ``graph = _build()``
     # against ``def _build(): ...; return builder.compile()`` — the
-    # canonical idiom most LangGraph examples use (see issue #555).
+    # canonical idiom most LangGraph examples use (see issue #555) —
+    # plus the wrapper-around-factory shape (``return create_deep_agent(...)``).
     if has_lg:
         for stmt in module.body:
             if isinstance(
                 stmt, (ast.FunctionDef, ast.AsyncFunctionDef)
-            ) and _function_returns_langgraph(stmt):
+            ) and _function_returns_langgraph(stmt, factory_names):
                 lg_builder_funcs.add(stmt.name)
 
     # Second pass: emit detections.
@@ -198,6 +212,25 @@ def _detect_in_source(rel_path: str, abs_path: Path) -> list[DetectedAgent]:
             continue
 
         if has_lg and _is_call_to(rhs, frozenset(lg_builder_funcs)):
+            for target_name in targets:
+                found.append(
+                    DetectedAgent(
+                        framework="LANGGRAPH",
+                        file_path=rel_path,
+                        variable_name=target_name,
+                        inferred_name="",
+                        confidence="MEDIUM",
+                        source="source",
+                    )
+                )
+            continue
+
+        # Order matters: ``lg_builder_funcs`` is checked above so that a
+        # same-module wrapper around a factory (``def make(): return
+        # create_deep_agent(...); agent = make()``) emits exactly one
+        # detection through the builder path rather than double-firing here
+        # if the name happened to be re-imported.
+        if has_lg and factory_names and _is_call_to(rhs, factory_names):
             for target_name in targets:
                 found.append(
                     DetectedAgent(
@@ -286,18 +319,74 @@ def _iter_fn_statements(fn: ast.FunctionDef | ast.AsyncFunctionDef):
             stack.append(child)
 
 
+def _annotation_is_compiled_state_graph(node: ast.AST | None) -> bool:
+    """True if ``node`` is an annotation naming ``CompiledStateGraph``.
+
+    Accepts the unqualified name, dotted attribute paths
+    (``langgraph.graph.state.CompiledStateGraph``), and subscript forms
+    (``CompiledStateGraph[State]``). The presence of this annotation —
+    on a function return or a variable — is a load-bearing signal that
+    the file produces a compiled LangGraph.
+
+    This helper is gate-agnostic — the caller is responsible for
+    ensuring the file actually imports langgraph (``has_lg``) before
+    trusting an annotation match.
+    """
+    if node is None:
+        return False
+    if isinstance(node, ast.Subscript):
+        return _annotation_is_compiled_state_graph(node.value)
+    if isinstance(node, ast.Name):
+        return node.id == "CompiledStateGraph"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "CompiledStateGraph"
+    return False
+
+
+def _collect_factory_names(module: ast.Module) -> frozenset[str]:
+    """Return the in-scope names of known LangGraph-producing factories.
+
+    Walks module-level ``ImportFrom`` nodes. For each ``from <mod> import
+    <name>`` whose ``<mod>`` is a key in ``_LANGGRAPH_FACTORY_EXPORTS``
+    and whose ``<name>`` is in the allowed set, the in-scope binding
+    (``alias.asname or alias.name``) is added. Star imports are skipped
+    because they can't be statically resolved.
+    """
+    names: set[str] = set()
+    for stmt in module.body:
+        if not isinstance(stmt, ast.ImportFrom) or stmt.module is None:
+            continue
+        allowed = _LANGGRAPH_FACTORY_EXPORTS.get(stmt.module)
+        if allowed is None:
+            continue
+        for alias in stmt.names:
+            if alias.name == "*":
+                continue
+            if alias.name in allowed:
+                names.add(alias.asname or alias.name)
+    return frozenset(names)
+
+
 def _function_returns_langgraph(
     fn: ast.FunctionDef | ast.AsyncFunctionDef,
+    factory_names: frozenset[str] = frozenset(),
 ) -> bool:
-    """True if ``fn`` returns a ``StateGraph(...)`` (compiled or bare).
+    """True if ``fn`` returns a compiled LangGraph.
 
-    Mirrors the module-level shapes recognized in ``_detect_in_source``:
-    direct ``StateGraph(...)``, ``StateGraph(...).compile()``, ``<g>.compile()``
-    where ``g`` is a local StateGraph binding, or a return of any such
-    binding by name.
+    Recognized shapes (mirroring ``_detect_in_source``):
+
+    - ``-> CompiledStateGraph`` annotation on the function (trusted on its own).
+    - Body returns ``StateGraph(...)``, ``StateGraph(...).compile()``, or
+      ``<g>.compile()`` where ``<g>`` is a local ``StateGraph`` binding.
+    - Body returns a call to a known factory in ``factory_names``.
+    - Body returns a local name bound to any of the above.
     """
+    if _annotation_is_compiled_state_graph(fn.returns):
+        return True
+
     state_graph_locals: set[str] = set()
     compiled_locals: set[str] = set()
+    factory_result_locals: set[str] = set()
 
     for node in _iter_fn_statements(fn):
         targets = _assign_targets(node)
@@ -311,6 +400,9 @@ def _function_returns_langgraph(
             continue
         if _module_compile_target(rhs, state_graph_locals):
             compiled_locals.update(targets)
+            continue
+        if factory_names and _is_call_to(rhs, factory_names):
+            factory_result_locals.update(targets)
 
     for node in _iter_fn_statements(fn):
         if not isinstance(node, ast.Return) or node.value is None:
@@ -320,8 +412,12 @@ def _function_returns_langgraph(
             return True
         if _module_compile_target(value, state_graph_locals):
             return True
+        if factory_names and _is_call_to(value, factory_names):
+            return True
         if isinstance(value, ast.Name) and (
-            value.id in state_graph_locals or value.id in compiled_locals
+            value.id in state_graph_locals
+            or value.id in compiled_locals
+            or value.id in factory_result_locals
         ):
             return True
     return False

--- a/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
+++ b/libs/idun_agent_standalone/tests/unit/services/test_scanner.py
@@ -245,6 +245,395 @@ async def test_detect_langgraph_via_build_function_called_twice(tmp_path: Path) 
     assert names == {"alpha", "beta"}
 
 
+async def test_detect_create_deep_agent(tmp_path: Path) -> None:
+    """``agent = create_deep_agent(...)`` is the canonical deepagents shape."""
+    src = (
+        "from deepagents import create_deep_agent\n"
+        "\n"
+        "agent = create_deep_agent(model=None, tools=[])\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    d = result.detected[0]
+    assert d.framework == "LANGGRAPH"
+    assert d.variable_name == "agent"
+    assert d.confidence == "MEDIUM"
+    assert d.source == "source"
+
+
+async def test_detect_create_react_agent(tmp_path: Path) -> None:
+    """``agent = create_react_agent(...)`` is the canonical langgraph prebuilt shape."""
+    src = (
+        "from langgraph.prebuilt import create_react_agent\n"
+        "\n"
+        "agent = create_react_agent(model=None, tools=[])\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].framework == "LANGGRAPH"
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_detect_factory_with_aliased_import(tmp_path: Path) -> None:
+    """``from deepagents import create_deep_agent as build`` honors the alias."""
+    src = (
+        "from deepagents import create_deep_agent as build\n"
+        "\n"
+        "agent = build(model=None, tools=[])\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_detect_factory_wrapped_in_function(tmp_path: Path) -> None:
+    """Wrapper function returning a factory call is recognized without an annotation.
+
+    Mirrors the exact text-to-sql-agent shape: a builder function that
+    forwards to ``create_deep_agent`` with no return annotation.
+    """
+    src = (
+        "from deepagents import create_deep_agent\n"
+        "\n"
+        "def make():\n"
+        "    return create_deep_agent(model=None, tools=[])\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_detect_factory_wrapped_in_async_function(tmp_path: Path) -> None:
+    """``async def make(): return create_deep_agent(...)`` is also a builder."""
+    src = (
+        "from deepagents import create_deep_agent\n"
+        "\n"
+        "async def make():\n"
+        "    return create_deep_agent(model=None, tools=[])\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_detect_factory_wrapped_via_local_binding(tmp_path: Path) -> None:
+    """Wrapper that binds the factory result and returns the name still counts."""
+    src = (
+        "from deepagents import create_deep_agent\n"
+        "\n"
+        "def make():\n"
+        "    tmp = create_deep_agent(model=None, tools=[])\n"
+        "    return tmp\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_detect_multiple_factories_in_same_file(tmp_path: Path) -> None:
+    """Two factory calls produce two detections."""
+    src = (
+        "from langgraph.prebuilt import create_react_agent\n"
+        "from deepagents import create_deep_agent\n"
+        "\n"
+        "alpha = create_react_agent(model=None, tools=[])\n"
+        "beta = create_deep_agent(model=None, tools=[])\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    names = {d.variable_name for d in result.detected}
+    assert names == {"alpha", "beta"}
+    assert all(d.framework == "LANGGRAPH" for d in result.detected)
+
+
+async def test_detect_factory_among_other_imports_from_same_module(
+    tmp_path: Path,
+) -> None:
+    """Mixed import list: only the recognized factory name is bound."""
+    src = (
+        "from deepagents import create_deep_agent, FilesystemBackend\n"
+        "\n"
+        "_backend = FilesystemBackend(root_dir='.')\n"
+        "agent = create_deep_agent(model=None, tools=[], backend=_backend)\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    names = {d.variable_name for d in result.detected}
+    assert names == {"agent"}
+
+
+async def test_detect_langgraph_via_compiled_state_graph_return_annotation(
+    tmp_path: Path,
+) -> None:
+    """``def make() -> CompiledStateGraph`` is a builder even with an opaque body."""
+    src = (
+        "from langgraph.graph.state import CompiledStateGraph\n"
+        "\n"
+        "def make() -> CompiledStateGraph:\n"
+        "    return _something_opaque()  # type: ignore[name-defined]\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_detect_langgraph_via_compiled_state_graph_subscript_annotation(
+    tmp_path: Path,
+) -> None:
+    """Generic ``-> CompiledStateGraph[State]`` is still recognized."""
+    src = (
+        "from langgraph.graph.state import CompiledStateGraph\n"
+        "\n"
+        "def make() -> CompiledStateGraph[dict]:\n"
+        "    return _opaque()  # type: ignore[name-defined]\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_detect_langgraph_via_compiled_state_graph_dotted_annotation(
+    tmp_path: Path,
+) -> None:
+    """Fully qualified ``langgraph.graph.state.CompiledStateGraph`` is recognized."""
+    src = (
+        "import langgraph.graph.state\n"
+        "\n"
+        "def make() -> langgraph.graph.state.CompiledStateGraph:\n"
+        "    return _opaque()  # type: ignore[name-defined]\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_detect_async_function_with_compiled_state_graph_annotation(
+    tmp_path: Path,
+) -> None:
+    """Async builder with the annotation is recognized."""
+    src = (
+        "from langgraph.graph.state import CompiledStateGraph\n"
+        "\n"
+        "async def make() -> CompiledStateGraph:\n"
+        "    return _opaque()  # type: ignore[name-defined]\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_no_detection_for_factory_name_without_import(tmp_path: Path) -> None:
+    """A local function named ``create_deep_agent`` is not a factory.
+
+    Confirms the import gate: only names actually imported from the
+    recognized factory modules count.
+    """
+    src = (
+        "from langgraph.graph import StateGraph\n"  # forces has_lg=True
+        "\n"
+        "def create_deep_agent():\n"
+        "    return 'fake'\n"
+        "\n"
+        "agent = create_deep_agent()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    names = {d.variable_name for d in result.detected}
+    assert "agent" not in names
+
+
+async def test_no_detection_for_factory_import_without_call(tmp_path: Path) -> None:
+    """Imported but never called → no detection."""
+    src = "from deepagents import create_deep_agent\n"
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_no_detection_for_factory_in_conditional_expression(
+    tmp_path: Path,
+) -> None:
+    """``agent = factory(...) if cond else None`` is an IfExp, not a Call."""
+    src = (
+        "from deepagents import create_deep_agent\n"
+        "\n"
+        "cond = True\n"
+        "agent = create_deep_agent(model=None, tools=[]) if cond else None\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    names = {d.variable_name for d in result.detected}
+    assert "agent" not in names
+
+
+async def test_no_detection_for_factory_in_dict_value(tmp_path: Path) -> None:
+    """Factory call inside a dict literal is not a module-level agent binding."""
+    src = (
+        "from deepagents import create_deep_agent\n"
+        "\n"
+        "agents = {'sql': create_deep_agent(model=None, tools=[])}\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_no_detection_when_wrapper_discards_factory_result(
+    tmp_path: Path,
+) -> None:
+    """A wrapper that calls the factory but returns ``None`` is not a builder."""
+    src = (
+        "from deepagents import create_deep_agent\n"
+        "\n"
+        "def make():\n"
+        "    create_deep_agent(model=None, tools=[])  # result discarded\n"
+        "    return None\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_no_detection_for_factory_via_star_import(tmp_path: Path) -> None:
+    """``from deepagents import *`` is not statically resolvable.
+
+    The scanner can't know which names the wildcard brought in, so the
+    safe default is no detection. Documented limitation.
+    """
+    src = (
+        "from deepagents import *\n"
+        "\n"
+        "agent = create_deep_agent(model=None, tools=[])\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_no_detection_for_compiled_state_graph_annotation_without_langgraph_import(
+    tmp_path: Path,
+) -> None:
+    """A ``-> CompiledStateGraph`` annotation in a file with no langgraph
+    or deepagents import is not enough on its own.
+
+    Pins the contract that ``_annotation_is_compiled_state_graph`` is
+    gate-agnostic and the caller (the ``has_lg`` regex pre-filter) owns
+    the trust decision. Without the import gate firing, the annotation
+    pre-pass never runs.
+    """
+    src = (
+        "def make() -> CompiledStateGraph:  # type: ignore[name-defined]\n"
+        "    return None  # type: ignore[return-value]\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_detect_compiled_state_graph_annotation_with_none_body(
+    tmp_path: Path,
+) -> None:
+    """The annotation is trusted even when the body returns ``None``.
+
+    The annotation is treated as a declarative contract — we don't try to
+    second-guess the body. This pins that ``trust-the-annotation``
+    contract explicitly.
+    """
+    src = (
+        "from langgraph.graph.state import CompiledStateGraph\n"
+        "\n"
+        "def make() -> CompiledStateGraph:\n"
+        "    return None  # type: ignore[return-value]\n"
+        "\n"
+        "agent = make()\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert len(result.detected) == 1
+    assert result.detected[0].variable_name == "agent"
+
+
+async def test_no_detection_for_factory_via_module_import_attribute_access(
+    tmp_path: Path,
+) -> None:
+    """``import deepagents`` + ``deepagents.create_deep_agent(...)`` is not detected.
+
+    The scanner only resolves bare ``Name`` calls, not ``Attribute``
+    calls. Documented limitation matching the existing scanner's
+    ``StateGraph`` recognizer (which also requires the unqualified
+    name). Users who hit this should switch to ``from deepagents import
+    create_deep_agent``.
+    """
+    src = (
+        "import deepagents\n"
+        "\n"
+        "agent = deepagents.create_deep_agent(model=None, tools=[])\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    assert result.detected == []
+
+
+async def test_factory_and_state_graph_coexist_in_same_file(tmp_path: Path) -> None:
+    """A file with both a StateGraph compile and a factory call emits both."""
+    src = (
+        "from langgraph.graph import StateGraph\n"
+        "from deepagents import create_deep_agent\n"
+        "\n"
+        "graph = StateGraph(int).compile()\n"
+        "agent = create_deep_agent(model=None, tools=[])\n"
+    )
+    (tmp_path / "agent.py").write_text(src)
+    result = await scan_folder(tmp_path)
+    names = {d.variable_name for d in result.detected}
+    assert names == {"graph", "agent"}
+    assert all(d.framework == "LANGGRAPH" for d in result.detected)
+
+
+async def test_factory_in_file_does_not_block_adk_in_another_file(
+    tmp_path: Path,
+) -> None:
+    """Factory detection in one file is independent of ADK detection in another."""
+    (tmp_path / "lg.py").write_text(
+        "from deepagents import create_deep_agent\n"
+        "agent = create_deep_agent(model=None, tools=[])\n"
+    )
+    (tmp_path / "adk.py").write_text(
+        "from google.adk.agents import Agent\n" "root_agent = Agent(name='x')\n"
+    )
+    result = await scan_folder(tmp_path)
+    by_framework = {d.framework: d.variable_name for d in result.detected}
+    assert by_framework == {"LANGGRAPH": "agent", "ADK": "root_agent"}
+
+
 async def test_detect_minimal_adk(tmp_path: Path) -> None:
     (tmp_path / "agent.py").write_text(
         "from google.adk.agents import Agent\n" "root_agent = Agent(name='x')\n"


### PR DESCRIPTION
## Summary

- Onboarding scanner now recognizes LangGraph agents built via known third-party factories. Adds an import-gated allowlist (`langgraph.prebuilt.create_react_agent`, `deepagents.create_deep_agent`) wired in next to the existing `StateGraph` / ADK recognizers.
- `_function_returns_langgraph` also accepts a `-> CompiledStateGraph` return annotation (unqualified, dotted, and subscript forms) as a parallel signal — covers wrappers around opaque factory bodies.
- Repro case: `~/Desktop/code/work/text-to-sql-agent/agent.py` (deepagents-built compiled graph) now detects to one `LANGGRAPH agent` entry; previously silently missed.

## Test plan

- [ ] `uv run pytest libs/idun_agent_standalone/tests/unit/services/test_scanner.py` — 69 tests including 20 new (8 factory positives, 4 annotation positives, 6 negative gates, 2 cross-framework interactions, 3 edge cases pinning the import gate / annotation-with-None-body / module-import limitation).
- [ ] `uv run pytest libs/idun_agent_standalone/tests` — full standalone suite, no regressions (550 passed locally).
- [ ] `uv run ruff check libs/idun_agent_standalone/src/idun_agent_standalone/services/scanner.py` and `uv run mypy …/scanner.py` — clean.
- [ ] Manual: point the wizard at a folder containing a `create_deep_agent` build with no `langgraph.json` / `config.yaml`. Expect a single `LANGGRAPH` detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded LangGraph agent detection to recognize factory-based creation patterns, including DeepAgents and LangGraph prebuilt factories
  * Enhanced compiled state graph detection with improved annotation recognition

* **Tests**
  * Added extensive test coverage for factory detection patterns, compiled state graph scenarios, and edge cases to ensure accurate agent identification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Idun-Group/idun-agent-platform/pull/657)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->