### PR TITLE
feat: open chat under password mode; propagate user_id end-to-end

### DIFF
--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
@@ -33,6 +33,17 @@ from idun_agent_engine.server.dependencies import (
 logger = logging.getLogger(__name__)
 agent_router = APIRouter(tags=["Runtime"])
 
+# Generous cap; fits emails, UUIDs, opaque SSO subs without rejecting
+# realistic identities. Oversized or control-char values fall through to
+# the uuid4 fallback in _resolve_user_id.
+_MAX_HEADER_USER_ID_LEN = 256
+
+
+def _is_valid_header_user_id(value: str) -> bool:
+    if not value or len(value) > _MAX_HEADER_USER_ID_LEN:
+        return False
+    return not any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value)
+
 
 def _extract_text_values(data: Any) -> list[str]:
     """Extract all non-empty string values from structured input."""
@@ -113,7 +124,7 @@ def _resolve_user_id(user: dict | None, request: Request) -> str:
         if claim:
             return claim
     header = request.headers.get("x-idun-user-id", "").strip()
-    if header:
+    if _is_valid_header_user_id(header):
         return header
     return uuid.uuid4().hex
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
@@ -216,15 +216,13 @@ async def run(
     encoder = EventEncoder(accept=accept_header or "")
 
     async def event_generator():
-        # Bind for the streaming task so adapter user_id_extractors and
-        # session-listing fallbacks see the same value.
-        token = current_user_id.set(resolved_user_id)
-        try:
-            # Project the resolved user into OTel context so
-            # LangChainInstrumentor stamps user.id on every span emitted
-            # while agent.run is running. See
-            # tasks/trace-feature-08-05-2026/15-user-session-propagation.md.
-            with using_user(resolved_user_id):
+        # _bind_user_id mirrors the binding used by /agent/sessions* so a
+        # future change to the helper picks up the streaming path too.
+        # using_user projects the resolved user into OTel context for
+        # LangChainInstrumentor span stamping (see
+        # tasks/trace-feature-08-05-2026/15-user-session-propagation.md).
+        with _bind_user_id(resolved_user_id), using_user(resolved_user_id):
+            try:
                 async for event in agent.run(input_data):
                     # Registry isolates per-observer exceptions, so dispatch cannot
                     # masquerade as an agent failure here. Route-synthesized
@@ -255,22 +253,19 @@ async def run(
                         except Exception:
                             yield 'event: error\ndata: {"error": "Event encoding failed"}\n\n'
                         break
-        except Exception as agent_error:
-            logger.error(f"Agent run error: {agent_error}", exc_info=True)
-            from ag_ui.core import EventType, RunErrorEvent
+            except Exception as agent_error:
+                logger.error(f"Agent run error: {agent_error}", exc_info=True)
+                from ag_ui.core import EventType, RunErrorEvent
 
-            error_event = RunErrorEvent(
-                type=EventType.RUN_ERROR,
-                message=f"Agent execution failed: {agent_error}",
-                code="FRAMEWORK_ERROR",
-            )
-            try:
-                yield encoder.encode(error_event)
-            except Exception:
-                yield 'event: error\ndata: {"error": "Agent execution failed"}\n\n'
-        finally:
-            current_user_id.reset(token)
-            logger.debug(f"Run — reset user_id token thread_id={input_data.thread_id}")
+                error_event = RunErrorEvent(
+                    type=EventType.RUN_ERROR,
+                    message=f"Agent execution failed: {agent_error}",
+                    code="FRAMEWORK_ERROR",
+                )
+                try:
+                    yield encoder.encode(error_event)
+                except Exception:
+                    yield 'event: error\ndata: {"error": "Agent execution failed"}\n\n'
 
     return StreamingResponse(event_generator(), media_type=encoder.get_content_type())
 

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
@@ -2,6 +2,8 @@
 
 import logging
 import time
+import uuid
+from contextlib import contextmanager
 from typing import Annotated, Any
 
 from ag_ui.core.types import RunAgentInput
@@ -78,16 +80,42 @@ async def capabilities(
     return caps
 
 
-def _resolve_user_id(user: dict | None) -> str | None:
-    """Map a verified SSO claims dict to a user identifier for scoping.
+@contextmanager
+def _bind_user_id(user_id: str):
+    """Bind ``current_user_id`` for the duration of a route's adapter call.
 
-    Prefers ``email`` (matches ADK's per-user session model), falls back
-    to ``sub``. Returns ``None`` when SSO is off — the route relies on the
-    adapter's own scoping rules in that case.
+    Adapters that scope by user (LangGraph in Step 2, ADK today) can
+    read this ContextVar without depending on the route to thread the id
+    through as a kwarg on every method.
     """
-    if not user:
-        return None
-    return user.get("email") or user.get("sub")
+    token = current_user_id.set(user_id)
+    try:
+        yield
+    finally:
+        current_user_id.reset(token)
+
+
+def _resolve_user_id(user: dict | None, request: Request) -> str:
+    """Resolve the user id for chat scoping.
+
+    Priority:
+      1. SSO claim (``email``, then ``sub``) when the verified user dict
+         carries a non-empty value.
+      2. ``X-Idun-User-Id`` request header when claims are absent.
+      3. Fresh ``uuid.uuid4().hex`` minted per request as a safety net
+         so callers never see ``None``.
+
+    The header is trusted only when claims are absent. With SSO
+    configured the JWT claim wins; the header is ignored even if sent.
+    """
+    if user:
+        claim = user.get("email") or user.get("sub")
+        if claim:
+            return claim
+    header = request.headers.get("x-idun-user-id", "").strip()
+    if header:
+        return header
+    return uuid.uuid4().hex
 
 
 @agent_router.get("/sessions", response_model=list[SessionSummary])
@@ -112,8 +140,9 @@ async def list_sessions(
                 "agent_type": agent.agent_type,
             },
         )
-    user_id = _resolve_user_id(user)
-    return await agent.list_sessions(user_id=user_id)
+    user_id = _resolve_user_id(user, request)
+    with _bind_user_id(user_id):
+        return await agent.list_sessions(user_id=user_id)
 
 
 @agent_router.get("/sessions/{session_id}", response_model=SessionDetail)
@@ -139,8 +168,9 @@ async def get_session(
                 "agent_type": agent.agent_type,
             },
         )
-    user_id = _resolve_user_id(user)
-    detail = await agent.get_session(session_id, user_id=user_id)
+    user_id = _resolve_user_id(user, request)
+    with _bind_user_id(user_id):
+        detail = await agent.get_session(session_id, user_id=user_id)
     if detail is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return detail
@@ -159,7 +189,7 @@ async def run(
     """
     last_msg = input_data.messages[-1] if input_data.messages else None
     last_content = str(last_msg.content)[:120] if last_msg else "<empty>"
-    resolved_user_id = _resolve_user_id(user) or current_user_id.get()
+    resolved_user_id = _resolve_user_id(user, request)
     logger.info(
         f"Run — thread_id={input_data.thread_id}, "
         f"user_id={resolved_user_id}, message={last_content}"

--- a/libs/idun_agent_engine/tests/unit/server/routers/test_resolve_user_id.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/test_resolve_user_id.py
@@ -126,3 +126,37 @@ def test_uuid_fallbacks_are_distinct_across_requests():
     req1 = _request_with_headers({})
     req2 = _request_with_headers({})
     assert _resolve_user_id(None, req1) != _resolve_user_id(None, req2)
+
+
+# --- header validation (security) -----------------------------------------
+
+
+def test_header_value_at_max_length_is_accepted():
+    """The cap is generous (256 chars) to fit emails, UUIDs, and opaque
+    SSO subs without rejecting realistic identities."""
+    value = "a" * 256
+    req = _request_with_headers({"X-Idun-User-Id": value})
+    assert _resolve_user_id(None, req) == value
+
+
+def test_header_value_exceeding_max_length_falls_back_to_uuid():
+    """Caller cannot inflate the user_id past the cap. Oversized values
+    fall through silently so misbehaving clients still get a usable
+    (anonymous) identity."""
+    oversized = "a" * 257
+    req = _request_with_headers({"X-Idun-User-Id": oversized})
+    result = _resolve_user_id(None, req)
+    assert _UUID_HEX.fullmatch(result), f"expected uuid hex, got {result!r}"
+    assert result != oversized
+
+
+def test_header_value_with_control_chars_falls_back_to_uuid():
+    """Control characters (newlines, nulls, etc.) could break log
+    parsing, DB queries that scope by user_id, or HTTP header
+    serialization downstream. Reject by falling through to uuid."""
+    for bad in ("alice\nbob", "alice\x00bob", "alice\tbob", "alice\x7fbob"):
+        req = _request_with_headers({"X-Idun-User-Id": bad})
+        result = _resolve_user_id(None, req)
+        assert _UUID_HEX.fullmatch(result), (
+            f"control-char value {bad!r} should have fallen through, got {result!r}"
+        )

--- a/libs/idun_agent_engine/tests/unit/server/routers/test_resolve_user_id.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/test_resolve_user_id.py
@@ -1,0 +1,128 @@
+"""Tests for `_resolve_user_id` resolution order and contract.
+
+Resolution priority:
+1. SSO claim (`email`, then `sub`) when the verified user dict carries one.
+2. `X-Idun-User-Id` request header when no claim is available.
+3. Fresh `uuid4().hex` minted per-request as a safety net so callers
+   never see ``None``.
+
+The header is trusted only when claims are absent. With SSO configured
+the JWT claim wins and the header is ignored, even when present.
+
+Each test in this file targets a concrete failure mode rather than a
+branch coverage tick:
+  * the contract (always a non-empty string),
+  * the trust boundary (claim beats header),
+  * implementation traps (empty-string claim, UUID-not-hex, accidental
+    caching of the fallback).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from starlette.requests import Request
+
+from idun_agent_engine.server.routers.agent import _resolve_user_id
+
+pytestmark = pytest.mark.unit
+
+_UUID_HEX = re.compile(r"[0-9a-f]{32}")
+
+
+def _request_with_headers(headers: dict[str, str]) -> Request:
+    """Build a Starlette Request carrying the given HTTP headers."""
+    scope = {
+        "type": "http",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+    }
+    return Request(scope)
+
+
+# --- claim path -----------------------------------------------------------
+
+
+def test_returns_email_claim_when_present():
+    """Happy path: SSO with email claim wins. Pinning email over sub
+    preserves the existing trace-dashboard contract."""
+    req = _request_with_headers({})
+    user = {"email": "alice@example.com", "sub": "alice-1"}
+    assert _resolve_user_id(user, req) == "alice@example.com"
+
+
+def test_falls_back_to_sub_when_email_missing():
+    """Some IdPs (Okta machine-to-machine, custom audiences) omit email."""
+    req = _request_with_headers({})
+    user = {"sub": "alice-1"}
+    assert _resolve_user_id(user, req) == "alice-1"
+
+
+def test_empty_email_falls_through_to_sub():
+    """An empty-string `email` claim must not become the resolved id.
+    Catches `user.get("email", "")` without an emptiness check, which
+    would return ``""`` and break downstream header passthrough."""
+    req = _request_with_headers({})
+    user = {"email": "", "sub": "alice-1"}
+    assert _resolve_user_id(user, req) == "alice-1"
+
+
+# --- header path ----------------------------------------------------------
+
+
+def test_reads_x_idun_user_id_header_when_no_claim():
+    """SSO off: the SPA-minted identity comes in via the header."""
+    req = _request_with_headers({"X-Idun-User-Id": "bob@example.com"})
+    assert _resolve_user_id(None, req) == "bob@example.com"
+
+
+def test_header_lookup_is_case_insensitive():
+    """Header lookup must follow HTTP norms; pins reliance on Starlette
+    rather than ``request.headers[...]`` raw access."""
+    req = _request_with_headers({"x-idun-user-id": "lowercase-client"})
+    assert _resolve_user_id(None, req) == "lowercase-client"
+
+
+def test_whitespace_only_header_falls_back_to_uuid():
+    """A user-controlled header containing only whitespace must not
+    become a user id. Combined with the contract test below, this pins
+    both stripping and the absent-after-strip handling."""
+    req = _request_with_headers({"X-Idun-User-Id": "   "})
+    result = _resolve_user_id(None, req)
+    assert _UUID_HEX.fullmatch(result), f"expected uuid hex, got {result!r}"
+
+
+# --- trust boundary (security-critical) -----------------------------------
+
+
+def test_claim_wins_over_header_when_both_present():
+    """The header is trusted only when SSO is off. If a spoofed header
+    could override a valid claim, an authenticated user could be
+    impersonated by any client. Pin this explicitly."""
+    req = _request_with_headers({"X-Idun-User-Id": "evil-spoofer"})
+    user = {"email": "alice@example.com"}
+    assert _resolve_user_id(user, req) == "alice@example.com"
+
+
+# --- uuid fallback contract -----------------------------------------------
+
+
+def test_uuid_fallback_returns_plain_hex_string():
+    """``uuid.uuid4()`` returns a UUID object; ``.hex`` returns a 32-char
+    lowercase hex string. If the implementation forgets ``.hex`` the
+    downstream header passthrough breaks because ``str(UUID(...))`` has
+    dashes (a different format from what the SPA mints with
+    ``crypto.randomUUID()`` plus header normalization)."""
+    req = _request_with_headers({})
+    result = _resolve_user_id(None, req)
+    assert isinstance(result, str)
+    assert _UUID_HEX.fullmatch(result), f"expected 32-char hex, got {result!r}"
+
+
+def test_uuid_fallbacks_are_distinct_across_requests():
+    """If the fallback were a constant (``"anonymous"``) or accidentally
+    cached, every visitor without SSO would share a single user_id —
+    that's the exact cross-user-session-leak bug this work fixes."""
+    req1 = _request_with_headers({})
+    req2 = _request_with_headers({})
+    assert _resolve_user_id(None, req1) != _resolve_user_id(None, req2)

--- a/libs/idun_agent_engine/tests/unit/server/routers/test_sessions_user_scoping.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/test_sessions_user_scoping.py
@@ -1,0 +1,131 @@
+"""Tests for `/agent/sessions` user_id propagation.
+
+Today the route resolves a user_id and passes it to the adapter as a
+kwarg, but does NOT bind ``current_user_id`` ContextVar. That worked
+when only ADK consumed the kwarg. With Step 2 the LangGraph adapter
+will scope checkpoint metadata via the ContextVar (since the adapter's
+runtime path doesn't carry the user_id as a kwarg), so the route must
+bind both consistently.
+
+Each test pins a concrete failure mode:
+  * route forwards the resolved user_id as the kwarg (today's contract),
+  * route ALSO binds ``current_user_id`` to that same value while the
+    adapter call is in flight (new behavior),
+  * the two values agree — if they drift, scoping silently splits across
+    the two propagation channels.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from idun_agent_schema.engine.sessions import HistoryCapabilities, SessionDetail
+
+from idun_agent_engine.identity import current_user_id
+from idun_agent_engine.server.auth import get_verified_user
+from idun_agent_engine.server.dependencies import get_agent
+from idun_agent_engine.server.routers.agent import agent_router
+
+pytestmark = pytest.mark.unit
+
+
+def _build_app(fake_agent) -> FastAPI:
+    app = FastAPI()
+    app.include_router(agent_router, prefix="/agent")
+    app.state.sso_validator = None
+    app.dependency_overrides[get_verified_user] = lambda: None
+    app.dependency_overrides[get_agent] = lambda: fake_agent
+    return app
+
+
+class _CapturingAgent:
+    """Mock adapter that records both the kwarg and the ContextVar value
+    seen during the adapter call."""
+
+    agent_type = "fake"
+
+    def __init__(self) -> None:
+        self.captured: dict[str, object] = {}
+
+    def history_capabilities(self) -> HistoryCapabilities:
+        return HistoryCapabilities(can_list=True, can_get=True)
+
+    async def list_sessions(self, *, user_id: str | None = None):
+        self.captured["list_kwarg"] = user_id
+        self.captured["list_ctxvar"] = current_user_id.get()
+        return []
+
+    async def get_session(self, session_id: str, *, user_id: str | None = None):
+        self.captured["get_kwarg"] = user_id
+        self.captured["get_ctxvar"] = current_user_id.get()
+        return SessionDetail(
+            id=session_id,
+            last_update_time=0.0,
+            user_id=user_id,
+            thread_id=session_id,
+            messages=[],
+        )
+
+
+def test_list_sessions_binds_contextvar_to_resolved_user_id():
+    """When `/agent/sessions` is called with an X-Idun-User-Id header,
+    the ContextVar must hold that value during the adapter call. Without
+    this, LangGraph adapter code in Step 2 that reads the ContextVar to
+    stamp checkpoint metadata sees the default ``"standalone"`` and
+    every visitor's threads collide on the same logical user."""
+    agent = _CapturingAgent()
+    app = _build_app(agent)
+    with TestClient(app) as client:
+        resp = client.get("/agent/sessions", headers={"X-Idun-User-Id": "alice"})
+    assert resp.status_code == 200
+    assert agent.captured["list_kwarg"] == "alice"
+    assert agent.captured["list_ctxvar"] == "alice"
+
+
+def test_get_session_binds_contextvar_to_resolved_user_id():
+    """Same contract as list_sessions for the detail route."""
+    agent = _CapturingAgent()
+    app = _build_app(agent)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/agent/sessions/t-1", headers={"X-Idun-User-Id": "bob"}
+        )
+    assert resp.status_code == 200
+    assert agent.captured["get_kwarg"] == "bob"
+    assert agent.captured["get_ctxvar"] == "bob"
+
+
+def test_kwarg_and_contextvar_never_disagree():
+    """The kwarg and the ContextVar are two propagation channels for
+    the same value. If they drift, half the adapter scoping uses one
+    user_id and half the other. Pin equality explicitly."""
+    agent = _CapturingAgent()
+    app = _build_app(agent)
+    with TestClient(app) as client:
+        client.get("/agent/sessions", headers={"X-Idun-User-Id": "alice"})
+        client.get(
+            "/agent/sessions/t-1", headers={"X-Idun-User-Id": "alice"}
+        )
+    assert agent.captured["list_kwarg"] == agent.captured["list_ctxvar"]
+    assert agent.captured["get_kwarg"] == agent.captured["get_ctxvar"]
+
+
+def test_anonymous_request_gets_uuid_in_both_channels():
+    """When no SSO and no header are sent, the route mints a uuid (per
+    `_resolve_user_id`) and propagates it to BOTH channels. Anonymous
+    visitors get an isolated identity, not the shared ``"standalone"``
+    default."""
+    agent = _CapturingAgent()
+    app = _build_app(agent)
+    with TestClient(app) as client:
+        resp = client.get("/agent/sessions")
+    assert resp.status_code == 200
+    # uuid4().hex is 32 lowercase hex chars; the exact value differs per
+    # request, but the kwarg and ctxvar must match each other and must
+    # not be the contextvar default.
+    kwarg = agent.captured["list_kwarg"]
+    ctxvar = agent.captured["list_ctxvar"]
+    assert isinstance(kwarg, str) and len(kwarg) == 32
+    assert kwarg == ctxvar
+    assert kwarg != "standalone"

--- a/libs/idun_agent_engine/tests/unit/server/routers/test_user_id_propagation.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/test_user_id_propagation.py
@@ -131,7 +131,10 @@ def test_event_generator_wraps_agent_run_with_using_user(
 
     # `_resolve_user_id` is a plain function called inside the route
     # body — patch the module attribute so it returns "alice".
-    monkeypatch.setattr(agent_module, "_resolve_user_id", lambda _user: "alice")
+    # Signature is ``(user, request)`` since the header fallback was added.
+    monkeypatch.setattr(
+        agent_module, "_resolve_user_id", lambda _user, _request: "alice"
+    )
 
     with TestClient(app) as client:
         # AG-UI RunAgentInput shape — minimal valid payload. The agent
@@ -159,9 +162,14 @@ def test_event_generator_wraps_agent_run_with_using_user(
     assert "alice" in user_attrs
 
 
-def test_event_generator_default_user_does_not_crash(monkeypatch, in_memory_tracer):
-    """The ContextVar default is the literal "standalone" — confirm the
-    wrap accepts it without error and stamps the default."""
+def test_event_generator_stamps_anonymous_uuid_fallback(monkeypatch, in_memory_tracer):
+    """When no SSO claim and no header are present, `_resolve_user_id`
+    mints a uuid hex string. The wrap must still stamp that value onto
+    emitted spans so anonymous traffic remains attributable.
+
+    Pin: the route no longer reads the ContextVar's default; every chat
+    request produces a non-empty `user.id` on its spans.
+    """
     from idun_agent_engine.server.routers import agent as agent_module
 
     exporter, provider = in_memory_tracer
@@ -179,9 +187,10 @@ def test_event_generator_default_user_does_not_crash(monkeypatch, in_memory_trac
     fake_agent = _FakeAgent()
     app = _build_test_app(fake_agent)
 
-    # No SSO user; _resolve_user_id returns None so the route falls
-    # back to current_user_id.get() which has the "standalone" default.
-    monkeypatch.setattr(agent_module, "_resolve_user_id", lambda _user: None)
+    minted_id = "deadbeef" * 4  # 32-char hex, stands in for uuid4().hex
+    monkeypatch.setattr(
+        agent_module, "_resolve_user_id", lambda _user, _request: minted_id
+    )
 
     with TestClient(app) as client:
         response = client.post(
@@ -201,5 +210,4 @@ def test_event_generator_default_user_does_not_crash(monkeypatch, in_memory_trac
 
     provider.force_flush()
     user_attrs = [s.attributes.get("user.id") for s in exporter.get_finished_spans()]
-    # Default ContextVar value is "standalone".
-    assert "standalone" in user_attrs
+    assert minted_id in user_attrs

--- a/libs/idun_agent_engine/tests/unit/server/routers/test_user_id_propagation.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/test_user_id_propagation.py
@@ -162,6 +162,59 @@ def test_event_generator_wraps_agent_run_with_using_user(
     assert "alice" in user_attrs
 
 
+def test_event_generator_binds_current_user_id_contextvar(
+    monkeypatch, in_memory_tracer
+):
+    """The /run path must set current_user_id during agent.run so adapter
+    code reading the ContextVar (LangGraph stamping checkpoint metadata in
+    Step 2, ADK's user_id_extractor today) sees the route-resolved value
+    and not the "standalone" default."""
+    from idun_agent_engine.identity import current_user_id
+    from idun_agent_engine.server.routers import agent as agent_module
+
+    exporter, provider = in_memory_tracer
+    tracer = provider.get_tracer(__name__)
+
+    seen: dict[str, object] = {}
+
+    class _FakeAgent:
+        run_event_observers = AsyncMock()
+
+        async def run(self, _input) -> AsyncIterator[object]:
+            seen["ctxvar"] = current_user_id.get()
+            with tracer.start_as_current_span("FakeLLM.invoke") as span:
+                span.set_attribute("openinference.span.kind", "LLM")
+            if False:
+                yield None  # pragma: no cover
+
+    app = _build_test_app(_FakeAgent())
+    monkeypatch.setattr(
+        agent_module, "_resolve_user_id", lambda _user, _request: "alice"
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/agent/run",
+            json={
+                "thread_id": "t-1",
+                "run_id": "r-1",
+                "messages": [],
+                "tools": [],
+                "context": [],
+                "state": {},
+                "forwarded_props": {},
+            },
+            headers={"accept": "text/event-stream"},
+        )
+        _ = response.read()
+
+    assert seen["ctxvar"] == "alice"
+    # And after the stream completes, the route must restore the default
+    # so the test process's ContextVar doesn't leak the resolved id to
+    # subsequent code paths.
+    assert current_user_id.get() == "standalone"
+
+
 def test_event_generator_stamps_anonymous_uuid_fallback(monkeypatch, in_memory_tracer):
     """When no SSO claim and no header are present, `_resolve_user_id`
     mints a uuid hex string. The wrap must still stamp that value onto

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/app.py
@@ -90,6 +90,9 @@ def _is_public_runtime_path(path: str) -> bool:
         or path.startswith("/_next/")
     ):
         return True
+    # Chat sessions are public; per-user scoping happens in the adapter.
+    if path == "/agent/sessions" or path.startswith("/agent/sessions/"):
+        return True
     if path.startswith("/agent/") or path.startswith("/_engine/"):
         return False
     return path != "/reload"

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/runtime_config.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/runtime_config.py
@@ -87,10 +87,16 @@ _POSTHOG_PROJECT_KEY = "phc_mpAplkH6w5zK1aSkkG0IL5Ys55m6X34BFvGozB2NqPw"  # noqa
 async def runtime_config_js(request: Request) -> Response:
     """Return a tiny script that seeds ``window.__IDUN_CONFIG__``."""
     settings = request.app.state.settings
+    # agentReady + bootReason let the chat root route fresh installs to
+    # /onboarding without an extra fetch.
+    agent = getattr(request.app.state, "agent", None)
+    boot_error = getattr(request.app.state, "boot_error", None)
     config: dict[str, Any] = {
         "theme": _DEFAULT_THEME,
         "authMode": settings.auth_mode.value,
         "layout": _DEFAULT_THEME["layout"],
+        "agentReady": agent is not None,
+        "bootReason": str(boot_error) if boot_error else None,
         "telemetry": {
             "enabled": settings.telemetry_enabled,
             "host": _POSTHOG_HOST,

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/runtime_config.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/runtime_config.py
@@ -87,8 +87,10 @@ _POSTHOG_PROJECT_KEY = "phc_mpAplkH6w5zK1aSkkG0IL5Ys55m6X34BFvGozB2NqPw"  # noqa
 async def runtime_config_js(request: Request) -> Response:
     """Return a tiny script that seeds ``window.__IDUN_CONFIG__``."""
     settings = request.app.state.settings
-    # agentReady + bootReason let the chat root route fresh installs to
-    # /onboarding without an extra fetch.
+    # agentReady + bootFailed let the chat root route fresh installs to
+    # /onboarding without an extra fetch. bootFailed is a boolean — the
+    # raw error string can carry DB URIs or file paths and this endpoint
+    # is public.
     agent = getattr(request.app.state, "agent", None)
     boot_error = getattr(request.app.state, "boot_error", None)
     config: dict[str, Any] = {
@@ -96,7 +98,7 @@ async def runtime_config_js(request: Request) -> Response:
         "authMode": settings.auth_mode.value,
         "layout": _DEFAULT_THEME["layout"],
         "agentReady": agent is not None,
-        "bootReason": str(boot_error) if boot_error else None,
+        "bootFailed": boot_error is not None,
         "telemetry": {
             "enabled": settings.telemetry_enabled,
             "host": _POSTHOG_HOST,

--- a/libs/idun_agent_standalone/tests/integration/standalone/test_runtime_config.py
+++ b/libs/idun_agent_standalone/tests/integration/standalone/test_runtime_config.py
@@ -53,7 +53,14 @@ async def test_runtime_config_body_shape(standalone):
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/runtime-config.js")
     config = _parse_runtime_config(response.text)
-    assert set(config) == {"theme", "authMode", "layout", "telemetry"}
+    assert set(config) == {
+        "theme",
+        "authMode",
+        "layout",
+        "agentReady",
+        "bootReason",
+        "telemetry",
+    }
     assert config["authMode"] == "none"
 
 

--- a/libs/idun_agent_standalone/tests/integration/standalone/test_runtime_config.py
+++ b/libs/idun_agent_standalone/tests/integration/standalone/test_runtime_config.py
@@ -58,7 +58,7 @@ async def test_runtime_config_body_shape(standalone):
         "authMode",
         "layout",
         "agentReady",
-        "bootReason",
+        "bootFailed",
         "telemetry",
     }
     assert config["authMode"] == "none"

--- a/libs/idun_agent_standalone/tests/unit/test_app_public_paths.py
+++ b/libs/idun_agent_standalone/tests/unit/test_app_public_paths.py
@@ -47,3 +47,28 @@ def test_public_paths_bypass_gate(path: str) -> None:
 )
 def test_private_paths_require_auth(path: str) -> None:
     assert _is_public_runtime_path(path) is False
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # List endpoint — the SPA's useChat fetches this on every chat
+        # page load to render the history sidebar.
+        "/agent/sessions",
+        # Detail endpoint — useChat hydrates the active thread by id.
+        # The path parameter is arbitrary user_id-scoped state, not an
+        # admin handle.
+        "/agent/sessions/abc-123",
+        "/agent/sessions/12345678-90ab-4cde-9f01-234567890abc",
+    ],
+)
+def test_chat_session_paths_are_public(path: str) -> None:
+    """Chat-surface endpoints must be reachable under password mode.
+
+    Without this, the SPA's `useChat` hits 401 on every page load and
+    `apiFetch`'s global 401 handler hard-redirects the user to /login —
+    even though the chat page itself is not gated. Per-user scoping of
+    these endpoints is the engine's job (Step 2 of the SPEC); the gate
+    must not pre-empt that.
+    """
+    assert _is_public_runtime_path(path) is True

--- a/libs/idun_agent_standalone/tests/unit/test_runtime_config_js.py
+++ b/libs/idun_agent_standalone/tests/unit/test_runtime_config_js.py
@@ -1,0 +1,96 @@
+"""Tests for `/runtime-config.js` bootstrap payload.
+
+The SPA reads `window.__IDUN_CONFIG__` synchronously before hydration to
+decide whether to redirect first-run users to `/onboarding`. The signal
+lives here (and not in `/health` or a dedicated endpoint) because:
+
+  * bootstrap data already arrives on this script; one fewer fetch,
+  * setup state is page-lifetime, matching the bootstrap layer,
+  * `/health` is a liveness probe; overloading it ties UX routing to
+    probe-shape changes.
+
+Each test pins a concrete signal the SPA depends on.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from idun_agent_standalone.core.settings import StandaloneSettings
+from idun_agent_standalone.runtime_config import router as runtime_config_router
+
+
+def _settings() -> StandaloneSettings:
+    """Minimal valid settings; auth_mode is irrelevant to the payload
+    fields under test."""
+    return StandaloneSettings(
+        IDUN_ADMIN_AUTH_MODE="none",  # type: ignore[call-arg]
+    )
+
+
+def _build_app(*, agent: object | None, boot_error: str | None = None) -> FastAPI:
+    app = FastAPI()
+    app.include_router(runtime_config_router)
+    app.state.settings = _settings()
+    app.state.agent = agent
+    if boot_error is not None:
+        app.state.boot_error = boot_error
+    return app
+
+
+def _parse_config(body: str) -> dict:
+    """Extract the JSON dict from `window.__IDUN_CONFIG__ = {...};`."""
+    match = re.search(r"window\.__IDUN_CONFIG__\s*=\s*({.*});", body, re.DOTALL)
+    assert match, f"unexpected bootstrap shape: {body!r}"
+    return json.loads(match.group(1))
+
+
+def test_agent_ready_true_when_agent_attached():
+    """When the standalone has materialized an agent, the SPA must
+    render chat immediately. `agentReady=true` is the signal."""
+    app = _build_app(agent=object())
+    with TestClient(app) as client:
+        body = client.get("/runtime-config.js").text
+    config = _parse_config(body)
+    assert config["agentReady"] is True
+    assert config["bootReason"] is None
+
+
+def test_agent_ready_false_when_no_agent_attached():
+    """Fresh install: no agent row in DB, engine boots without one.
+    `agentReady=false` triggers the SPA's redirect to /onboarding."""
+    app = _build_app(agent=None)
+    with TestClient(app) as client:
+        body = client.get("/runtime-config.js").text
+    config = _parse_config(body)
+    assert config["agentReady"] is False
+    assert config["bootReason"] is None
+
+
+def test_boot_reason_surfaces_assembly_error():
+    """Broken deploy: agent rows exist but assembly failed. The SPA
+    must NOT redirect to /onboarding (the wizard can't fix this); it
+    should render chat so the eventual 503 reaches the user with a
+    diagnostic message. `bootReason` lets the SPA tell the cases apart.
+    """
+    app = _build_app(agent=None, boot_error="Agent assembly failed: bad YAML")
+    with TestClient(app) as client:
+        body = client.get("/runtime-config.js").text
+    config = _parse_config(body)
+    assert config["agentReady"] is False
+    assert config["bootReason"] == "Agent assembly failed: bad YAML"
+
+
+def test_response_is_javascript_no_store():
+    """Bootstrap script is per-page and may differ per deploy. Cache
+    headers must keep proxies from serving a stale `agentReady` value
+    after the operator runs onboarding."""
+    app = _build_app(agent=object())
+    with TestClient(app) as client:
+        resp = client.get("/runtime-config.js")
+    assert resp.headers["content-type"].startswith("application/javascript")
+    assert resp.headers["cache-control"] == "no-store"

--- a/libs/idun_agent_standalone/tests/unit/test_runtime_config_js.py
+++ b/libs/idun_agent_standalone/tests/unit/test_runtime_config_js.py
@@ -57,7 +57,7 @@ def test_agent_ready_true_when_agent_attached():
         body = client.get("/runtime-config.js").text
     config = _parse_config(body)
     assert config["agentReady"] is True
-    assert config["bootReason"] is None
+    assert config["bootFailed"] is False
 
 
 def test_agent_ready_false_when_no_agent_attached():
@@ -68,21 +68,34 @@ def test_agent_ready_false_when_no_agent_attached():
         body = client.get("/runtime-config.js").text
     config = _parse_config(body)
     assert config["agentReady"] is False
-    assert config["bootReason"] is None
+    assert config["bootFailed"] is False
 
 
-def test_boot_reason_surfaces_assembly_error():
-    """Broken deploy: agent rows exist but assembly failed. The SPA
-    must NOT redirect to /onboarding (the wizard can't fix this); it
-    should render chat so the eventual 503 reaches the user with a
-    diagnostic message. `bootReason` lets the SPA tell the cases apart.
-    """
+def test_boot_failed_true_on_assembly_error():
+    """Broken deploy: assembly failed. SPA must NOT redirect to
+    /onboarding (wizard can't help); render chat so the eventual 503
+    reaches the user. `bootFailed=true` is the signal."""
     app = _build_app(agent=None, boot_error="Agent assembly failed: bad YAML")
     with TestClient(app) as client:
         body = client.get("/runtime-config.js").text
     config = _parse_config(body)
     assert config["agentReady"] is False
-    assert config["bootReason"] == "Agent assembly failed: bad YAML"
+    assert config["bootFailed"] is True
+
+
+def test_boot_failed_does_not_leak_exception_details():
+    """Information-disclosure guard: the public endpoint must not echo
+    raw exception text (DB URIs, file paths, parse traces). The boolean
+    signal is sufficient for the SPA's routing decision."""
+    sensitive = (
+        "Agent assembly failed: postgresql://idun:hunter2@10.0.0.1:5432/prod"
+    )
+    app = _build_app(agent=None, boot_error=sensitive)
+    with TestClient(app) as client:
+        body = client.get("/runtime-config.js").text
+    assert sensitive not in body
+    assert "hunter2" not in body
+    assert "10.0.0.1" not in body
 
 
 def test_response_is_javascript_no_store():

--- a/services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx
@@ -1,26 +1,15 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 import Home from "@/app/page";
+import { DEFAULT_RUNTIME_CONFIG } from "@/lib/runtime-config";
 
 const replace = vi.fn();
-// Stable router object so useEffect deps don't refire across renders.
 const routerInstance = { replace };
 
 vi.mock("next/navigation", () => ({
   useRouter: () => routerInstance,
   useSearchParams: () => new URLSearchParams(""),
 }));
-
-vi.mock("@/lib/api", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
-  return {
-    ...actual,
-    api: {
-      ...actual.api,
-      getAgent: vi.fn(),
-    },
-  };
-});
 
 vi.mock("@/components/chat/BrandedLayout", () => ({
   BrandedLayout: () => <div data-testid="branded-layout" />,
@@ -34,57 +23,52 @@ vi.mock("@/components/chat/InspectorLayout", () => ({
   InspectorLayout: () => <div data-testid="inspector-layout" />,
 }));
 
-import { api, ApiError } from "@/lib/api";
-
+/**
+ * Home reads `agentReady` + `bootReason` from `window.__IDUN_CONFIG__`
+ * (seeded by /runtime-config.js) and decides:
+ *   - agentReady=true → render chat,
+ *   - agentReady=false + no bootReason → redirect to /onboarding (wizard),
+ *   - agentReady=false + bootReason → render chat (wizard can't fix a
+ *     broken-config deploy; let the eventual 503 surface).
+ * Source of truth: SPEC S1.9.
+ */
 describe("Home (chat root)", () => {
   beforeEach(() => {
     replace.mockReset();
-    (api.getAgent as ReturnType<typeof vi.fn>).mockReset();
+  });
+  afterEach(() => {
+    delete window.__IDUN_CONFIG__;
   });
 
-  it("renders chat when getAgent returns 200", async () => {
-    (api.getAgent as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      id: "x",
-      name: "Foo",
-    });
+  it("renders chat when the bootstrap reports the agent is ready", async () => {
+    window.__IDUN_CONFIG__ = { ...DEFAULT_RUNTIME_CONFIG, agentReady: true };
     const { findByTestId } = render(<Home />);
     await findByTestId("branded-layout");
     expect(replace).not.toHaveBeenCalled();
   });
 
-  it("redirects to /onboarding when getAgent returns 404", async () => {
-    (api.getAgent as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      new ApiError(404, null),
-    );
+  it("redirects to /onboarding on fresh install (no agent, no boot error)", async () => {
+    window.__IDUN_CONFIG__ = {
+      ...DEFAULT_RUNTIME_CONFIG,
+      agentReady: false,
+      bootReason: null,
+    };
     render(<Home />);
-    await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
-  });
-
-  it("does not redirect on non-404 errors (e.g. transient 500)", async () => {
-    (api.getAgent as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      new ApiError(500, null),
-    );
-    render(<Home />);
-    // Wait until the probe was invoked, then assert no redirect happened.
     await waitFor(() =>
-      expect(api.getAgent as ReturnType<typeof vi.fn>).toHaveBeenCalled(),
+      expect(replace).toHaveBeenCalledWith("/onboarding"),
     );
-    expect(replace).not.toHaveBeenCalled();
   });
 
-  it("does not redirect if unmounted before getAgent resolves", async () => {
-    let resolveIt!: () => void;
-    (api.getAgent as ReturnType<typeof vi.fn>).mockReturnValueOnce(
-      new Promise<never>((_resolve, reject) => {
-        // Reject (matches the 404 path) only after we've unmounted.
-        resolveIt = () => reject(new ApiError(404, null));
-      }),
-    );
-    const { unmount } = render(<Home />);
-    unmount();
-    resolveIt();
-    // Yield one microtask so any leaked then/catch would have a chance to fire.
-    await new Promise((r) => setTimeout(r, 0));
+  it("renders chat on a broken-config deploy so the eventual 503 reaches the user", async () => {
+    // Wizard can't fix assembly errors. Redirecting would loop the
+    // operator through onboarding fruitlessly.
+    window.__IDUN_CONFIG__ = {
+      ...DEFAULT_RUNTIME_CONFIG,
+      agentReady: false,
+      bootReason: "Agent assembly failed: bad YAML",
+    };
+    const { findByTestId } = render(<Home />);
+    await findByTestId("branded-layout");
     expect(replace).not.toHaveBeenCalled();
   });
 });

--- a/services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/page-redirect.test.tsx
@@ -51,7 +51,7 @@ describe("Home (chat root)", () => {
     window.__IDUN_CONFIG__ = {
       ...DEFAULT_RUNTIME_CONFIG,
       agentReady: false,
-      bootReason: null,
+      bootFailed: false,
     };
     render(<Home />);
     await waitFor(() =>
@@ -65,7 +65,7 @@ describe("Home (chat root)", () => {
     window.__IDUN_CONFIG__ = {
       ...DEFAULT_RUNTIME_CONFIG,
       agentReady: false,
-      bootReason: "Agent assembly failed: bad YAML",
+      bootFailed: true,
     };
     const { findByTestId } = render(<Home />);
     await findByTestId("branded-layout");

--- a/services/idun_agent_standalone_ui/__tests__/user-id-concurrency.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/user-id-concurrency.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Mocking `@/lib/auth` lets us drive `getCurrentAuthUser` from each test
+ * and count how many times it's invoked across concurrent callers.
+ *
+ * Greptile flagged the original `getUserId()` implementation for caching
+ * the *resolved value* rather than the in-flight Promise: two callers on
+ * the first page load could both see `cached === null`, both run the
+ * async branch, and each return a distinct uuid. Last write to `cached`
+ * wins, but the early callers already got different identities — that's
+ * the per-user-isolation bug we set out to fix, reintroduced inside the
+ * helper itself. These tests pin the fix.
+ */
+vi.mock("@/lib/auth", () => ({
+  getCurrentAuthUser: vi.fn(),
+}));
+
+import { getCurrentAuthUser } from "@/lib/auth";
+import { getUserId, resetUserId } from "@/lib/user-id";
+
+describe("getUserId under concurrent callers", () => {
+  beforeEach(() => {
+    resetUserId();
+    vi.mocked(getCurrentAuthUser).mockReset();
+  });
+  afterEach(() => {
+    resetUserId();
+  });
+
+  it("returns the same identity to many parallel callers (SSO off)", async () => {
+    vi.mocked(getCurrentAuthUser).mockResolvedValue(null);
+    const results = await Promise.all(
+      Array.from({ length: 50 }, () => getUserId()),
+    );
+    expect(new Set(results).size).toBe(1);
+  });
+
+  it("invokes getCurrentAuthUser exactly once for concurrent callers", async () => {
+    // The first caller starts the resolution; subsequent callers must
+    // await the same promise rather than each calling auth themselves.
+    // Without this, every page load would trigger 5–10 redundant SSO
+    // probes on cold boot.
+    vi.mocked(getCurrentAuthUser).mockResolvedValue({
+      email: "alice@example.com",
+    });
+    await Promise.all(Array.from({ length: 50 }, () => getUserId()));
+    expect(getCurrentAuthUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the SSO email to all callers when the user is authenticated", async () => {
+    vi.mocked(getCurrentAuthUser).mockResolvedValue({
+      email: "alice@example.com",
+    });
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => getUserId()),
+    );
+    expect(results).toEqual(Array(10).fill("alice@example.com"));
+  });
+
+  it("resetUserId clears the cache so a fresh identity is minted next", async () => {
+    vi.mocked(getCurrentAuthUser).mockResolvedValue(null);
+    const first = await getUserId();
+    resetUserId();
+    const second = await getUserId();
+    expect(first).not.toBe(second);
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/user-id.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/user-id.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { formatUserIdForDisplay } from "@/lib/user-id";
+
+/**
+ * `formatUserIdForDisplay` is the only piece of `lib/user-id.ts`
+ * worth pinning in isolation — the rest is React glue (`useUserId`)
+ * and a thin module-level cache (`getUserId`) that are covered by
+ * integration tests.
+ *
+ * Each test targets a concrete failure mode rather than a branch tick.
+ */
+describe("formatUserIdForDisplay", () => {
+  it("returns an email address as-is", () => {
+    // Emails are recognizable and short enough; truncating one to 8
+    // chars would render them useless.
+    expect(formatUserIdForDisplay("alice@example.com")).toBe(
+      "alice@example.com",
+    );
+  });
+
+  it("truncates engine-minted uuid hex to 8 chars + ellipsis", () => {
+    // 32-char lowercase hex (uuid4().hex). Pin the exact slice + glyph
+    // so layouts can rely on a fixed width.
+    expect(
+      formatUserIdForDisplay("749f9e33278746e99b9a6039b5f9b814"),
+    ).toBe("749f9e33…");
+  });
+
+  it("truncates SPA-minted uuid with dashes the same way", () => {
+    // `crypto.randomUUID()` returns 36 chars with dashes; the first 8
+    // include a dash, which is fine — we keep what comes first.
+    expect(
+      formatUserIdForDisplay("12345678-90ab-4cde-9f01-234567890abc"),
+    ).toBe("12345678…");
+  });
+
+  it("does not truncate values already at or below 8 chars", () => {
+    // Some IdPs return numeric `sub`s ("123"). No ellipsis needed.
+    expect(formatUserIdForDisplay("123")).toBe("123");
+    expect(formatUserIdForDisplay("12345678")).toBe("12345678");
+  });
+
+  it("treats a value with `@` as an email even if it's long", () => {
+    // The presence of `@` is the email marker, not the length. A very
+    // long email must still render in full.
+    const longish = "averylongusername@subdomain.example.com";
+    expect(formatUserIdForDisplay(longish)).toBe(longish);
+  });
+});

--- a/services/idun_agent_standalone_ui/app/page.tsx
+++ b/services/idun_agent_standalone_ui/app/page.tsx
@@ -53,7 +53,7 @@ function ChatHome() {
   useEffect(() => {
     if (signedIn !== true) return;
     const cfg = getRuntimeConfig();
-    if (!cfg.agentReady && !cfg.bootReason) {
+    if (!cfg.agentReady && !cfg.bootFailed) {
       router.replace("/onboarding");
       return;
     }

--- a/services/idun_agent_standalone_ui/app/page.tsx
+++ b/services/idun_agent_standalone_ui/app/page.tsx
@@ -3,7 +3,6 @@
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { getRuntimeConfig } from "@/lib/runtime-config";
-import { ApiError, api } from "@/lib/api";
 import {
   fetchSsoInfo,
   getCurrentAuthUser,
@@ -53,23 +52,12 @@ function ChatHome() {
 
   useEffect(() => {
     if (signedIn !== true) return;
-    let cancelled = false;
-    api
-      .getAgent()
-      .then(() => {
-        if (!cancelled) setAgentReady(true);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        if (err instanceof ApiError && err.status === 404) {
-          router.replace("/onboarding");
-        } else {
-          setAgentReady(true);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
+    const cfg = getRuntimeConfig();
+    if (!cfg.agentReady && !cfg.bootReason) {
+      router.replace("/onboarding");
+      return;
+    }
+    setAgentReady(true);
   }, [router, signedIn]);
 
   if (ssoInfo === null || signedIn === null) {

--- a/services/idun_agent_standalone_ui/components/chat/BrandedLayout.tsx
+++ b/services/idun_agent_standalone_ui/components/chat/BrandedLayout.tsx
@@ -75,15 +75,14 @@ export function BrandedLayout({ threadId }: { threadId: string }) {
 
   const header = (
     <header className="relative z-10">
-      <div className="mx-auto flex max-w-[720px] items-center justify-between gap-3 px-6 pt-6 pb-4">
-        <div className="flex items-center gap-3">
-          <HamburgerButton onClick={() => setDrawerOpen(true)} />
-          <Logo theme={theme} />
+      <div className="flex items-center gap-3 px-6 pt-6 pb-4">
+        <HamburgerButton onClick={() => setDrawerOpen(true)} />
+        <div className="ml-auto">
+          <HeaderActions
+            threadId={threadId}
+            onNewSession={newConversation}
+          />
         </div>
-        <HeaderActions
-          threadId={threadId}
-          onNewSession={newConversation}
-        />
       </div>
       {!empty ? (
         <div className="mx-auto max-w-[720px] px-6">

--- a/services/idun_agent_standalone_ui/components/chat/HistorySidebar.tsx
+++ b/services/idun_agent_standalone_ui/components/chat/HistorySidebar.tsx
@@ -9,6 +9,8 @@ import {
   signOut as ssoSignOut,
   type SsoInfo,
 } from "@/lib/auth";
+import { getRuntimeConfig } from "@/lib/runtime-config";
+import { useUserId } from "@/lib/user-id";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
@@ -119,9 +121,33 @@ export function HistorySidebar({
     if (typeof window !== "undefined") window.location.replace("/");
   };
 
+  const theme = getRuntimeConfig().theme;
+  const appName = theme.appName;
+  const logoText = (theme.logo?.text ?? "IA").slice(0, 2).toUpperCase();
+  const userId = useUserId();
+
   return (
     <aside className="flex h-screen w-[300px] shrink-0 flex-col border-r border-border bg-card/60">
-      <header className="flex items-center justify-between px-5 pt-5 pb-3">
+      <div className="px-5 pt-5 pb-3">
+        <div className="flex items-center gap-2">
+          <span className="flex h-7 w-7 items-center justify-center rounded-full bg-foreground font-serif text-xs font-medium text-background">
+            {logoText}
+          </span>
+          <span className="text-[14px] font-medium text-foreground">
+            {appName}
+          </span>
+        </div>
+        {userId ? (
+          <div
+            className="mt-2 break-all text-[11px] text-muted-foreground"
+            title={userId}
+            data-testid="sidebar-user-id"
+          >
+            User ID: {userId}
+          </div>
+        ) : null}
+      </div>
+      <header className="flex items-center justify-between px-5 pt-2 pb-3">
         <div className="font-serif text-[18px] font-medium text-foreground">
           History
         </div>
@@ -133,7 +159,6 @@ export function HistorySidebar({
           + New
         </button>
       </header>
-      <div className="hairline mx-5" />
       <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
         {!canListHistory ? (
           <Alert className="mx-1">

--- a/services/idun_agent_standalone_ui/components/chat/InspectorLayout.tsx
+++ b/services/idun_agent_standalone_ui/components/chat/InspectorLayout.tsx
@@ -153,7 +153,6 @@ export function InspectorLayout({ threadId }: { threadId: string }) {
           >
             <Menu className="h-4 w-4" />
           </button>
-          <strong className="text-sm font-medium">{appName}</strong>
           <div className="ml-auto">
             <HeaderActions
               threadId={threadId}

--- a/services/idun_agent_standalone_ui/lib/agui.ts
+++ b/services/idun_agent_standalone_ui/lib/agui.ts
@@ -8,6 +8,7 @@
  */
 
 import { authHeaders } from "@/lib/auth";
+import { getUserId } from "@/lib/user-id";
 
 export type AGUIEvent = {
   type: string;
@@ -64,12 +65,14 @@ export type ToolCall = {
 
 export async function runAgent(opts: RunOptions): Promise<void> {
   const bearer = await authHeaders();
+  const userId = await getUserId();
   const res = await fetch("/agent/run", {
     method: "POST",
     credentials: "include",
     headers: {
       "content-type": "application/json",
       accept: "text/event-stream",
+      "x-idun-user-id": userId,
       ...bearer,
     },
     body: JSON.stringify({

--- a/services/idun_agent_standalone_ui/lib/api/client.ts
+++ b/services/idun_agent_standalone_ui/lib/api/client.ts
@@ -10,6 +10,7 @@
  */
 
 import { authHeaders, clearManualToken, fetchSsoInfo } from "@/lib/auth";
+import { getUserId } from "@/lib/user-id";
 
 export class ApiError extends Error {
   constructor(
@@ -47,11 +48,17 @@ async function handleUnauthorized(path: string): Promise<void> {
 
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const bearer = await authHeaders();
+  // Chat surface carries an explicit per-visitor identity. Admin routes
+  // never need it — JWT/cookie auth covers identity there.
+  const userIdHeader: Record<string, string> = isAgentPath(path)
+    ? { "x-idun-user-id": await getUserId() }
+    : {};
   const res = await fetch(path, {
     credentials: "include",
     headers: {
       "content-type": "application/json",
       ...bearer,
+      ...userIdHeader,
       ...(init?.headers || {}),
     },
     ...init,

--- a/services/idun_agent_standalone_ui/lib/runtime-config.ts
+++ b/services/idun_agent_standalone_ui/lib/runtime-config.ts
@@ -57,7 +57,7 @@ export type RuntimeConfig = {
   authMode: "none" | "password" | "oidc";
   layout: "branded" | "minimal" | "inspector";
   agentReady: boolean;
-  bootReason: string | null;
+  bootFailed: boolean;
   telemetry: TelemetryConfig;
 };
 
@@ -133,7 +133,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   authMode: "none",
   layout: "branded",
   agentReady: true,
-  bootReason: null,
+  bootFailed: false,
   telemetry: {
     enabled: false, // dev / SSR default is OFF; the backend overrides at runtime
     host: "https://us.i.posthog.com",

--- a/services/idun_agent_standalone_ui/lib/runtime-config.ts
+++ b/services/idun_agent_standalone_ui/lib/runtime-config.ts
@@ -56,6 +56,8 @@ export type RuntimeConfig = {
   theme: ThemeConfig;
   authMode: "none" | "password" | "oidc";
   layout: "branded" | "minimal" | "inspector";
+  agentReady: boolean;
+  bootReason: string | null;
   telemetry: TelemetryConfig;
 };
 
@@ -130,6 +132,8 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   theme: DEFAULT_THEME,
   authMode: "none",
   layout: "branded",
+  agentReady: true,
+  bootReason: null,
   telemetry: {
     enabled: false, // dev / SSR default is OFF; the backend overrides at runtime
     host: "https://us.i.posthog.com",

--- a/services/idun_agent_standalone_ui/lib/user-id.ts
+++ b/services/idun_agent_standalone_ui/lib/user-id.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-session user identity for chat requests.
+ *
+ * Resolves once per page load:
+ *   - SSO email when an authenticated user is present.
+ *   - Fresh `crypto.randomUUID()` otherwise.
+ *
+ * The result is cached in module state. No localStorage / sessionStorage:
+ * anonymous visitors get a new id on every reload, which is what the
+ * standalone wants for the open-chat case. `resetUserId()` clears the
+ * cache for sign-out flows.
+ */
+
+import { useEffect, useState } from "react";
+
+import { getCurrentAuthUser } from "@/lib/auth";
+
+let cached: string | null = null;
+
+export async function getUserId(): Promise<string> {
+  if (cached !== null) return cached;
+  const user = await getCurrentAuthUser().catch(() => null);
+  cached = user?.email ?? crypto.randomUUID();
+  return cached;
+}
+
+export function resetUserId(): void {
+  cached = null;
+}
+
+/**
+ * React hook returning the resolved user_id, or `null` while resolving.
+ * Re-renders the consumer once the value is available.
+ */
+export function useUserId(): string | null {
+  const [id, setId] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    getUserId().then((value) => {
+      if (!cancelled) setId(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return id;
+}
+
+/**
+ * Format a resolved user_id for display in the chat header.
+ *
+ *   - Emails (contain `@`): returned as-is.
+ *   - Otherwise: first 8 chars followed by `…` to keep the header tight.
+ *     Covers both engine-minted uuid hex (32 chars) and SPA-minted
+ *     `crypto.randomUUID()` (36 chars with dashes) without dropping
+ *     the meaningful prefix.
+ */
+export function formatUserIdForDisplay(value: string): string {
+  if (value.includes("@")) return value;
+  if (value.length > 8) return `${value.slice(0, 8)}…`;
+  return value;
+}

--- a/services/idun_agent_standalone_ui/lib/user-id.ts
+++ b/services/idun_agent_standalone_ui/lib/user-id.ts
@@ -15,12 +15,19 @@ import { useEffect, useState } from "react";
 
 import { getCurrentAuthUser } from "@/lib/auth";
 
-let cached: string | null = null;
+// Cache the in-flight promise (not the resolved value) so concurrent
+// callers all await the same resolution. Caching the value created a
+// race on cold page load where each caller minted its own uuid before
+// `cached` was assigned.
+let cached: Promise<string> | null = null;
 
-export async function getUserId(): Promise<string> {
-  if (cached !== null) return cached;
-  const user = await getCurrentAuthUser().catch(() => null);
-  cached = user?.email ?? crypto.randomUUID();
+export function getUserId(): Promise<string> {
+  if (cached === null) {
+    cached = (async () => {
+      const user = await getCurrentAuthUser().catch(() => null);
+      return user?.email ?? crypto.randomUUID();
+    })();
+  }
   return cached;
 }
 


### PR DESCRIPTION
## Summary

Step 1 of standalone per-user session isolation (SPEC at
`idun-dev/tasks/standalone-user-isolation-19-05-2026/SPEC.md`).

- **Chat reachable under `IDUN_ADMIN_AUTH_MODE=password` without SSO.** Root
  cause was the SPA's `api.getAgent()` admin precheck on `/admin/api/v1/agent`
  triggering the global 401-redirect-to-`/login` in `apiFetch`. The chat
  surface no longer calls admin endpoints. Onboarding routing preserved via
  `/runtime-config.js` (`agentReady` + `bootReason`) read synchronously at
  hydration.
- **Per-visitor `user_id` end-to-end.** SPA mints (SSO email or fresh UUID,
  no localStorage), sends as `X-Idun-User-Id` on every `/agent/*` call.
  Engine's `_resolve_user_id` reads it (SSO claim wins, header next, fresh
  uuid4 as safety net). `current_user_id` ContextVar is bound on
  `/agent/sessions*` (new) and `/agent/run` so adapter code reading the var
  sees the right value.
- **`/agent/sessions*` opened in the standalone runtime gate** so the SPA's
  history calls don't 401 and trigger the redirect bug.
- **User identity visible in chat UI.** `HistorySidebar` now carries the app
  brand + active `user_id` at the top. Chat-area headers no longer duplicate
  the brand.

## Follow-up

Cross-user session leak still present until LangGraph adapter implements
filter-based scoping. Tracked in #670.

## Commits

- `feat(ui): open chat without admin precheck; mint and send X-Idun-User-Id`
- `feat(engine): accept X-Idun-User-Id; bind current_user_id on sessions routes`
- `feat(standalone): expose agentReady on /runtime-config.js; open /agent/sessions*`
- `feat(ui): show brand + user_id in HistorySidebar; clean up chat header`

## Tests

- Engine: 13 new TDD tests (`test_resolve_user_id.py` 9, `test_sessions_user_scoping.py` 4),
  plus updated `test_user_id_propagation.py` for the new signature. Full
  router suite green.
- Standalone: 4 new TDD tests (`test_runtime_config_js.py`), 3 added to
  `test_app_public_paths.py`, integration `test_runtime_config.py` updated
  for the new key set. Full suite green.
- SPA: 5 new tests for `formatUserIdForDisplay`, rewrote `page-redirect.test.tsx`
  (3 tests covering ready / fresh-install / broken-deploy). 353 pass,
  6 pre-existing `__tests__/api/*` failures unchanged (broken on develop too).
- Typecheck clean across both engine and SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)