### PR TITLE
chore(release): 0.6.1 prep — version bumps + CHANGELOGs

### DIFF
--- a/libs/idun_agent_engine/CHANGELOG.md
+++ b/libs/idun_agent_engine/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to `idun-agent-engine` are documented here. This project fol
 
 _No unreleased changes yet._
 
+## 0.6.1 — 2026-05-20
+
+Patch release. The engine now accepts a per-request `X-Idun-User-Id` header and binds it to a `current_user_id` ContextVar that adapter code (and the standalone trace writer) read at the start of every `/agent/*` invocation, so chat history and traces can be scoped per user when the standalone UI runs under password auth without a full OIDC ladder. Pairs with the standalone changes in `0.6.1` that open the chat shell under password mode.
+
+### Added
+
+- `_resolve_user_id` resolution order on `/agent/*`: SSO claim (`email` > `sub`) > `X-Idun-User-Id` header > fresh `uuid4().hex`. Always returns a non-empty string. The header is trusted only when SSO claims are absent (#671).
+- `_bind_user_id` context manager wraps adapter calls in `list_sessions` and `get_session` so the LangGraph adapter can read `current_user_id` to scope checkpoint metadata (#671).
+
+### Changed
+
+- `X-Idun-User-Id` is validated: capped at 256 chars; control bytes `0x00–0x1F` and `0x7F` are rejected; on rejection the resolver falls through to the `uuid4` fallback so the caller still gets a usable id (#671).
+
 ## 0.6.0 — 2026-05-17
 
 The release where Idun Engine becomes **the third path between LangGraph Cloud and DIY**. The engine wheel now bundles the `idun-agent-standalone` admin/chat/traces app and the `idun` console script, so adopters can `pip install idun-agent-engine && idun setup && idun serve` without installing any other package. The release also removes the Haystack adapter, demotes `guardrails-ai` to an optional extra, lands the trace pipeline that powers the admin `/traces/` viewer, and rebrands the public surface from "Idun Platform" to "Idun Engine".

--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-agent-engine"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python SDK and runtime to serve AI agents with FastAPI, LangGraph, and observability."
 authors = [{ name = "Idun Group", email = "h.geoffrey@idun-group.com" }]
 requires-python = ">=3.12,<3.13"

--- a/libs/idun_agent_engine/src/idun_agent_engine/_version.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/_version.py
@@ -1,3 +1,3 @@
 """Version information for Idun Agent Engine."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/libs/idun_agent_schema/pyproject.toml
+++ b/libs/idun_agent_schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-agent-schema"
-version = "0.6.0"
+version = "0.6.1"
 description = "Centralized Pydantic schema library for Idun Agent Engine"
 authors = [{ name = "Idun Group", email = "h.geoffrey@idun-group.com" }]
 license = "GPL-3.0-only"

--- a/libs/idun_agent_schema/src/idun_agent_schema/__init__.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/__init__.py
@@ -6,4 +6,4 @@ Public namespaces:
 - idun_agent_schema.shared: Shared cross-cutting schemas
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/libs/idun_agent_standalone/CHANGELOG.md
+++ b/libs/idun_agent_standalone/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to `idun-agent-standalone` are documented here. This package
 
 _No unreleased changes yet._
 
+## 0.6.1 — 2026-05-20
+
+Patch release. Fixes the password-mode chat surface that the v0.6.0 hardening accidentally locked behind `/login`, and propagates a stable per-session `user_id` end-to-end so chat history and traces can be scoped per user when the standalone UI runs under password auth without a full OIDC ladder.
+
+### Added
+
+- `/runtime-config.js` now carries `agentReady` (bool) and `bootFailed` (bool) so the SPA can decide between rendering chat and redirecting to `/onboarding` synchronously at hydration, with no extra HTTP roundtrip. `bootFailed` is boolean by design — the raw boot-error string was previously echoed back to anonymous browsers and could leak DB connection URIs, file paths, and parse traces (#671).
+- Chat SPA mints a stable per-session `user_id` (SSO email when present, else fresh UUID, cached in module state) and attaches `X-Idun-User-Id` on every `/agent/*` call. The active id renders in the History sidebar so visitors can confirm which identity is being sent to the engine (#671).
+
+### Changed
+
+- `_is_public_runtime_path` lets `/agent/sessions` and `/agent/sessions/{id}` through the password gate. `useChat` hits these on every chat page load; without this they 401 and the SPA's global handler hard-navigates to `/login` even though chat itself is open under `auth_mode: password`. Per-user scoping of these endpoints is the engine adapter's job (#671).
+- `BrandedLayout` and `InspectorLayout` drop the duplicated brand from their own chat-area headers; brand (logo + app name) and the active `user_id` move into the sidebar top, above History/New (#671).
+
+### Fixed
+
+- Password mode no longer hard-redirects to `/login` on the chat surface. The chat root no longer calls `api.getAgent()` (admin-gated under password mode, the source of the 401-redirect-to-`/login` bug); onboarding routing now reads `agentReady` / `bootFailed` from `/runtime-config.js` synchronously (#671).
+
 ## 0.6.0 — 2026-05-17
 
 First wide release of the standalone admin/chat/traces app, the bundled UI behind the **Idun Engine v0.6.0** launch. Previously circulated as a `0.1.0` dev snapshot; this release is the version published as part of `idun-agent-engine 0.6.0` and is the first one adopters will install via `pip install idun-agent-engine && idun setup && idun serve`. Full launch context: [The third path](https://idun-group.com/blog/2026-05-17-third-path-engine-v0.6).

--- a/libs/idun_agent_standalone/pyproject.toml
+++ b/libs/idun_agent_standalone/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "idun-agent-standalone"
-version = "0.6.0"
+version = "0.6.1"
 description = "Single-process, single-tenant Idun agent with embedded UI, admin panel, and traces viewer."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/__init__.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/__init__.py
@@ -1,3 +1,3 @@
 """idun-agent-standalone — single-process, single-tenant Idun agent."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-engine"
-version = "0.6.0"
+version = "0.6.1"
 description = "Idun Engine"
 authors = [{ name = "Idun Group", email = "h.geoffrey@idun-group.com" }]
 requires-python = ">=3.12,<3.13"

--- a/services/idun_agent_standalone_ui/package.json
+++ b/services/idun_agent_standalone_ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idun-agent-standalone-ui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3100",

--- a/uv.lock
+++ b/uv.lock
@@ -1709,7 +1709,7 @@ wheels = [
 
 [[package]]
 name = "idun-agent-engine"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "libs/idun_agent_engine" }
 dependencies = [
     { name = "ag-ui-adk" },
@@ -1873,7 +1873,7 @@ dev = [
 
 [[package]]
 name = "idun-agent-schema"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "libs/idun_agent_schema" }
 dependencies = [
     { name = "jinja2" },
@@ -1890,7 +1890,7 @@ requires-dist = [
 
 [[package]]
 name = "idun-agent-standalone"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "libs/idun_agent_standalone" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1941,7 +1941,7 @@ requires-dist = [
 
 [[package]]
 name = "idun-engine"
-version = "0.6.0"
+version = "0.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "idun-agent-engine" },


### PR DESCRIPTION
## Summary

Bumps the workspace to **0.6.1** ahead of a `develop → main` sync. Same shape as #653 (the v0.6.0 prep).

- `idun-engine`, `idun-agent-engine`, `idun-agent-schema`, `idun-agent-standalone`, `idun-agent-standalone-ui` → `0.6.1`
- `uv.lock` regenerated
- CHANGELOG entries added to `libs/idun_agent_engine/CHANGELOG.md` and `libs/idun_agent_standalone/CHANGELOG.md` documenting the only product change in this train: #671 (open chat under password mode + `X-Idun-User-Id` propagation end-to-end)

The other commits on develop since v0.6.0 (#663, #664, docs.idun-group.com rebrand) are docs-only and don't need CHANGELOG entries.

## Test plan

- [ ] CI green (lint, mypy, pytest, UI typecheck, build-standalone-wheel)
- [ ] `grep -rn "0\.6\.0" libs/ services/ pyproject.toml` returns only legitimate non-version hits (dep floors / classifiers)
- [ ] Once merged, open a `develop → main` PR titled `release: merge develop → main (v0.6.1)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)