### PR TITLE
fix(standalone-ui): SPA navigation fixes for admin login + trace pages

### DIFF
--- a/services/idun_agent_standalone_ui/__tests__/admin/AuthGuard.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/admin/AuthGuard.test.tsx
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+
+import { AuthGuard } from "@/components/admin/AuthGuard";
+
+const replace = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+}));
+
+vi.mock("@/lib/use-auth", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+describe("AuthGuard", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    replace.mockReset();
+    useAuthMock.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  function setLocation(pathname: string, search = "", hash = "") {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, pathname, search, hash },
+    });
+  }
+
+  it("renders children when authenticated", () => {
+    useAuthMock.mockReturnValue({
+      data: { authenticated: true },
+      isLoading: false,
+      error: null,
+    });
+    const { getByText } = render(
+      <AuthGuard>
+        <span>inner</span>
+      </AuthGuard>,
+    );
+    expect(getByText("inner")).toBeTruthy();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /login/?next=<current path> when not authenticated", async () => {
+    setLocation("/admin/mcp/", "");
+    useAuthMock.mockReturnValue({
+      data: { authenticated: false },
+      isLoading: false,
+      error: null,
+    });
+    render(
+      <AuthGuard>
+        <span>inner</span>
+      </AuthGuard>,
+    );
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith("/login/?next=%2Fadmin%2Fmcp%2F"),
+    );
+  });
+
+  it("preserves the query string in ?next=", async () => {
+    setLocation("/admin/agent/", "?foo=bar");
+    useAuthMock.mockReturnValue({
+      data: { authenticated: false },
+      isLoading: false,
+      error: null,
+    });
+    render(
+      <AuthGuard>
+        <span>inner</span>
+      </AuthGuard>,
+    );
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith(
+        "/login/?next=%2Fadmin%2Fagent%2F%3Ffoo%3Dbar",
+      ),
+    );
+  });
+
+  it("redirects on auth query error (e.g. network failure)", async () => {
+    setLocation("/admin/", "");
+    useAuthMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("boom"),
+    });
+    render(
+      <AuthGuard>
+        <span>inner</span>
+      </AuthGuard>,
+    );
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith("/login/?next=%2Fadmin%2F"),
+    );
+  });
+
+  it("does not redirect while loading", () => {
+    useAuthMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    render(
+      <AuthGuard>
+        <span>inner</span>
+      </AuthGuard>,
+    );
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("redirects exactly once after loading resolves to unauthenticated", async () => {
+    setLocation("/admin/", "");
+    useAuthMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    const { rerender } = render(
+      <AuthGuard>
+        <span>inner</span>
+      </AuthGuard>,
+    );
+    expect(replace).not.toHaveBeenCalled();
+
+    useAuthMock.mockReturnValue({
+      data: { authenticated: false },
+      isLoading: false,
+      error: null,
+    });
+    await act(async () => {
+      rerender(
+        <AuthGuard>
+          <span>inner</span>
+        </AuthGuard>,
+      );
+    });
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith("/login/?next=%2Fadmin%2F"),
+    );
+    expect(replace).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the hash fragment from ?next= (login round-trip preserves path + search only)", async () => {
+    // The hash is intentionally dropped — login.tsx's open-redirect
+    // guard (``isSafeNext``) operates on path + search, and the hash
+    // would need its own validation. Codify the current behavior so a
+    // future change is explicit.
+    setLocation("/admin/traces/", "", "#span-123");
+    useAuthMock.mockReturnValue({
+      data: { authenticated: false },
+      isLoading: false,
+      error: null,
+    });
+    render(
+      <AuthGuard>
+        <span>inner</span>
+      </AuthGuard>,
+    );
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith("/login/?next=%2Fadmin%2Ftraces%2F"),
+    );
+  });
+});

--- a/services/idun_agent_standalone_ui/__tests__/login.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/login.test.tsx
@@ -2,11 +2,15 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import LoginPage from "@/app/login/page";
 
-const replace = vi.fn();
+// The login page hard-navigates via `window.location.replace` instead of
+// Next.js `router.replace`. The former forces the browser to re-issue the
+// request with the freshly-set `idun_session` cookie attached, which
+// `router.replace` does not reliably do in an App Router static export with
+// `trailingSlash: true`. Tests assert against this hard navigation.
+const locationReplace = vi.fn();
 const useSearchParamsMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace }),
   useSearchParams: () => useSearchParamsMock(),
 }));
 
@@ -30,8 +34,32 @@ import { toast } from "sonner";
 import { makeRuntimeConfig } from "./helpers/runtime-config-fixture";
 
 describe("LoginPage", () => {
+  let restoreReplace: (() => void) | null = null;
+
   beforeEach(() => {
-    replace.mockReset();
+    locationReplace.mockReset();
+    // jsdom marks `Location.prototype.replace` as non-configurable, so we
+    // can't `defineProperty` on the instance. Swap the whole `location`
+    // (which IS configurable on `window`) for a stub that delegates the
+    // properties we don't care about and captures the navigation we do.
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        href: originalLocation.href,
+        replace: locationReplace,
+        assign: vi.fn(),
+        reload: vi.fn(),
+      },
+    });
+    restoreReplace = () => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    };
+
     useSearchParamsMock.mockReturnValue(new URLSearchParams(""));
     (api.login as ReturnType<typeof vi.fn>).mockReset();
     (toast.error as ReturnType<typeof vi.fn>).mockReset();
@@ -42,6 +70,8 @@ describe("LoginPage", () => {
   });
 
   afterEach(() => {
+    restoreReplace?.();
+    restoreReplace = null;
     vi.clearAllMocks();
     delete window.__IDUN_CONFIG__;
   });
@@ -53,7 +83,7 @@ describe("LoginPage", () => {
       target: { value: "hunter2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
-    await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+    await waitFor(() => expect(locationReplace).toHaveBeenCalledWith("/"));
   });
 
   it("on success with ?next=/onboarding, redirects there", async () => {
@@ -64,7 +94,26 @@ describe("LoginPage", () => {
       target: { value: "hunter2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
-    await waitFor(() => expect(replace).toHaveBeenCalledWith("/onboarding"));
+    await waitFor(() =>
+      expect(locationReplace).toHaveBeenCalledWith("/onboarding"),
+    );
+  });
+
+  it("on success with ?next=/admin/, redirects there (regression: cookie must travel)", async () => {
+    // The original bug: router.replace("/admin/") fired but didn't actually
+    // navigate the browser in static export mode, so the freshly-set
+    // idun_session cookie never reached /admin/ and the user stayed
+    // looking at the (already-submitted) sign-in form.
+    useSearchParamsMock.mockReturnValue(new URLSearchParams("next=/admin/"));
+    (api.login as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+    render(<LoginPage />);
+    fireEvent.change(screen.getByLabelText(/admin password/i), {
+      target: { value: "hunter2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() =>
+      expect(locationReplace).toHaveBeenCalledWith("/admin/"),
+    );
   });
 
   it("on 401, fires toast.error and does not redirect", async () => {
@@ -77,7 +126,7 @@ describe("LoginPage", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
-    expect(replace).not.toHaveBeenCalled();
+    expect(locationReplace).not.toHaveBeenCalled();
   });
 
   it("rejects unsafe ?next= values and falls back to /", async () => {
@@ -90,7 +139,7 @@ describe("LoginPage", () => {
       target: { value: "hunter2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
-    await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+    await waitFor(() => expect(locationReplace).toHaveBeenCalledWith("/"));
   });
 
   it("rejects protocol-relative ?next= values", async () => {
@@ -103,7 +152,7 @@ describe("LoginPage", () => {
       target: { value: "hunter2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
-    await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+    await waitFor(() => expect(locationReplace).toHaveBeenCalledWith("/"));
   });
 
   describe("when runtime config is missing entirely", () => {
@@ -118,7 +167,7 @@ describe("LoginPage", () => {
     it("renders the sign-in form (no auto-redirect)", () => {
       render(<LoginPage />);
       expect(screen.getByLabelText(/admin password/i)).toBeInTheDocument();
-      expect(replace).not.toHaveBeenCalled();
+      expect(locationReplace).not.toHaveBeenCalled();
     });
   });
 
@@ -139,7 +188,7 @@ describe("LoginPage", () => {
 
     it("redirects to / on mount", async () => {
       render(<LoginPage />);
-      await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+      await waitFor(() => expect(locationReplace).toHaveBeenCalledWith("/"));
     });
 
     it("honors ?next=/admin/ when the form would have redirected there", async () => {
@@ -147,7 +196,9 @@ describe("LoginPage", () => {
         new URLSearchParams("next=/admin/"),
       );
       render(<LoginPage />);
-      await waitFor(() => expect(replace).toHaveBeenCalledWith("/admin/"));
+      await waitFor(() =>
+        expect(locationReplace).toHaveBeenCalledWith("/admin/"),
+      );
     });
 
     it("falls back to / for unsafe ?next= values", async () => {
@@ -155,7 +206,7 @@ describe("LoginPage", () => {
         new URLSearchParams("next=https://evil.com"),
       );
       render(<LoginPage />);
-      await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+      await waitFor(() => expect(locationReplace).toHaveBeenCalledWith("/"));
     });
 
     it("rejects ?next=/login to avoid an infinite redirect loop (CR-1)", async () => {
@@ -163,7 +214,7 @@ describe("LoginPage", () => {
         new URLSearchParams("next=/login"),
       );
       render(<LoginPage />);
-      await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+      await waitFor(() => expect(locationReplace).toHaveBeenCalledWith("/"));
     });
 
     it("rejects ?next=/login/ (trailing slash) to avoid loops", async () => {
@@ -171,7 +222,7 @@ describe("LoginPage", () => {
         new URLSearchParams("next=/login/"),
       );
       render(<LoginPage />);
-      await waitFor(() => expect(replace).toHaveBeenCalledWith("/"));
+      await waitFor(() => expect(locationReplace).toHaveBeenCalledWith("/"));
     });
   });
 });

--- a/services/idun_agent_standalone_ui/__tests__/traces/detail-page-url-parser.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/traces/detail-page-url-parser.test.tsx
@@ -15,16 +15,18 @@ import * as tracesApi from "@/lib/api/traces";
  * ``dynamicParams: false`` and one materialised placeholder
  * (``__trace__``), ``useParams()`` returns the build-time placeholder
  * for every dynamic URL hit at runtime. The real trace id only lives
- * on ``window.location.pathname``. ``readTraceIdFromLocation`` is the
- * fix; this file pins its behaviour against drift.
+ * on the pathname. ``readTraceIdFromPathname`` is the fix; this file
+ * pins its integration with ``TraceDetailClient`` against drift.
  *
- * The function itself is module-private — it is exercised through the
- * component (``TraceDetailClient``) by:
+ * The pure function is unit-tested in
+ * ``readTraceIdFromPathname.test.ts``. This file exercises the
+ * end-to-end resolver chain inside ``TraceDetailClient`` by:
  *
  *   1. configuring ``useParams`` to return the placeholder (the real
- *      runtime shape under static export), and
- *   2. setting ``window.location.pathname`` to the deep link the user
- *      lands on.
+ *      runtime shape under static export),
+ *   2. configuring ``usePathname`` to mirror ``window.location.pathname``
+ *      (so the legacy ``setPath()`` helper still drives the test), and
+ *   3. setting the pathname to the deep link the user lands on.
  *
  * Each test asserts what id ``getTrace`` is invoked with — that is the
  * single observable that decides whether the user sees their real
@@ -38,6 +40,13 @@ const mockUseParams = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useParams: () => mockUseParams(),
+  // Read from ``window.location.pathname`` so the legacy ``setPath()``
+  // helper below continues to drive the component without per-test
+  // mock-return-value wiring. ``usePathname`` is non-reactive here
+  // (no listener) — that's fine because each test calls ``setPath``
+  // before ``render``, so the first paint already reads the right path.
+  usePathname: () =>
+    typeof window !== "undefined" ? window.location.pathname : "",
   useRouter: () => ({
     push: vi.fn(),
     replace: vi.fn(),

--- a/services/idun_agent_standalone_ui/__tests__/traces/detail-page.test.tsx
+++ b/services/idun_agent_standalone_ui/__tests__/traces/detail-page.test.tsx
@@ -106,8 +106,17 @@ const replaceMock = vi.fn((url: string) => {
   setSearchParams(qs);
 });
 
+// `usePathname` is read by the production component to resolve the
+// trace id reactively under `output: "export"` + `dynamicParams:false`
+// (see TraceDetailClient comment). We stub a fixed detail-page path
+// so the resolver returns the canonical TRACE_ID in every test.
+const pathnameMock = vi.fn<() => string>(
+  () => `/admin/traces/${TRACE_ID}`,
+);
+
 vi.mock("next/navigation", () => ({
   useParams: () => ({ traceId: TRACE_ID }),
+  usePathname: () => pathnameMock(),
   useRouter: () => ({
     push: pushMock,
     replace: replaceMock,
@@ -151,6 +160,13 @@ function withQuery(children: ReactNode) {
 }
 
 describe("TraceDetailPage", () => {
+  // Captures `window.location.assign` calls — the production code
+  // hard-navs to `/admin/traces/` on delete-success and on the
+  // `goBackToList` no-history fallback to dodge the static-export
+  // router-cache collision documented in TraceDetailClient.
+  const locationAssign = vi.fn();
+  let restoreLocation: (() => void) | null = null;
+
   beforeEach(() => {
     // Use mockClear(), not mockReset(). mockReset() drops the
     // implementation we registered in `vi.fn(impl)`, which means
@@ -161,10 +177,37 @@ describe("TraceDetailPage", () => {
     pushMock.mockClear();
     replaceMock.mockClear();
     backMock.mockClear();
+    pathnameMock.mockClear();
+    pathnameMock.mockImplementation(() => `/admin/traces/${TRACE_ID}`);
+    locationAssign.mockReset();
     setSearchParams("");
+
+    // jsdom marks `Location.prototype.assign` as non-configurable, so
+    // we swap the whole `location` (which IS configurable on `window`)
+    // for a stub that captures the navigation. Mirrors the pattern in
+    // __tests__/login.test.tsx.
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        href: originalLocation.href,
+        assign: locationAssign,
+        replace: vi.fn(),
+        reload: vi.fn(),
+      },
+    });
+    restoreLocation = () => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    };
   });
 
   afterEach(() => {
+    restoreLocation?.();
+    restoreLocation = null;
     vi.restoreAllMocks();
   });
 
@@ -305,9 +348,12 @@ describe("TraceDetailPage", () => {
     await waitFor(() => {
       expect(deleteSpy).toHaveBeenCalledWith(TRACE_ID);
     });
+    // Hard nav (window.location.assign) — see comment on the
+    // delete-success path in TraceDetailClient for the rationale.
     await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith("/admin/traces");
+      expect(locationAssign).toHaveBeenCalledWith("/admin/traces/");
     });
+    expect(pushMock).not.toHaveBeenCalled();
   });
 
   // ── P3 Sub-A coverage ────────────────────────────────────────────────

--- a/services/idun_agent_standalone_ui/__tests__/traces/readTraceIdFromPathname.test.ts
+++ b/services/idun_agent_standalone_ui/__tests__/traces/readTraceIdFromPathname.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { readTraceIdFromPathname } from "@/app/admin/traces/[traceId]/TraceDetailClient";
+
+describe("readTraceIdFromPathname", () => {
+  it("extracts the trace id from a real path", () => {
+    expect(readTraceIdFromPathname("/admin/traces/abc123/")).toBe("abc123");
+    expect(readTraceIdFromPathname("/admin/traces/abc123")).toBe("abc123");
+  });
+
+  it("returns null for the build-time placeholder", () => {
+    expect(readTraceIdFromPathname("/admin/traces/__trace__/")).toBeNull();
+    expect(readTraceIdFromPathname("/admin/traces/__trace__")).toBeNull();
+  });
+
+  it("returns null when pathname is null", () => {
+    expect(readTraceIdFromPathname(null)).toBeNull();
+  });
+
+  it("returns null for the list page (no id segment)", () => {
+    expect(readTraceIdFromPathname("/admin/traces/")).toBeNull();
+    expect(readTraceIdFromPathname("/admin/traces")).toBeNull();
+  });
+
+  it("returns null for unrelated admin paths", () => {
+    expect(readTraceIdFromPathname("/admin/agent/")).toBeNull();
+    expect(readTraceIdFromPathname("/")).toBeNull();
+  });
+});

--- a/services/idun_agent_standalone_ui/app/admin/traces/[traceId]/TraceDetailClient.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/traces/[traceId]/TraceDetailClient.tsx
@@ -33,7 +33,12 @@
 
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ArrowLeftIcon, GitBranchIcon, ListTreeIcon, Trash2Icon } from "lucide-react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -139,9 +144,9 @@ function StatusBadge({ status }: { status: string | null }) {
 // docstring in ``page.tsx`` and AUDIT.md follow-up #43.
 const _PLACEHOLDER_TRACE_ID = "__trace__";
 
-function readTraceIdFromLocation(): string | null {
-  if (typeof window === "undefined") return null;
-  const segments = window.location.pathname.split("/").filter(Boolean);
+export function readTraceIdFromPathname(pathname: string | null): string | null {
+  if (!pathname) return null;
+  const segments = pathname.split("/").filter(Boolean);
   // ``/admin/traces/<id>`` and ``/admin/traces/<id>/`` both produce
   // ``["admin", "traces", "<id>"]`` after the empty-segment filter. The
   // id sits at index 2.
@@ -155,15 +160,31 @@ export default function TraceDetailClient() {
   const params = useParams<{ traceId: string }>();
   const router = useRouter();
   const searchParams = useSearchParams();
-  // Resolve the trace id from ``window.location.pathname`` first because
-  // ``useParams`` returns the build-time placeholder ``__trace__`` under
-  // ``output: "export"`` with ``dynamicParams: false`` — the static
-  // export only knows about the placeholder route, so the runtime
-  // params object reflects the placeholder, not the URL. Fall back to
-  // ``params?.traceId`` only when the location parser can't extract a
-  // value (e.g. an in-app ``router.push`` that hasn't flushed yet).
+  // Resolve the trace id from the pathname because ``useParams`` returns
+  // the build-time placeholder ``__trace__`` under ``output: "export"``
+  // with ``dynamicParams: false`` — the static export only knows about
+  // the placeholder route, so the runtime params object reflects the
+  // placeholder, not the URL.
+  //
+  // We read ``usePathname`` (not ``window.location.pathname``) because on
+  // a soft client-side navigation Next.js mounts this component before
+  // it flushes ``history.pushState``; reading ``window.location`` once
+  // at mount captured the previous page's path, leaving ``traceId``
+  // empty and the data query disabled until the user hard-refreshed.
+  // ``usePathname`` is reactive to the router state, so it returns the
+  // target URL by the time React commits.
+  //
+  // The ``paramTraceId`` fallback is documentation: under the current
+  // static-export config it never fires (``useParams`` only ever yields
+  // the placeholder), but it preserves the contract — if a future
+  // refactor drops ``dynamicParams: false`` the param will become live
+  // and the resolver still works.
   const paramTraceId = params?.traceId ?? "";
-  const locationTraceId = useMemo(readTraceIdFromLocation, []);
+  const pathname = usePathname();
+  const locationTraceId = useMemo(
+    () => readTraceIdFromPathname(pathname),
+    [pathname],
+  );
   const traceId =
     locationTraceId ??
     (paramTraceId && paramTraceId !== _PLACEHOLDER_TRACE_ID ? paramTraceId : "");

--- a/services/idun_agent_standalone_ui/app/admin/traces/[traceId]/TraceDetailClient.tsx
+++ b/services/idun_agent_standalone_ui/app/admin/traces/[traceId]/TraceDetailClient.tsx
@@ -330,7 +330,13 @@ export default function TraceDetailClient() {
           result.deletedSpans === 1 ? "" : "s"
         } removed)`,
       );
-      router.push("/admin/traces");
+      // Hard nav, mirroring the AppSidebar Traces workaround: a soft
+      // `router.push("/admin/traces")` under `output: "export"` +
+      // `dynamicParams: false` can mount the sibling `[traceId]` route
+      // at the list URL, leaving the operator on "No spans recorded"
+      // until refresh — especially confusing immediately after a
+      // destructive action.
+      window.location.assign("/admin/traces/");
     },
     onError: (err) => {
       const detail =
@@ -357,7 +363,8 @@ export default function TraceDetailClient() {
     if (typeof window !== "undefined" && window.history.length > 1) {
       router.back();
     } else {
-      router.push("/admin/traces");
+      // Hard nav for the same reason as the delete-success path above.
+      window.location.assign("/admin/traces/");
     }
   }, [router]);
 

--- a/services/idun_agent_standalone_ui/app/login/page.tsx
+++ b/services/idun_agent_standalone_ui/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
@@ -26,7 +26,6 @@ function pickPostLoginPath(raw: string): string {
 }
 
 function LoginForm() {
-  const router = useRouter();
   const params = useSearchParams();
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
@@ -45,8 +44,9 @@ function LoginForm() {
   useEffect(() => {
     if (!authDisabled) return;
     const raw = params?.get("next") ?? "/";
-    router.replace(pickPostLoginPath(raw));
-  }, [authDisabled, params, router]);
+    // Same reason as the post-submit branch below — see comment there.
+    window.location.replace(pickPostLoginPath(raw));
+  }, [authDisabled, params]);
   if (authDisabled) return null;
 
   return (
@@ -73,7 +73,12 @@ function LoginForm() {
                 duration_ms: Math.round(performance.now() - startedAt),
               });
               const raw = params?.get("next") ?? "/";
-              router.replace(pickPostLoginPath(raw));
+              // Hard-navigate. router.replace doesn't reliably navigate
+              // cross-route in Next.js App Router static exports with
+              // trailingSlash:true; window.location.replace also forces
+              // the browser to re-issue the request with the freshly-set
+              // session cookie attached.
+              window.location.replace(pickPostLoginPath(raw));
             } catch (err) {
               const status = err instanceof ApiError ? err.status : 0;
               void capture(Events.AUTH_LOGIN_FAILURE, {

--- a/services/idun_agent_standalone_ui/components/admin/AppSidebar.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/AppSidebar.tsx
@@ -42,6 +42,14 @@ type NavItem = {
   label: string;
   icon: React.ComponentType<{ className?: string }>;
   external?: boolean;
+  // Render as a plain ``<a>`` and force a hard browser navigation via
+  // ``window.location.assign``. Use only when Next.js's client-side
+  // router resolves the target URL incorrectly under ``output: "export"``
+  // — e.g. ``/admin/traces/`` soft-navs sometimes mount the sibling
+  // ``[traceId]`` route component instead of the explicit list page.
+  // Follow-up: collide-free rename of the dynamic route (singular
+  // ``/admin/trace/[traceId]/``) would let us drop this workaround.
+  hardNav?: boolean;
 };
 type NavGroup = { label: string; items: NavItem[] };
 
@@ -50,7 +58,7 @@ const NAV: NavGroup[] = [
     label: "Overview",
     items: [
       { href: "/admin/", label: "Dashboard", icon: LayoutDashboard },
-      { href: "/admin/traces/", label: "Traces", icon: Activity },
+      { href: "/admin/traces/", label: "Traces", icon: Activity, hardNav: true },
     ],
   },
   {
@@ -170,6 +178,21 @@ export function AppSidebar() {
                             className="ml-auto h-3 w-3 opacity-60"
                             aria-hidden="true"
                           />
+                        </a>
+                      ) : item.hardNav ? (
+                        <a
+                          href={item.href}
+                          // Plain-click forces a hard nav. Cmd+Click /
+                          // middle-click bypass ``onClick`` and use the
+                          // ``href`` directly, which is the intended
+                          // behavior (new tab also gets a hard nav).
+                          onClick={(e) => {
+                            e.preventDefault();
+                            window.location.assign(item.href);
+                          }}
+                        >
+                          <item.icon className="h-4 w-4" />
+                          <span>{item.label}</span>
                         </a>
                       ) : (
                         <Link href={item.href}>

--- a/services/idun_agent_standalone_ui/components/admin/AuthGuard.tsx
+++ b/services/idun_agent_standalone_ui/components/admin/AuthGuard.tsx
@@ -4,12 +4,24 @@ import { useRouter } from "next/navigation";
 import { type ReactNode, useEffect } from "react";
 import { useAuth } from "@/lib/use-auth";
 
+// /admin/api/v1/auth/me returns 200 `{authenticated: false}` (not 401)
+// when password mode is on and there's no session cookie, so the global
+// 401 redirect in `lib/api/client.ts` doesn't fire for the `me()` probe
+// itself (it still fires for other admin endpoints that return 401).
+// Build the `?next=` ourselves from the current location so login
+// round-trips back to the admin page the operator was trying to reach.
+function loginPathWithNext(): string {
+  if (typeof window === "undefined") return "/login/";
+  const here = window.location.pathname + window.location.search;
+  return `/login/?next=${encodeURIComponent(here)}`;
+}
+
 export function AuthGuard({ children }: { children: ReactNode }) {
   const router = useRouter();
   const { data, isLoading, error } = useAuth();
   useEffect(() => {
     if (!isLoading && (error || !data?.authenticated)) {
-      router.replace("/login/");
+      router.replace(loginPathWithNext());
     }
   }, [data, error, isLoading, router]);
   if (isLoading)


### PR DESCRIPTION
## Summary

Three related bugfixes for the standalone admin UI under Next.js 15 `output: "export"` + FastAPI SPA-rewrite.

- **AuthGuard `?next=` preservation** — `api.me()` returns 200 `{authenticated:false}` under password mode, so the global 401 redirect in `lib/api/client.ts` doesn't fire for the `me()` probe itself. AuthGuard's redirect now builds `?next=<current path>` so login round-trips back to the admin page the operator tried to reach instead of defaulting to `/` (chat).
- **Hard-nav after login** — replaces `router.replace` with `window.location.replace` on the login form's success path. Soft cross-route navigation under `output:"export" + trailingSlash:true` isn't reliable; the hard nav also forces the next request to reissue with the freshly-set session cookie.
- **Trace detail data fetch on soft nav** — `TraceDetailClient` resolved the trace id via `useMemo(readLocation, [])`. The empty deps captured the *previous* page's pathname on `<Link>` clicks because React commits the new tree before Next.js flushes `history.pushState`. `traceId` resolved to `""`, `useQuery` was disabled, page rendered "No spans recorded" until refresh. Switched to the reactive `usePathname()` hook.
- **Sidebar Traces hard-nav** — soft nav to `/admin/traces/` from another admin page sometimes mounted the sibling `[traceId]` component at the list URL (Next.js router cache + `dynamicParams:false` collision). Sidebar Traces link now uses `window.location.assign`. A follow-up rename of the dynamic route would let us drop this workaround.

## Test plan

- [x] `pnpm vitest run __tests__/admin/AuthGuard.test.tsx __tests__/traces/readTraceIdFromPathname.test.ts __tests__/login.test.tsx` — 25/25 pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — no new errors introduced
- [x] Live verification against a local standalone (Playwright + browser): trace row click loads data, sidebar Traces from `/admin/agent/` lands on the list, login round-trips back to `/admin/...`

## Notes

- `TraceDetailClient.readTraceIdFromPathname` is now exported and unit-tested.
- New `hardNav?: boolean` flag on `NavItem` in `AppSidebar` — currently only used by Traces; comment links the follow-up.
- New `AuthGuard.test.tsx` covers authenticated/unauthenticated/loading/loading-to-resolved/hash-drop/query-string preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)