### PR TITLE
chore(release): 0.6.2 prep — version bumps + CHANGELOGs

### DIFF
--- a/libs/idun_agent_engine/CHANGELOG.md
+++ b/libs/idun_agent_engine/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `idun-agent-engine` are documented here. This project fol
 
 _No unreleased changes yet._
 
+## 0.6.2 — 2026-05-21
+
+Patch release. No engine code changes. Ships the bundled `idun-agent-standalone` UI at 0.6.2, which fixes a cluster of SPA-navigation bugs in the admin surface under Next.js 15 `output: "export"` (AuthGuard `?next=` preservation, post-login hard-nav, trace detail soft-nav resolution, sidebar Traces + post-delete hard-nav). See `libs/idun_agent_standalone/CHANGELOG.md` for the full list (#682).
+
 ## 0.6.1 — 2026-05-20
 
 Patch release. The engine now accepts a per-request `X-Idun-User-Id` header and binds it to a `current_user_id` ContextVar that adapter code (and the standalone trace writer) read at the start of every `/agent/*` invocation, so chat history and traces can be scoped per user when the standalone UI runs under password auth without a full OIDC ladder. Pairs with the standalone changes in `0.6.1` that open the chat shell under password mode.

--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-agent-engine"
-version = "0.6.1"
+version = "0.6.2"
 description = "Python SDK and runtime to serve AI agents with FastAPI, LangGraph, and observability."
 authors = [{ name = "Idun Group", email = "h.geoffrey@idun-group.com" }]
 requires-python = ">=3.12,<3.13"

--- a/libs/idun_agent_engine/src/idun_agent_engine/_version.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/_version.py
@@ -1,3 +1,3 @@
 """Version information for Idun Agent Engine."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/libs/idun_agent_schema/pyproject.toml
+++ b/libs/idun_agent_schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-agent-schema"
-version = "0.6.1"
+version = "0.6.2"
 description = "Centralized Pydantic schema library for Idun Agent Engine"
 authors = [{ name = "Idun Group", email = "h.geoffrey@idun-group.com" }]
 license = "GPL-3.0-only"

--- a/libs/idun_agent_schema/src/idun_agent_schema/__init__.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/__init__.py
@@ -6,4 +6,4 @@ Public namespaces:
 - idun_agent_schema.shared: Shared cross-cutting schemas
 """
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/libs/idun_agent_standalone/CHANGELOG.md
+++ b/libs/idun_agent_standalone/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to `idun-agent-standalone` are documented here. This package
 
 _No unreleased changes yet._
 
+## 0.6.2 — 2026-05-21
+
+Patch release. Fixes a cluster of SPA-navigation bugs in the standalone admin UI under Next.js 15 `output: "export"` + FastAPI SPA-rewrite, where soft client-side navigation and cookie handling do not behave as they would in a standard server-rendered Next.js app.
+
+### Fixed
+
+- **AuthGuard `?next=` preservation.** `api.me()` returns `200 {authenticated:false}` under password mode, so the global 401 redirect in `lib/api/client.ts` does not fire for the `me()` probe itself. AuthGuard's redirect now builds `?next=<current path>` so login round-trips back to the admin page the operator tried to reach instead of defaulting to `/` (chat) (#682).
+- **Hard-nav after login.** Replaced `router.replace` with `window.location.replace` on the login form's success path. Soft cross-route navigation under `output:"export" + trailingSlash:true` is not reliable; the hard nav also forces the next request to reissue with the freshly-set session cookie (#682).
+- **Trace detail data fetch on soft nav.** `TraceDetailClient` previously resolved the trace id via `useMemo(readLocation, [])`. The empty deps captured the previous page's pathname on `<Link>` clicks because React commits the new tree before Next.js flushes `history.pushState`. `traceId` resolved to `""`, `useQuery` was disabled, page rendered "No spans recorded" until refresh. Switched to the reactive `usePathname()` hook (#682).
+- **Sidebar Traces hard-nav.** Soft nav to `/admin/traces/` from another admin page sometimes mounted the sibling `[traceId]` component at the list URL (Next.js router cache + `dynamicParams:false` collision). Sidebar Traces link now uses `window.location.assign` (#682).
+- **Post-delete hard-nav.** The delete mutation's `onSuccess` now uses `window.location.assign("/admin/traces/")` instead of `router.push("/admin/traces")` — same router-cache collision the sidebar workaround addresses, but immediately after a destructive action where landing on a stale shell would be the worst UX (#682).
+- **`goBackToList` no-history fallback.** Same hard-nav treatment as the delete-success path for the error-screen back-to-list fallback (#682).
+
+### Tests
+
+- New `__tests__/admin/AuthGuard.test.tsx` covering authenticated / unauthenticated / loading / loading-to-resolved / hash-drop / query-string preservation (#682).
+- New `__tests__/traces/readTraceIdFromPathname.test.ts` for the now-exported pure resolver (#682).
+- Repaired `__tests__/traces/detail-page.test.tsx` and `__tests__/traces/detail-page-url-parser.test.tsx` to mock `usePathname` and stub `window.location.assign` (#682).
+
 ## 0.6.1 — 2026-05-20
 
 Patch release. Fixes the password-mode chat surface that the v0.6.0 hardening accidentally locked behind `/login`, and propagates a stable per-session `user_id` end-to-end so chat history and traces can be scoped per user when the standalone UI runs under password auth without a full OIDC ladder.

--- a/libs/idun_agent_standalone/pyproject.toml
+++ b/libs/idun_agent_standalone/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "idun-agent-standalone"
-version = "0.6.1"
+version = "0.6.2"
 description = "Single-process, single-tenant Idun agent with embedded UI, admin panel, and traces viewer."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/__init__.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/__init__.py
@@ -1,3 +1,3 @@
 """idun-agent-standalone — single-process, single-tenant Idun agent."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-engine"
-version = "0.6.1"
+version = "0.6.2"
 description = "Idun Engine"
 authors = [{ name = "Idun Group", email = "h.geoffrey@idun-group.com" }]
 requires-python = ">=3.12,<3.13"

--- a/services/idun_agent_standalone_ui/package.json
+++ b/services/idun_agent_standalone_ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idun-agent-standalone-ui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3100",

--- a/uv.lock
+++ b/uv.lock
@@ -1709,7 +1709,7 @@ wheels = [
 
 [[package]]
 name = "idun-agent-engine"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "libs/idun_agent_engine" }
 dependencies = [
     { name = "ag-ui-adk" },
@@ -1873,7 +1873,7 @@ dev = [
 
 [[package]]
 name = "idun-agent-schema"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "libs/idun_agent_schema" }
 dependencies = [
     { name = "jinja2" },
@@ -1890,7 +1890,7 @@ requires-dist = [
 
 [[package]]
 name = "idun-agent-standalone"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "libs/idun_agent_standalone" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1941,7 +1941,7 @@ requires-dist = [
 
 [[package]]
 name = "idun-engine"
-version = "0.6.1"
+version = "0.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "idun-agent-engine" },


### PR DESCRIPTION
## Summary

Bumps the workspace to **0.6.2** ahead of a `develop → main` sync. Same shape as #677 (the v0.6.1 prep).

- `idun-engine`, `idun-agent-engine`, `idun-agent-schema`, `idun-agent-standalone`, `idun-agent-standalone-ui` → `0.6.2`
- `uv.lock` regenerated
- CHANGELOG entries added — full notes in `libs/idun_agent_standalone/CHANGELOG.md`, brief pointer in `libs/idun_agent_engine/CHANGELOG.md` (no engine code changes this release)

## What's in 0.6.2

All UI fixes — engine code is unchanged. Product change: **#682** — SPA navigation fixes for admin login + trace pages under Next.js 15 `output: "export"` + FastAPI SPA-rewrite:

- AuthGuard `?next=` preservation (login round-trips back to the admin page)
- Login form hard-navs via `window.location.replace` so the session cookie travels
- Trace detail resolves the trace id via reactive `usePathname()` instead of stale `useMemo(readLocation, [])`
- Sidebar Traces + post-delete + `goBackToList` no-history fallback all hard-nav to `/admin/traces/` to dodge the router-cache collision under `dynamicParams:false`
- Repaired pre-existing broken tests (`detail-page.test.tsx`, `detail-page-url-parser.test.tsx`) that were silently broken on develop by the `usePathname` introduction

## Test plan

- [ ] CI green (lint, mypy, pytest, UI typecheck, build-standalone-wheel)
- [ ] `grep -rn "0\.6\.1" libs/ services/ pyproject.toml` returns only legitimate non-version hits (CHANGELOG history, dep constraints from the previous release)
- [ ] Once merged, open `develop → main` PR titled `release: merge develop → main (v0.6.2)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)