### PR TITLE
feat(engine): standalone telemetry sink, async config-from-API, and reload-concurrency fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,14 @@ jobs:
           enable-cache: false
 
       - name: Install workspace dependencies
+        # --all-extras pulls in idun-agent-engine's opt-in [guardrails] extra
+        # (guardrails-ai + the `guardrails` CLI) so the guardrails tests run for
+        # real instead of erroring on a missing CLI. guardrails is the only
+        # extra in the workspace, so this stays lean. The conftest's
+        # pytest_sessionstart configures the Hub and installs validators when the
+        # CLI is present and GUARDRAILS_API_KEY is set.
         run: |
-          uv sync --group dev
+          uv sync --group dev --all-extras
 
       - name: Run engine tests
         env:

--- a/libs/idun_agent_engine/src/idun_agent_engine/core/config_builder.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/core/config_builder.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+import httpx
 import yaml
 from idun_agent_schema.engine.adk import AdkAgentConfig
 from idun_agent_schema.engine.agent_framework import AgentFramework
@@ -28,6 +29,11 @@ from ..agent.base import BaseAgent
 from .engine_config import AgentConfig, EngineConfig, ServerConfig
 
 logger = logging.getLogger(__name__)
+
+
+async def _fetch_config(url: str, headers: dict[str, str]) -> httpx.Response:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0)) as client:
+        return await client.get(url, headers=headers)
 
 
 class ConfigBuilder:
@@ -95,18 +101,16 @@ class ConfigBuilder:
         self._server_config = ServerConfig(api=api_config)
         return self
 
-    def with_config_from_api(self, agent_api_key: str, url: str) -> "ConfigBuilder":
+    async def with_config_from_api(self, agent_api_key: str, url: str) -> "ConfigBuilder":
         """Fetch config from the idun agent manager API and populate the builder.
 
         Requires the agent api key to pass in the headers.
         """
-        import requests  # TODO: replace with httpx
-        import yaml
-
         headers = {"auth": f"Bearer {agent_api_key}"}
         try:
-            logger.info(f"Fetching config from {url}/api/v1/agents/config")
-            response = requests.get(url=url + "/api/v1/agents/config", headers=headers)
+            base = url.rstrip("/")
+            logger.info(f"Fetching config from {base}/api/v1/agents/config")
+            response = await _fetch_config(f"{base}/api/v1/agents/config", headers)
             if response.status_code != 200:
                 raise ValueError(
                     f"Error retrieving config from url. response: {response.text}"

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -128,16 +128,34 @@ def ensure_reload_state(app: FastAPI) -> asyncio.Lock:
     return lock
 
 
-async def counted_run_stream(app: FastAPI, source):
+def counted_run_stream(app: FastAPI, source):
     """Re-yield a run's SSE stream while counting it as in-flight.
 
     A StreamingResponse generator stays alive until the client finishes
     reading it, and it keeps using the agent it started with the whole time.
     Counting that span lets a concurrent reload wait for the run to finish on
     the old agent instead of closing the agent out from under it mid-stream.
+
+    The count is taken *here*, synchronously when the route handler constructs
+    the wrapper, not on the body generator's first iteration. Starlette does
+    not start a StreamingResponse body until after it has sent the response
+    headers (an ``await`` that yields control to the loop), so an increment
+    deferred to first iteration would leave a window between the route
+    returning ``StreamingResponse`` and the body starting in which a concurrent
+    reload observes ``inflight_runs == 0``, drains, and closes the very agent
+    this stream is about to call ``run`` on. Counting at construction collapses
+    that window to zero; the matching decrement runs in the body's ``finally``,
+    which Starlette always reaches because it iterates (and, on client
+    disconnect, ``aclose``s) the body iterator.
     """
     ensure_reload_state(app)
     app.state.inflight_runs += 1
+    return _counted_run_stream_body(app, source)
+
+
+async def _counted_run_stream_body(app: FastAPI, source):
+    """Body half of :func:`counted_run_stream`; see its docstring for why the
+    increment lives in the synchronous wrapper and only the decrement here."""
     try:
         async for chunk in source:
             yield chunk
@@ -152,6 +170,17 @@ async def drain_inflight_runs(app: FastAPI, *, timeout: float = 30.0) -> None:
     old one, so runs that started on the old agent get to finish on it. The
     timeout caps how long one stuck run can hold up a reload; past it we close
     anyway and that run may error.
+
+    ``inflight_runs`` is a single process-wide counter, not partitioned by
+    agent generation. Runs that start on the *new* agent after the swap also
+    bump it, so under continuous traffic this can wait the full ``timeout``
+    before the old agent closes even though the old agent's own runs drained
+    much earlier. That is an accepted, bounded cost: correctness never depends
+    on it (the old agent's runs hold their own reference and finish regardless;
+    the only penalty is delayed cleanup of the old agent, capped at ``timeout``).
+    A precise drain would require keying the counter by the agent object each
+    run captured; deferred as it touches every streaming call site, including
+    the deprecated copilotkit paths that resolve a separate agent.
     """
     ensure_reload_state(app)
     waited = 0.0

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/lifespan.py
@@ -3,6 +3,7 @@
 Initializes the agent at startup and cleans up resources on shutdown.
 """
 
+import asyncio
 import inspect
 import logging
 import warnings
@@ -108,16 +109,75 @@ def _parse_guardrails(
     return guards, failures
 
 
-async def cleanup_agent(app: FastAPI):
-    """Clean up agent resources."""
+def ensure_reload_state(app: FastAPI) -> asyncio.Lock:
+    """Get-or-create the reload lock and the in-flight run counter.
+
+    A reload holds the lock for its whole teardown+build so two reloads
+    cannot interleave changes to the route table, the OTel provider, or the
+    agent. ``inflight_runs`` tracks how many agent runs are mid-stream so a
+    reload can drain them before closing the agent they are using. Created
+    lazily here because an embedder may call ``configure_app`` directly,
+    without going through the engine lifespan.
+    """
+    lock = getattr(app.state, "reload_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        app.state.reload_lock = lock
+    if not hasattr(app.state, "inflight_runs"):
+        app.state.inflight_runs = 0
+    return lock
+
+
+async def counted_run_stream(app: FastAPI, source):
+    """Re-yield a run's SSE stream while counting it as in-flight.
+
+    A StreamingResponse generator stays alive until the client finishes
+    reading it, and it keeps using the agent it started with the whole time.
+    Counting that span lets a concurrent reload wait for the run to finish on
+    the old agent instead of closing the agent out from under it mid-stream.
+    """
+    ensure_reload_state(app)
+    app.state.inflight_runs += 1
+    try:
+        async for chunk in source:
+            yield chunk
+    finally:
+        app.state.inflight_runs -= 1
+
+
+async def drain_inflight_runs(app: FastAPI, *, timeout: float = 30.0) -> None:
+    """Wait for in-flight runs to finish, up to ``timeout`` seconds.
+
+    Reload calls this after swapping in the new agent and before closing the
+    old one, so runs that started on the old agent get to finish on it. The
+    timeout caps how long one stuck run can hold up a reload; past it we close
+    anyway and that run may error.
+    """
+    ensure_reload_state(app)
+    waited = 0.0
+    step = 0.05
+    while app.state.inflight_runs > 0 and waited < timeout:
+        await asyncio.sleep(step)
+        waited += step
+
+
+async def cleanup_agent(app: FastAPI, *, close_agent: bool = True):
+    """Tear down integrations, routes, and OTel, and close the agent.
+
+    Reload passes ``close_agent=False`` so the old agent keeps serving its
+    in-flight runs while the new one is built and swapped in; reload closes
+    the old agent itself once those runs drain. Boot and shutdown close it
+    here.
+    """
     set_active_registry(None)
-    agent = getattr(app.state, "agent", None)
-    if agent is not None:
-        close_fn = getattr(agent, "close", None)
-        if callable(close_fn):
-            result = close_fn()
-            if inspect.isawaitable(result):
-                await result
+    if close_agent:
+        agent = getattr(app.state, "agent", None)
+        if agent is not None:
+            close_fn = getattr(agent, "close", None)
+            if callable(close_fn):
+                result = close_fn()
+                if inspect.isawaitable(result):
+                    await result
 
     integrations = getattr(app.state, "integrations", [])
     if integrations:
@@ -314,6 +374,7 @@ async def lifespan(app: FastAPI):
 
     # Load config and initialize agent on startup
     logger.info("🚀 Server starting up...")
+    ensure_reload_state(app)
     if app.state.engine_config is not None:
         await configure_app(app, app.state.engine_config)
     else:

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/agent.py
@@ -29,6 +29,7 @@ from idun_agent_engine.server.dependencies import (
     get_capabilities,
     get_copilotkit_agent,
 )
+from idun_agent_engine.server.lifespan import counted_run_stream
 
 logger = logging.getLogger(__name__)
 agent_router = APIRouter(tags=["Runtime"])
@@ -267,7 +268,10 @@ async def run(
                 except Exception:
                     yield 'event: error\ndata: {"error": "Agent execution failed"}\n\n'
 
-    return StreamingResponse(event_generator(), media_type=encoder.get_content_type())
+    return StreamingResponse(
+        counted_run_stream(request.app, event_generator()),
+        media_type=encoder.get_content_type(),
+    )
 
 
 @agent_router.get("/graph", response_model=AgentGraph)
@@ -354,6 +358,7 @@ async def get_config(request: Request):
 @agent_router.post("/stream", deprecated=True)
 async def stream(
     request: ChatRequest,
+    http_request: Request,
     agent: Annotated[BaseAgent, Depends(get_agent)],
     _user: Annotated[dict | None, Depends(get_verified_user)],
 ):
@@ -369,7 +374,10 @@ async def stream(
             async for event in agent.stream(message):
                 yield f"data: {event.model_dump_json()}\n\n"
 
-        return StreamingResponse(event_stream(), media_type="text/event-stream")
+        return StreamingResponse(
+            counted_run_stream(http_request.app, event_stream()),
+            media_type="text/event-stream",
+        )
     except Exception as e:  # noqa: BLE001
         logger.error(
             f"Stream failed — session_id={request.session_id}, error={e}",
@@ -419,7 +427,7 @@ async def copilotkit_stream(
                     yield encoder.encode(event)  # type: ignore[arg-type]
 
             return StreamingResponse(
-                event_generator(),  # type: ignore[arg-type]
+                counted_run_stream(request.app, event_generator()),  # type: ignore[arg-type]
                 media_type=encoder.get_content_type(),
             )
         except Exception as e:  # noqa: BLE001
@@ -487,7 +495,8 @@ async def copilotkit_stream(
                         yield 'event: error\ndata: {"error": "Agent execution failed"}\n\n'
 
             return StreamingResponse(
-                event_generator(), media_type=encoder.get_content_type()
+                counted_run_stream(request.app, event_generator()),
+                media_type=encoder.get_content_type(),
             )
         except Exception as e:  # noqa: BLE001
             raise HTTPException(status_code=500, detail=str(e)) from e

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
@@ -10,7 +10,12 @@ from pydantic import BaseModel
 
 from ..._version import __version__
 from ...core.config_builder import ConfigBuilder
-from ..lifespan import cleanup_agent, configure_app
+from ..lifespan import (
+    cleanup_agent,
+    configure_app,
+    drain_inflight_runs,
+    ensure_reload_state,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -132,51 +137,71 @@ async def reload_config(
 ):
     """Reload the agent configuration from the manager or a file.
 
-    The optional ``_auth`` dependency consults
-    ``app.state.reload_auth`` (configured via ``create_app(reload_auth=...)``)
-    and, if set, invokes it. The configured callable is responsible for
-    raising :class:`fastapi.HTTPException` to deny the request.
+    The optional ``_auth`` dependency consults ``app.state.reload_auth``
+    (configured via ``create_app(reload_auth=...)``) and, if set, invokes it.
+    The configured callable raises :class:`fastapi.HTTPException` to deny.
+
+    Reloads serialize on a per-app lock and build the new agent before tearing
+    down the old one. ``app.state.agent`` is swapped in one assignment and the
+    previous agent is closed only after its in-flight runs drain, so a reload
+    never corrupts the shared route table or hands a request a closed agent.
     """
-    try:
-        if body and body.path:
-            logger.info(f"🔄 Reloading configuration from file: {body.path}...")
-            new_config = ConfigBuilder.load_from_file(body.path)
-        else:
-            logger.info("🔄 Reloading configuration from manager...")
-            agent_api_key = os.getenv("IDUN_AGENT_API_KEY")
-            manager_host = os.getenv("IDUN_MANAGER_HOST")
+    app = request.app
+    async with ensure_reload_state(app):
+        try:
+            if body and body.path:
+                logger.info(f"🔄 Reloading configuration from file: {body.path}...")
+                new_config = ConfigBuilder.load_from_file(body.path)
+            else:
+                logger.info("🔄 Reloading configuration from manager...")
+                agent_api_key = os.getenv("IDUN_AGENT_API_KEY")
+                manager_host = os.getenv("IDUN_MANAGER_HOST")
 
-            if not agent_api_key or not manager_host:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Cannot reload from manager: IDUN_AGENT_API_KEY or IDUN_MANAGER_HOST environment variables are missing.",
+                if not agent_api_key or not manager_host:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Cannot reload from manager: IDUN_AGENT_API_KEY or IDUN_MANAGER_HOST environment variables are missing.",
+                    )
+
+                config_builder = await ConfigBuilder().with_config_from_api(
+                    agent_api_key=agent_api_key, url=manager_host
                 )
+                new_config = config_builder.build()
 
-            # Fetch new config
-            config_builder = await ConfigBuilder().with_config_from_api(
-                agent_api_key=agent_api_key, url=manager_host
+            old_agent = getattr(app.state, "agent", None)
+
+            # Tear down the old agent's integrations, routes, and OTel, but keep
+            # the old agent object alive so its in-flight runs keep working.
+            await cleanup_agent(app, close_agent=False)
+
+            # Build and publish the new agent (configure_app swaps app.state.agent).
+            await configure_app(app, new_config)
+
+            # Drain runs that captured the old agent, then close it. Skipped when
+            # configure_app left the same object in place (no real swap).
+            if old_agent is not None and old_agent is not getattr(
+                app.state, "agent", None
+            ):
+                await drain_inflight_runs(app)
+                close_fn = getattr(old_agent, "close", None)
+                if callable(close_fn):
+                    result = close_fn()
+                    if inspect.isawaitable(result):
+                        await result
+
+            return {
+                "status": "success",
+                "message": "Agent configuration reloaded successfully",
+            }
+
+        except HTTPException:
+            raise
+
+        except Exception as e:
+            logger.exception(f"❌ Error reloading configuration: {e}")
+            raise HTTPException(
+                status_code=500, detail=f"Failed to reload configuration: {str(e)}"
             )
-            new_config = config_builder.build()
-
-        # Cleanup old agent
-        await cleanup_agent(request.app)
-
-        # Initialize new agent
-        await configure_app(request.app, new_config)
-
-        return {
-            "status": "success",
-            "message": "Agent configuration reloaded successfully",
-        }
-
-    except HTTPException:
-        raise
-
-    except Exception as e:
-        logger.exception(f"❌ Error reloading configuration: {e}")
-        raise HTTPException(
-            status_code=500, detail=f"Failed to reload configuration: {str(e)}"
-        )
 
 
 # Engine info — always served at /_engine/info. The bare `/` route is

--- a/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/server/routers/base.py
@@ -153,7 +153,7 @@ async def reload_config(
                 )
 
             # Fetch new config
-            config_builder = ConfigBuilder().with_config_from_api(
+            config_builder = await ConfigBuilder().with_config_from_api(
                 agent_api_key=agent_api_key, url=manager_host
             )
             new_config = config_builder.build()

--- a/libs/idun_agent_engine/tests/integration/guardrails/test_guardrails_runtime.py
+++ b/libs/idun_agent_engine/tests/integration/guardrails/test_guardrails_runtime.py
@@ -1,8 +1,18 @@
 import os
+import shutil
 from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+
+# guardrails-ai is an opt-in extra; without it the `guardrails` CLI is absent
+# and the guard cannot be built. Skip (rather than fail) so the suite degrades
+# gracefully when the extra isn't installed. CI installs it via
+# `uv sync --all-extras`, so these run there. Mirrors tests/conftest.py.
+pytestmark = pytest.mark.skipif(
+    shutil.which("guardrails") is None,
+    reason="guardrails-ai optional extra not installed (no `guardrails` CLI on PATH)",
+)
 
 
 @pytest.fixture

--- a/libs/idun_agent_engine/tests/unit/core/test_config_builder.py
+++ b/libs/idun_agent_engine/tests/unit/core/test_config_builder.py
@@ -1,7 +1,7 @@
 """Tests for the configuration builder API."""
 
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import yaml
@@ -290,9 +290,8 @@ class TestConfigBuilderValidateAgentConfig:
 class TestConfigBuilderWithConfigFromAPI:
     """Test fetching configuration from remote API."""
 
-    @patch("requests.get")
-    def test_with_config_from_api_success(self, mock_get: Mock, tmp_path: Path) -> None:
-        """with_config_from_api fetches and parses config successfully."""
+    async def test_with_config_from_api_success(self) -> None:
+        """with_config_from_api fetches and parses config, sending auth + URL."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = yaml.dump(
@@ -309,24 +308,21 @@ class TestConfigBuilderWithConfigFromAPI:
                 }
             }
         )
-        mock_get.return_value = mock_response
+        mock_fetch = AsyncMock(return_value=mock_response)
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config", mock_fetch
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
+        mock_fetch.assert_awaited_once_with(
+            "http://localhost:8000/api/v1/agents/config", {"auth": "Bearer test-key"}
         )
-
-        # Verify request was made with correct headers
-        mock_get.assert_called_once_with(
-            url="http://localhost:8000/api/v1/agents/config",
-            headers={"auth": "Bearer test-key"},
-        )
-
-        # Verify config was parsed
         engine_config = builder.build()
         assert engine_config.agent.config.name == "API Agent"
 
-    @patch("requests.get")
-    def test_with_config_from_api_with_observability(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_with_observability(self) -> None:
         """with_config_from_api parses observability config."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -355,42 +351,126 @@ class TestConfigBuilderWithConfigFromAPI:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.observability is not None
         assert len(engine_config.observability) == 1
         assert engine_config.observability[0].provider.value == "LANGFUSE"
 
-    @patch("requests.get")
-    def test_with_config_from_api_http_error(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_http_error(self) -> None:
         """with_config_from_api raises error on HTTP failure."""
         mock_response = Mock()
         mock_response.status_code = 401
-        mock_response.json.return_value = {"error": "Unauthorized"}
-        mock_get.return_value = mock_response
+        mock_response.text = "Unauthorized"
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            with pytest.raises(ValueError, match="Error retrieving config from url"):
+                await ConfigBuilder().with_config_from_api(
+                    agent_api_key="invalid-key", url="http://localhost:8000"
+                )
 
-        with pytest.raises(ValueError, match="Error retrieving config from url"):
-            ConfigBuilder().with_config_from_api(
-                agent_api_key="invalid-key", url="http://localhost:8000"
-            )
-
-    @patch("requests.get")
-    def test_with_config_from_api_invalid_yaml(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_invalid_yaml(self) -> None:
         """with_config_from_api handles invalid YAML."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = "invalid: yaml: content:"
-        mock_get.return_value = mock_response
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            with pytest.raises(Exception):  # YAML parsing error  # noqa: B017
+                await ConfigBuilder().with_config_from_api(
+                    agent_api_key="test-key", url="http://localhost:8000"
+                )
 
-        with pytest.raises(Exception):  # YAML parsing error  # noqa: B017
-            ConfigBuilder().with_config_from_api(
-                agent_api_key="test-key", url="http://localhost:8000"
-            ).build()
+    async def test_with_config_from_api_wraps_transport_error(self) -> None:
+        """A transport failure surfaces as ValueError, not the raw error."""
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(side_effect=RuntimeError("connection refused")),
+        ):
+            with pytest.raises(ValueError, match="Error occurred while getting config"):
+                await ConfigBuilder().with_config_from_api(
+                    agent_api_key="test-key", url="http://localhost:8000"
+                )
+
+    async def test_with_config_from_api_missing_engine_config(self) -> None:
+        """A response without an engine_config payload raises ValueError."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = yaml.dump({"not_engine_config": {}})
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            with pytest.raises(ValueError):
+                await ConfigBuilder().with_config_from_api(
+                    agent_api_key="test-key", url="http://localhost:8000"
+                )
+
+    async def test_with_config_from_api_empty_body_raises(self) -> None:
+        """An empty 200 body parses to None; it must surface as a wrapped
+        ValueError, not a bare AttributeError from ``None.get``."""
+        mock_response = Mock(status_code=200)
+        mock_response.text = ""
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            with pytest.raises(ValueError, match="Error occurred while getting config"):
+                await ConfigBuilder().with_config_from_api(
+                    agent_api_key="test-key", url="http://localhost:8000"
+                )
+
+    async def test_with_config_from_api_non_mapping_body_raises(self) -> None:
+        """A scalar 200 body parses to a str; it must surface as a wrapped
+        ValueError, not a bare AttributeError from ``str.get``."""
+        mock_response = Mock(status_code=200)
+        mock_response.text = "just-a-string"
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            with pytest.raises(ValueError, match="Error occurred while getting config"):
+                await ConfigBuilder().with_config_from_api(
+                    agent_api_key="test-key", url="http://localhost:8000"
+                )
+
+    async def test_with_config_from_api_strips_trailing_slash(self) -> None:
+        """A trailing slash on the manager host must not yield a //double-slash
+        request path. The trace sink already rstrips the host; the config fetch
+        has to match or a host with a trailing slash 404s on the manager."""
+        mock_response = Mock(status_code=200)
+        mock_response.text = yaml.dump(
+            {
+                "engine_config": {
+                    "server": {"api": {"port": 8000}},
+                    "agent": {
+                        "type": "LANGGRAPH",
+                        "config": {
+                            "name": "Slash Agent",
+                            "graph_definition": "./agent.py:graph",
+                        },
+                    },
+                }
+            }
+        )
+        mock_fetch = AsyncMock(return_value=mock_response)
+        with patch("idun_agent_engine.core.config_builder._fetch_config", mock_fetch):
+            await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000/"
+            )
+        called_url = mock_fetch.await_args.args[0]
+        assert called_url == "http://localhost:8000/api/v1/agents/config"
 
 
 @pytest.mark.unit
@@ -478,8 +558,7 @@ class TestConfigBuilderSSO:
         assert new_builder._sso is not None
         assert new_builder._sso.issuer == "https://accounts.google.com"
 
-    @patch("requests.get")
-    def test_with_config_from_api_parses_sso(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_parses_sso(self) -> None:
         """with_config_from_api parses SSO config from API response."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -502,11 +581,13 @@ class TestConfigBuilderSSO:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.sso is not None
@@ -514,8 +595,7 @@ class TestConfigBuilderSSO:
         assert engine_config.sso.client_id == "okta-client-id"
         assert engine_config.sso.audience == "api://default"
 
-    @patch("requests.get")
-    def test_with_config_from_api_without_sso(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_without_sso(self) -> None:
         """with_config_from_api sets SSO to None when not in response."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -533,11 +613,13 @@ class TestConfigBuilderSSO:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.sso is None
@@ -639,8 +721,7 @@ class TestConfigBuilderIntegrations:
         assert new_builder._integrations is not None
         assert len(new_builder._integrations) == 1
 
-    @patch("requests.get")
-    def test_with_config_from_api_parses_integrations(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_parses_integrations(self) -> None:
         """with_config_from_api parses integrations config from API response."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -669,19 +750,20 @@ class TestConfigBuilderIntegrations:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.integrations is not None
         assert len(engine_config.integrations) == 1
         assert engine_config.integrations[0].config.phone_number_id == "456"
 
-    @patch("requests.get")
-    def test_with_config_from_api_without_integrations(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_without_integrations(self) -> None:
         """with_config_from_api sets integrations to None when not in response."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -699,11 +781,13 @@ class TestConfigBuilderIntegrations:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.integrations is None
@@ -792,8 +876,7 @@ class TestConfigBuilderPrompts:
         assert len(new_builder._prompts) == 1
         assert new_builder._prompts[0].prompt_id == "sys"
 
-    @patch("requests.get")
-    def test_with_config_from_api_parses_prompts(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_parses_prompts(self) -> None:
         """with_config_from_api parses prompts config from API response."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -819,11 +902,13 @@ class TestConfigBuilderPrompts:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.prompts is not None
@@ -832,8 +917,7 @@ class TestConfigBuilderPrompts:
         assert engine_config.prompts[0].version == 3
         assert engine_config.prompts[0].content == "You are {{ role }}."
 
-    @patch("requests.get")
-    def test_with_config_from_api_without_prompts(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_without_prompts(self) -> None:
         """with_config_from_api sets prompts to None when not in response."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -851,11 +935,13 @@ class TestConfigBuilderPrompts:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.prompts is None
@@ -952,8 +1038,7 @@ class TestConfigBuilderMCPServers:
         assert engine_config.mcp_servers is not None
         assert len(engine_config.mcp_servers) == 0
 
-    @patch("requests.get")
-    def test_with_config_from_api_parses_mcp_servers(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_parses_mcp_servers(self) -> None:
         """with_config_from_api parses MCP servers from API response."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -966,11 +1051,13 @@ class TestConfigBuilderMCPServers:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.mcp_servers is not None
@@ -982,8 +1069,7 @@ class TestConfigBuilderMCPServers:
         assert engine_config.mcp_servers[1].transport == "streamable_http"
         assert engine_config.mcp_servers[1].url == "https://docs.example.com/mcp"
 
-    @patch("requests.get")
-    def test_with_config_from_api_without_mcp_servers(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_without_mcp_servers(self) -> None:
         """with_config_from_api sets mcp_servers to None when not in response."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -995,17 +1081,18 @@ class TestConfigBuilderMCPServers:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.mcp_servers is None
 
-    @patch("requests.get")
-    def test_with_config_from_api_full_config(self, mock_get: Mock) -> None:
+    async def test_with_config_from_api_full_config(self) -> None:
         """with_config_from_api parses all sections together."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -1033,11 +1120,13 @@ class TestConfigBuilderMCPServers:
                 }
             }
         )
-        mock_get.return_value = mock_response
-
-        builder = ConfigBuilder().with_config_from_api(
-            agent_api_key="test-key", url="http://localhost:8000"
-        )
+        with patch(
+            "idun_agent_engine.core.config_builder._fetch_config",
+            AsyncMock(return_value=mock_response),
+        ):
+            builder = await ConfigBuilder().with_config_from_api(
+                agent_api_key="test-key", url="http://localhost:8000"
+            )
 
         engine_config = builder.build()
         assert engine_config.server.api.port == 9000

--- a/libs/idun_agent_engine/tests/unit/server/routers/agent/guardrails/test_ban_list.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/agent/guardrails/test_ban_list.py
@@ -1,10 +1,20 @@
 import os
+import shutil
 
 import pytest
 from fastapi.testclient import TestClient
 
 from idun_agent_engine.core.app_factory import create_app
 from idun_agent_engine.core.config_builder import ConfigBuilder
+
+# guardrails-ai is an opt-in extra; without it the `guardrails` CLI is absent
+# and the guard cannot be built. Skip (rather than fail) so the suite degrades
+# gracefully when the extra isn't installed. CI installs it via
+# `uv sync --all-extras`, so these run there. Mirrors tests/conftest.py.
+pytestmark = pytest.mark.skipif(
+    shutil.which("guardrails") is None,
+    reason="guardrails-ai optional extra not installed (no `guardrails` CLI on PATH)",
+)
 
 
 @pytest.mark.unit

--- a/libs/idun_agent_engine/tests/unit/server/routers/agent/guardrails/test_detect_pii.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/agent/guardrails/test_detect_pii.py
@@ -1,10 +1,20 @@
 import os
+import shutil
 
 import pytest
 from fastapi.testclient import TestClient
 
 from idun_agent_engine.core.app_factory import create_app
 from idun_agent_engine.core.config_builder import ConfigBuilder
+
+# guardrails-ai is an opt-in extra; without it the `guardrails` CLI is absent
+# and the guard cannot be built. Skip (rather than fail) so the suite degrades
+# gracefully when the extra isn't installed. CI installs it via
+# `uv sync --all-extras`, so these run there. Mirrors tests/conftest.py.
+pytestmark = pytest.mark.skipif(
+    shutil.which("guardrails") is None,
+    reason="guardrails-ai optional extra not installed (no `guardrails` CLI on PATH)",
+)
 
 
 @pytest.mark.unit

--- a/libs/idun_agent_engine/tests/unit/server/routers/agent/guardrails/test_nsfw_text.py
+++ b/libs/idun_agent_engine/tests/unit/server/routers/agent/guardrails/test_nsfw_text.py
@@ -1,10 +1,20 @@
 import os
+import shutil
 
 import pytest
 from fastapi.testclient import TestClient
 
 from idun_agent_engine.core.app_factory import create_app
 from idun_agent_engine.core.config_builder import ConfigBuilder
+
+# guardrails-ai is an opt-in extra; without it the `guardrails` CLI is absent
+# and the guard cannot be built. Skip (rather than fail) so the suite degrades
+# gracefully when the extra isn't installed. CI installs it via
+# `uv sync --all-extras`, so these run there. Mirrors tests/conftest.py.
+pytestmark = pytest.mark.skipif(
+    shutil.which("guardrails") is None,
+    reason="guardrails-ai optional extra not installed (no `guardrails` CLI on PATH)",
+)
 
 
 @pytest.mark.unit

--- a/libs/idun_agent_engine/tests/unit/server/test_reload_concurrency.py
+++ b/libs/idun_agent_engine/tests/unit/server/test_reload_concurrency.py
@@ -270,3 +270,38 @@ async def test_counted_run_stream_decrements_on_error():
             pass
 
     assert app.state.inflight_runs == 0, "counter leaked when the stream errored"
+
+
+async def test_counted_run_stream_counts_before_first_iteration():
+    """The counter must register at construction time, not on first yield.
+
+    Starlette only starts a StreamingResponse body after sending the response
+    headers (an ``await`` that hands control back to the loop). If the in-flight
+    count waited until the body generator's first iteration, a reload firing in
+    the window between the route returning ``StreamingResponse`` and Starlette
+    starting the body would observe ``inflight_runs == 0``, drain immediately,
+    and close the very agent the stream is about to call ``run`` on -- the same
+    crash this reload work exists to prevent. Counting eagerly at construction
+    collapses that window to zero.
+    """
+    app = FastAPI()
+
+    started = asyncio.Event()
+
+    async def source():
+        started.set()
+        yield "a"
+
+    stream = counted_run_stream(app, source())
+    # The body generator has NOT started yet ...
+    assert not started.is_set()
+    # ... but the run must already be counted as in-flight.
+    assert app.state.inflight_runs == 1, (
+        "counter must increment when the stream is constructed, before the "
+        "body generator starts, to close the reload race window"
+    )
+
+    out = [chunk async for chunk in stream]
+    assert out == ["a"]
+    assert started.is_set()
+    assert app.state.inflight_runs == 0, "counter not released after the stream ended"

--- a/libs/idun_agent_engine/tests/unit/server/test_reload_concurrency.py
+++ b/libs/idun_agent_engine/tests/unit/server/test_reload_concurrency.py
@@ -1,0 +1,272 @@
+"""Reload concurrency + atomic-swap regression tests (findings #1, #2, integrations).
+
+These reproduce the current reload path's defects (server/routers/base.py
+``reload_config`` -> ``cleanup_agent`` then ``configure_app``, with no lock and
+teardown-before-build):
+
+* concurrent reloads run ``configure_app`` at the same time (no serialization) -> #1
+* a reload leaves ``app.state.agent`` pointing at a closed agent mid-swap -> #2
+* concurrent reloads mutate the shared integration route table with no
+  serialization, so integration routes can double / leak.
+
+All three are EXPECTED TO FAIL until reload is serialized (a lock) and
+restructured to build-the-new-agent-before-tearing-down-the-old.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from idun_agent_schema.engine.integrations import IntegrationConfig, IntegrationProvider
+
+from idun_agent_engine.integrations import base as integrations_base
+from idun_agent_engine.integrations.base import BaseIntegration, setup_integrations
+from idun_agent_engine.server.lifespan import counted_run_stream, ensure_reload_state
+from idun_agent_engine.server.routers import base as base_router
+
+pytestmark = pytest.mark.asyncio
+
+
+def _req(app: FastAPI):
+    # reload_config only ever touches request.app.
+    return SimpleNamespace(app=app)
+
+
+def _reload_body():
+    # path-mode reload so the (mocked) ConfigBuilder.load_from_file supplies config
+    # and reload_config never reaches the manager-fetch branch.
+    return base_router.ReloadRequest(path="fake-config.yaml")
+
+
+async def _noop_async(*_a, **_k):
+    return None
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+# --- #1: concurrent reloads must serialize -------------------------------------
+
+
+async def test_concurrent_reloads_serialize_configure(monkeypatch):
+    app = FastAPI()
+    app.state.agent = _FakeAgent()
+    monkeypatch.setattr(
+        base_router.ConfigBuilder, "load_from_file", lambda _p: object()
+    )
+    monkeypatch.setattr(base_router, "cleanup_agent", _noop_async)
+
+    state = {"now": 0, "max": 0}
+    release = asyncio.Event()
+
+    async def gated_configure(_app, _cfg):
+        state["now"] += 1
+        state["max"] = max(state["max"], state["now"])
+        await release.wait()
+        state["now"] -= 1
+
+    monkeypatch.setattr(base_router, "configure_app", gated_configure)
+
+    t1 = asyncio.create_task(base_router.reload_config(_req(app), _reload_body()))
+    t2 = asyncio.create_task(base_router.reload_config(_req(app), _reload_body()))
+    await asyncio.sleep(0.1)
+    observed_max = state["max"]
+    release.set()
+    await asyncio.gather(t1, t2)
+
+    assert observed_max == 1, (
+        f"two reloads ran configure_app concurrently (max overlap={observed_max}); "
+        "reload must hold a lock so teardown/build never interleave"
+    )
+
+
+# --- #2: reload must never expose a closed/None agent --------------------------
+
+
+async def test_reload_never_exposes_a_closed_agent(monkeypatch):
+    app = FastAPI()
+    old = _FakeAgent()
+    app.state.agent = old
+    monkeypatch.setattr(
+        base_router.ConfigBuilder, "load_from_file", lambda _p: object()
+    )
+    monkeypatch.setattr("idun_agent_engine.server.lifespan.shutdown_otel", lambda: None)
+    # Real cleanup_agent runs (it closes `old`). Gate configure so we can observe
+    # app.state.agent in the window after teardown and before the new agent lands.
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def gated_configure(a, _cfg):
+        entered.set()
+        await release.wait()
+        a.state.agent = _FakeAgent()
+
+    monkeypatch.setattr(base_router, "configure_app", gated_configure)
+
+    task = asyncio.create_task(base_router.reload_config(_req(app), _reload_body()))
+    await entered.wait()
+    # A request resolving the agent right now (get_agent reads app.state.agent):
+    current = app.state.agent
+    exposed_closed = current is None or getattr(current, "closed", False)
+    release.set()
+    await task
+
+    assert not exposed_closed, (
+        "during reload, app.state.agent was None/closed -- an in-flight request "
+        "would crash ('NoneType' object is not a mapping); reload must build the "
+        "new agent before tearing down the old"
+    )
+
+
+# --- integrations under concurrent reload --------------------------------------
+
+
+class _FakeIntegration(BaseIntegration):
+    def __init__(self) -> None:
+        self.shutdown_called = False
+
+    async def setup(self, app: FastAPI, agent) -> None:
+        router = APIRouter()
+
+        @router.post("/webhook")
+        async def webhook() -> dict:
+            return {"ok": True}
+
+        app.include_router(router, prefix="/integrations/fake")
+
+    async def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+def _integration_cfg() -> IntegrationConfig:
+    return IntegrationConfig(
+        provider=IntegrationProvider.WHATSAPP,
+        enabled=True,
+        config={"access_token": "t", "phone_number_id": "1", "verify_token": "v"},
+    )
+
+
+async def test_concurrent_reloads_keep_integration_routes_consistent(monkeypatch):
+    app = FastAPI()
+    app.state.agent = _FakeAgent()
+    monkeypatch.setattr(
+        base_router.ConfigBuilder, "load_from_file", lambda _p: object()
+    )
+    monkeypatch.setattr("idun_agent_engine.server.lifespan.shutdown_otel", lambda: None)
+    monkeypatch.setattr(
+        integrations_base, "_create_integration", lambda _cfg: _FakeIntegration()
+    )
+    # Seed one integration so the reload's cleanup has a route to remove.
+    await setup_integrations(app, [_integration_cfg()], app.state.agent)
+
+    # Mirror configure_app's integration step; count overlap of the
+    # route-mutating section across the two concurrent reloads.
+    state = {"now": 0, "max": 0}
+    release = asyncio.Event()
+
+    async def integ_configure(a, _cfg):
+        state["now"] += 1
+        state["max"] = max(state["max"], state["now"])
+        await release.wait()
+        await setup_integrations(a, [_integration_cfg()], a.state.agent)
+        state["now"] -= 1
+
+    monkeypatch.setattr(base_router, "configure_app", integ_configure)
+
+    t1 = asyncio.create_task(base_router.reload_config(_req(app), _reload_body()))
+    t2 = asyncio.create_task(base_router.reload_config(_req(app), _reload_body()))
+    await asyncio.sleep(0.1)
+    observed_max = state["max"]
+    release.set()
+    await asyncio.gather(t1, t2)
+
+    webhook_routes = [
+        r
+        for r in app.router.routes
+        if getattr(r, "path", "") == "/integrations/fake/webhook"
+    ]
+    assert observed_max == 1, (
+        f"integration rebuild ran concurrently (max overlap={observed_max}); "
+        "the shared route table was mutated by two reloads at once"
+    )
+    assert len(webhook_routes) == 1, (
+        f"expected exactly one integration webhook route, found "
+        f"{len(webhook_routes)} -- concurrent reloads corrupted the route table"
+    )
+
+
+# --- graceful drain: old agent closes only after in-flight runs finish --------
+
+
+async def test_reload_drains_inflight_before_closing_old_agent(monkeypatch):
+    app = FastAPI()
+    old = _FakeAgent()
+    app.state.agent = old
+    monkeypatch.setattr(
+        base_router.ConfigBuilder, "load_from_file", lambda _p: object()
+    )
+    monkeypatch.setattr("idun_agent_engine.server.lifespan.shutdown_otel", lambda: None)
+
+    new = _FakeAgent()
+
+    async def swap_configure(a, _cfg):
+        a.state.agent = new
+
+    monkeypatch.setattr(base_router, "configure_app", swap_configure)
+
+    # One run is mid-stream on the old agent when the reload lands.
+    ensure_reload_state(app)
+    app.state.inflight_runs = 1
+
+    task = asyncio.create_task(base_router.reload_config(_req(app), _reload_body()))
+    await asyncio.sleep(0.1)
+    # New agent already serves new requests, but the old one stays open while a
+    # run is still using it.
+    assert app.state.agent is new
+    assert old.closed is False, "old agent closed while a run was still in-flight"
+
+    # The run finishes -> drain unblocks -> reload closes the old agent.
+    app.state.inflight_runs = 0
+    await task
+    assert old.closed is True, "old agent never closed after its runs drained"
+
+
+# --- counted_run_stream brackets a stream with the in-flight counter ----------
+
+
+async def test_counted_run_stream_tracks_inflight():
+    app = FastAPI()
+    seen = []
+
+    async def source():
+        seen.append(app.state.inflight_runs)
+        yield "a"
+        yield "b"
+
+    out = [chunk async for chunk in counted_run_stream(app, source())]
+
+    assert out == ["a", "b"]
+    assert seen == [1], "stream did not register as in-flight while running"
+    assert app.state.inflight_runs == 0, "counter not released after the stream ended"
+
+
+async def test_counted_run_stream_decrements_on_error():
+    app = FastAPI()
+
+    async def boom():
+        yield "a"
+        raise RuntimeError("client gone")
+
+    with pytest.raises(RuntimeError):
+        async for _ in counted_run_stream(app, boom()):
+            pass
+
+    assert app.state.inflight_runs == 0, "counter leaked when the stream errored"

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/core/settings.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/core/settings.py
@@ -82,6 +82,10 @@ class StandaloneSettings(BaseSettings):
         alias="IDUN_ALLOW_OPEN_ADMIN",
     )
 
+    # When both are set, traces are shipped to the manager.
+    manager_host: str = Field(default="", alias="IDUN_MANAGER_HOST")
+    agent_api_key: str = Field(default="", alias="IDUN_AGENT_API_KEY")
+
     @field_validator("admin_password_hash", "session_secret", mode="before")
     @classmethod
     def _strip_secret(cls, v: str) -> str:
@@ -107,6 +111,21 @@ class StandaloneSettings(BaseSettings):
                 "IDUN_ADMIN_AUTH_MODE=password requires "
                 f"IDUN_SESSION_SECRET to be at least {_MIN_SESSION_SECRET_LEN} "
                 "characters."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_manager_telemetry(self) -> Self:
+        """Manager telemetry is all-or-nothing, and the host needs a scheme."""
+        if bool(self.manager_host) != bool(self.agent_api_key):
+            raise SettingsValidationError(
+                "IDUN_MANAGER_HOST and IDUN_AGENT_API_KEY must be set together."
+            )
+        if self.manager_host and not self.manager_host.startswith(
+            ("http://", "https://")
+        ):
+            raise SettingsValidationError(
+                "IDUN_MANAGER_HOST must include a scheme (http:// or https://)."
             )
         return self
 

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/_serialize.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/_serialize.py
@@ -1,0 +1,42 @@
+"""Serialize the writer's row dicts into a JSON-safe ``/collect`` body.
+
+Bytes are hex-encoded, datetimes ISO-8601, Decimals stringified.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+VERSION = 1
+
+
+def _encode_value(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, dict):
+        return {k: _encode_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_encode_value(v) for v in value]
+    return value
+
+
+def _encode_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {key: _encode_value(value) for key, value in row.items()}
+
+
+def encode_batch(
+    span_rows: list[dict[str, Any]],
+    trace_rows: list[dict[str, Any]],
+    *,
+    version: int = VERSION,
+) -> dict[str, Any]:
+    """Build the ``/collect`` request body from writer row dicts."""
+    return {
+        "version": version,
+        "spans": [_encode_row(r) for r in span_rows],
+        "traces": [_encode_row(r) for r in trace_rows],
+    }

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/bootstrap.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/bootstrap.py
@@ -22,10 +22,6 @@ catches its own failures and logs instead of propagating, matching the
 fail-open contract of ``otel_lifecycle.attach_*`` and the writer's
 ``_drain_once`` loop.
 
-Locked design:
-``~/Documents/GitHub/idun-dev/tasks/standalone-traces-trace-pr-09-05-2026/PLAN.md``
-    § Phase T7
-``~/Documents/GitHub/idun-dev/tasks/trace-feature-08-05-2026/08-otel-pipeline-integration.md``
 """
 
 from __future__ import annotations
@@ -33,6 +29,7 @@ from __future__ import annotations
 import inspect
 import logging
 
+import httpx
 from fastapi import FastAPI
 from idun_agent_engine.observability import otel_lifecycle
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -40,6 +37,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from . import costs
 from .exporter import StandaloneSpanExporter
 from .retention import RetentionScheduler
+from .sinks import HttpSink
 from .writer import TraceWriter
 
 logger = logging.getLogger(__name__)
@@ -118,6 +116,8 @@ async def attach_trace_pipeline(app: FastAPI) -> None:
     max_attribute_bytes = getattr(settings, "traces_input_value_max_bytes", 65536)
     prices_refresh_enabled = getattr(settings, "prices_refresh_enabled", False)
     costs.set_refresh_enabled(bool(prices_refresh_enabled))
+    manager_host = getattr(settings, "manager_host", "") or ""
+    agent_api_key = getattr(settings, "agent_api_key", "") or ""
 
     # 2. Resolve the active observability config so we know whether
     #    to self-install LangChainInstrumentor.
@@ -309,17 +309,25 @@ async def attach_trace_pipeline(app: FastAPI) -> None:
         otel_lifecycle.attach_span_processor(processor)
     except Exception:
         logger.exception(
-            "trace pipeline: BatchSpanProcessor attach failed; "
-            "trace capture disabled"
+            "trace pipeline: BatchSpanProcessor attach failed; trace capture disabled"
         )
         return
 
-    # 7. Spawn writer + retention. Both require app.state.sessionmaker.
+    # 7. Build the span sink: manager host + agent key configured → ship
+    #    to the manager; otherwise persist locally via the session factory.
     session_factory = getattr(app.state, "sessionmaker", None)
-    if session_factory is None:
+    http_sink = None
+    if manager_host and agent_api_key:
+        http_client = httpx.AsyncClient(timeout=httpx.Timeout(5.0, connect=2.0))
+        collect_url = f"{manager_host.rstrip('/')}/api/v1/telemetry/collect"
+        http_sink = HttpSink(collect_url, agent_api_key, client=http_client)
+        app.state.trace_http_client = http_client
+        logger.info("trace pipeline: shipping spans to %s", collect_url)
+
+    if http_sink is None and session_factory is None:
         logger.warning(
-            "trace pipeline: app.state.sessionmaker missing; writer + "
-            "retention not spawned (spans will queue but never persist)"
+            "trace pipeline: no manager host and no app.state.sessionmaker; "
+            "writer not spawned (spans will queue but never persist)"
         )
         return
 
@@ -327,6 +335,7 @@ async def attach_trace_pipeline(app: FastAPI) -> None:
         writer = TraceWriter(
             exporter=exporter,
             session_factory=session_factory,
+            http_sink=http_sink,
             max_export_batch_size=_MAX_EXPORT_BATCH_SIZE,
             schedule_delay_millis=_SCHEDULE_DELAY_MILLIS,
         )
@@ -335,17 +344,24 @@ async def attach_trace_pipeline(app: FastAPI) -> None:
     except Exception:
         logger.exception("trace pipeline: writer task failed to start")
 
-    try:
-        retention = RetentionScheduler(
-            session_factory=session_factory,
-            retention_days=int(retention_days),
-        )
-        await retention.start()
-        app.state.trace_retention_task = retention
-    except Exception:
-        logger.exception("trace pipeline: retention scheduler failed to start")
+    # Retention prunes local trace tables; skip it when shipping to the manager.
+    if http_sink is None and session_factory is not None:
+        try:
+            retention = RetentionScheduler(
+                session_factory=session_factory,
+                retention_days=int(retention_days),
+            )
+            await retention.start()
+            app.state.trace_retention_task = retention
+        except Exception:
+            logger.exception("trace pipeline: retention scheduler failed to start")
+    elif http_sink is not None:
+        logger.warning("trace pipeline: local retention disabled (manager mode)")
 
-    logger.info("trace pipeline attached")
+    logger.info(
+        "trace pipeline attached (%s mode)",
+        "manager" if http_sink is not None else "local",
+    )
 
 
 async def _stop_previous_tasks(app: FastAPI) -> None:
@@ -372,3 +388,13 @@ async def _stop_previous_tasks(app: FastAPI) -> None:
                 "trace pipeline: prior retention.stop() raised; continuing"
             )
         app.state.trace_retention_task = None
+
+    prior_client = getattr(app.state, "trace_http_client", None)
+    if prior_client is not None:
+        try:
+            await prior_client.aclose()
+        except Exception:
+            logger.exception(
+                "trace pipeline: prior http client aclose() raised; continuing"
+            )
+        app.state.trace_http_client = None

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/sinks.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/sinks.py
@@ -1,0 +1,41 @@
+"""Span sinks: where the trace writer's drained rows go.
+
+Local (unenrolled) mode persists to the standalone DB; enrolled mode
+POSTs to the manager's ``/collect`` endpoint.
+"""
+
+from typing import Any
+
+import httpx
+
+from ._serialize import encode_batch
+
+# TODO: collapse the writer's inline local-insert path and HttpSink behind
+# a single SpanSink protocol (LocalSqlSink + HttpSink) so the writer always
+# delegates, instead of branching on an optional sink.
+
+
+class HttpSink:
+    """POST finalized span + trace rows to the manager's ``/collect``.
+
+    Raises on a non-2xx response or a transport error.
+    """
+
+    def __init__(
+        self, collect_url: str, api_key: str, *, client: httpx.AsyncClient
+    ) -> None:
+        self._url = collect_url
+        self._api_key = api_key
+        self._client = client
+
+    async def write(
+        self,
+        span_rows: list[dict[str, Any]],
+        trace_rows: list[dict[str, Any]],
+    ) -> None:
+        response = await self._client.post(
+            self._url,
+            json=encode_batch(span_rows, trace_rows),
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+        response.raise_for_status()

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/writer.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/infrastructure/traces/writer.py
@@ -24,10 +24,6 @@ We use ``ON CONFLICT DO NOTHING`` (PG) / ``INSERT OR IGNORE`` (SQLite)
 so a duplicate root-span flush does not raise — the first finalise wins,
 later attempts are no-ops.
 
-Locked design:
-``~/Documents/GitHub/idun-dev/tasks/trace-feature-08-05-2026/08-otel-pipeline-integration.md``
-``~/Documents/GitHub/idun-dev/tasks/trace-feature-08-05-2026/13-sizing-perf.md``
-``~/Documents/GitHub/idun-dev/tasks/trace-feature-08-05-2026/18-postgres-throughput-probe.md``
 
 Fail-open: a failed batch insert is logged via ``logger.exception`` and
 the writer keeps draining. The agent route must never block on a trace
@@ -53,6 +49,7 @@ from idun_agent_standalone.infrastructure.db.models.trace import StandaloneTrace
 
 from ._finalizer import build_trace_rows
 from .exporter import StandaloneSpanExporter
+from .sinks import HttpSink
 
 logger = logging.getLogger(__name__)
 
@@ -121,12 +118,14 @@ class TraceWriter:
         self,
         *,
         exporter: StandaloneSpanExporter,
-        session_factory: async_sessionmaker[Any],
+        session_factory: async_sessionmaker[Any] | None = None,
+        http_sink: HttpSink | None = None,
         max_export_batch_size: int = 512,
         schedule_delay_millis: int = 2000,
     ) -> None:
         self._exporter = exporter
         self._session_factory = session_factory
+        self._http_sink = http_sink
         self._max_batch = max_export_batch_size
         self._schedule_delay = schedule_delay_millis / 1000.0
         self._stop_event: asyncio.Event | None = None
@@ -159,9 +158,7 @@ class TraceWriter:
             except asyncio.CancelledError:
                 pass  # clean cancel — expected shape after .cancel()
             except Exception:
-                logger.exception(
-                    "trace writer task raised during cancel; continuing"
-                )
+                logger.exception("trace writer task raised during cancel; continuing")
         except asyncio.CancelledError:
             pass
         finally:
@@ -215,6 +212,17 @@ class TraceWriter:
             span_rows.append(row)
 
         try:
+            if self._http_sink is not None:
+                await self._http_sink.write(span_rows, trace_rows)
+                return
+            if self._session_factory is None:
+                logger.error(
+                    "trace writer: no http_sink and no session_factory; "
+                    "dropping batch (spans=%d, traces=%d)",
+                    len(span_rows),
+                    len(trace_rows),
+                )
+                return
             async with self._session_factory() as session:
                 bind = session.get_bind()
                 if bind.dialect.name == "postgresql":

--- a/libs/idun_agent_standalone/tests/unit/test_settings.py
+++ b/libs/idun_agent_standalone/tests/unit/test_settings.py
@@ -92,3 +92,42 @@ def test_bind_all_with_password_auth_is_allowed(monkeypatch):
     settings = StandaloneSettings()
     assert settings.host == "0.0.0.0"
     assert settings.auth_mode == AuthMode.PASSWORD
+
+
+def test_manager_telemetry_requires_both_vars(monkeypatch):
+    monkeypatch.setenv("IDUN_MANAGER_HOST", "http://127.0.0.1:8900")
+    monkeypatch.delenv("IDUN_AGENT_API_KEY", raising=False)
+    with pytest.raises(ValidationError) as exc_info:
+        StandaloneSettings()
+    assert "IDUN_AGENT_API_KEY" in str(exc_info.value)
+
+
+def test_manager_telemetry_rejects_key_without_host(monkeypatch):
+    monkeypatch.delenv("IDUN_MANAGER_HOST", raising=False)
+    monkeypatch.setenv("IDUN_AGENT_API_KEY", "k")
+    with pytest.raises(ValidationError):
+        StandaloneSettings()
+
+
+def test_manager_host_requires_scheme(monkeypatch):
+    monkeypatch.setenv("IDUN_MANAGER_HOST", "mgr.internal:8080")
+    monkeypatch.setenv("IDUN_AGENT_API_KEY", "k")
+    with pytest.raises(ValidationError) as exc_info:
+        StandaloneSettings()
+    assert "scheme" in str(exc_info.value)
+
+
+def test_manager_telemetry_accepts_both_with_scheme(monkeypatch):
+    monkeypatch.setenv("IDUN_MANAGER_HOST", "http://127.0.0.1:8900")
+    monkeypatch.setenv("IDUN_AGENT_API_KEY", "k")
+    settings = StandaloneSettings()
+    assert settings.manager_host == "http://127.0.0.1:8900"
+    assert settings.agent_api_key == "k"
+
+
+def test_manager_telemetry_neither_set_is_local(monkeypatch):
+    monkeypatch.delenv("IDUN_MANAGER_HOST", raising=False)
+    monkeypatch.delenv("IDUN_AGENT_API_KEY", raising=False)
+    settings = StandaloneSettings()
+    assert settings.manager_host == ""
+    assert settings.agent_api_key == ""

--- a/libs/idun_agent_standalone/tests/unit/traces/test_serialize.py
+++ b/libs/idun_agent_standalone/tests/unit/traces/test_serialize.py
@@ -1,0 +1,67 @@
+"""Unit tests for the telemetry wire serializer."""
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from idun_agent_standalone.infrastructure.traces._serialize import encode_batch
+
+
+def test_encode_batch_is_json_serializable_and_converts_non_json_types():
+    span = {
+        "started_at": datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
+        "otel_span_id": b"\x01\x02\x03\x04\x05\x06\x07\x08",
+        "otel_trace_id": b"\x11\x12\x13\x14\x15\x16\x17\x18",
+        "parent_span_id": None,
+        "name": "chat",
+        "kind": "LLM",
+        "latency_ms": Decimal("12.5"),
+        "cost_usd": Decimal("0.0001234"),
+        "attributes": {"llm.model_name": "gpt-4o"},
+    }
+    trace = {
+        "started_at": datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
+        "otel_trace_id": bytes(range(0x11, 0x21)),
+        "name": "chat",
+        "models": ["gpt-4o"],
+    }
+
+    body = encode_batch([span], [trace])
+
+    # The whole point: no non-JSON-native types leak through.
+    json.dumps(body)
+
+    assert body["version"] == 1
+
+    s = body["spans"][0]
+    assert s["otel_span_id"] == "0102030405060708"
+    assert s["otel_trace_id"] == "1112131415161718"
+    assert s["parent_span_id"] is None
+    assert s["started_at"] == "2026-06-01T10:00:00+00:00"
+    assert s["latency_ms"] == "12.5"
+    assert s["cost_usd"] == "0.0001234"
+    assert s["name"] == "chat"
+    # Nested JSON-native values pass through untouched.
+    assert s["attributes"] == {"llm.model_name": "gpt-4o"}
+
+    t = body["traces"][0]
+    assert t["otel_trace_id"] == "1112131415161718191a1b1c1d1e1f20"
+    assert t["models"] == ["gpt-4o"]
+
+
+def test_encode_batch_handles_nested_non_json_values():
+    span = {
+        "otel_span_id": b"\x01",
+        "name": "s",
+        "kind": "LLM",
+        "cost_breakdown": {"input": Decimal("0.001"), "output": Decimal("0.002")},
+        "events": [{"name": "e", "ts": datetime(2026, 6, 1, tzinfo=UTC)}],
+    }
+
+    body = encode_batch([span], [])
+
+    json.dumps(body)  # must not raise on nested Decimal / datetime
+
+    s = body["spans"][0]
+    assert s["cost_breakdown"]["input"] == "0.001"
+    assert s["events"][0]["ts"] == "2026-06-01T00:00:00+00:00"

--- a/libs/idun_agent_standalone/tests/unit/traces/test_sinks.py
+++ b/libs/idun_agent_standalone/tests/unit/traces/test_sinks.py
@@ -1,0 +1,75 @@
+"""Unit tests for the telemetry span sinks."""
+
+import json
+
+import httpx
+import pytest
+from idun_agent_standalone.infrastructure.traces.sinks import HttpSink
+
+pytestmark = pytest.mark.asyncio
+
+URL = "https://mgr.test/api/v1/telemetry/collect"
+SPAN = {"otel_span_id": b"\x01\x02", "name": "chat", "kind": "LLM"}
+TRACE = {"otel_trace_id": b"\x11\x12", "name": "chat"}
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def test_http_sink_posts_encoded_batch_with_bearer_auth():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(202)
+
+    client = _client(handler)
+    sink = HttpSink(URL, "key-123", client=client)
+    await sink.write([SPAN], [])
+    await client.aclose()
+
+    assert captured["url"] == URL
+    assert captured["auth"] == "Bearer key-123"
+    assert captured["body"]["version"] == 1
+    assert captured["body"]["spans"][0]["otel_span_id"] == "0102"
+    assert captured["body"]["traces"] == []
+
+
+async def test_http_sink_encodes_both_spans_and_traces():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(202)
+
+    client = _client(handler)
+    sink = HttpSink(URL, "k", client=client)
+    await sink.write([SPAN], [TRACE])
+    await client.aclose()
+
+    assert captured["body"]["spans"][0]["otel_span_id"] == "0102"
+    assert captured["body"]["traces"][0]["otel_trace_id"] == "1112"
+
+
+async def test_http_sink_raises_on_error_status():
+    client = _client(lambda request: httpx.Response(401))
+    sink = HttpSink(URL, "bad-key", client=client)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await sink.write([SPAN], [])
+    await client.aclose()
+
+
+async def test_http_sink_propagates_transport_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    client = _client(handler)
+    sink = HttpSink(URL, "k", client=client)
+
+    with pytest.raises(httpx.ConnectError):
+        await sink.write([SPAN], [])
+    await client.aclose()

--- a/libs/idun_agent_standalone/tests/unit/traces/test_writer.py
+++ b/libs/idun_agent_standalone/tests/unit/traces/test_writer.py
@@ -7,6 +7,7 @@ import json
 from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 import pytest
 from idun_agent_standalone.infrastructure.db.models.span import StandaloneSpanRow
 from idun_agent_standalone.infrastructure.db.models.trace import StandaloneTraceRow
@@ -15,6 +16,7 @@ from idun_agent_standalone.infrastructure.traces import writer as writer_module
 from idun_agent_standalone.infrastructure.traces.exporter import (
     StandaloneSpanExporter,
 )
+from idun_agent_standalone.infrastructure.traces.sinks import HttpSink
 from idun_agent_standalone.infrastructure.traces.writer import TraceWriter
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -492,3 +494,34 @@ async def test_pg_writer_calls_copy_records_to_table_with_correct_columns():
     # Each tuple has the right arity.
     for tup in captured["records"]:
         assert len(tup) == len(SPAN_COPY_COLUMNS)
+
+
+@pytest.mark.asyncio
+async def test_writer_posts_to_http_sink_when_configured():
+    """With an http_sink set, the drained batch is POSTed and the local
+    insert path is bypassed (no session factory provided)."""
+    posted: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        posted["body"] = json.loads(request.content)
+        return httpx.Response(202)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sink = HttpSink("https://mgr.test/collect", "k", client=client)
+    exporter = StandaloneSpanExporter(max_queue_size=10)
+    writer = TraceWriter(
+        exporter=exporter,
+        http_sink=sink,
+        max_export_batch_size=10,
+        schedule_delay_millis=50,
+    )
+
+    exporter.export(
+        [_fake_span("agent.run", span_id=0x1, trace_id=0xABC, parent_span_id=None)]
+    )
+    await writer._drain_once()
+    await client.aclose()
+
+    assert len(posted["body"]["spans"]) == 1
+    # Root span present → a trace row is finalized and POSTed too.
+    assert len(posted["body"]["traces"]) == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,15 @@ dependencies = [
     "idun-agent-standalone",
 ]
 
+[project.optional-dependencies]
+# Re-export idun-agent-engine's opt-in [guardrails] extra at the workspace root.
+# uv's `--extra` / `--all-extras` apply to the ROOT project's extras, not to
+# workspace members', so without this a root-level `uv sync` cannot reach the
+# engine's guardrails extra and the `guardrails` CLI never lands in .venv/bin
+# (the cause of the e2e "Failed to spawn: guardrails" step). Kept opt-in so a
+# plain `uv sync` stays lean.
+guardrails = ["idun-agent-engine[guardrails]"]
+
 [dependency-groups]
 dev = [
     "ruff>=0.6.5,<0.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,20 +43,12 @@ members = [
 idun-agent-engine = { workspace = true }
 idun-agent-schema = { workspace = true }
 idun-agent-standalone = { workspace = true }
-# Temporary workaround: the PyPI ``guardrails-ai`` project was quarantined for
-# a security incident, so the published 0.9.2 wheel is no longer resolvable.
-# Point uv at the upstream git commit so ``uv lock`` / ``uv sync`` succeed for
-# the optional ``[guardrails]`` extra of idun-agent-engine. Source overrides
-# apply only to local resolution — published engine wheels still reference
-# ``guardrails-ai==0.9.2`` on PyPI, so end-users are unaffected once upstream
-# restores the project. Remove this entry when that happens.
-#
-# ``rev`` is the peeled commit object of the annotated ``v0.9.2`` tag, pinned
-# rather than the tag name itself — tags can be moved or rewritten upstream,
-# commit SHAs cannot, so this keeps resolution reproducible and reduces
-# supply-chain risk. To refresh: ``git ls-remote --tags
-# https://github.com/guardrails-ai/guardrails | grep 'v0.9.2\^{}'``.
-guardrails-ai = { git = "https://github.com/guardrails-ai/guardrails", rev = "ee6999d84d3becdb3dbf5862ae7b893130ddacb8" }
+# NOTE: the temporary ``guardrails-ai`` git-source override (added in #642 while
+# the PyPI project was quarantined for a security incident) has been removed now
+# that PyPI restored the project — ``guardrails-ai==0.9.2`` resolves from PyPI
+# again, and its wheel ships the ``guardrails`` console script the git build
+# omitted. ``guardrails-ai`` stays in the optional ``[guardrails]`` extra of
+# idun-agent-engine. Closes #643.
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -1953,6 +1953,11 @@ dependencies = [
     { name = "idun-agent-standalone" },
 ]
 
+[package.optional-dependencies]
+guardrails = [
+    { name = "idun-agent-engine", extra = ["guardrails"] },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "langchain-openai" },
@@ -1970,9 +1975,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "idun-agent-engine", editable = "libs/idun_agent_engine" },
+    { name = "idun-agent-engine", extras = ["guardrails"], marker = "extra == 'guardrails'", editable = "libs/idun_agent_engine" },
     { name = "idun-agent-schema", editable = "libs/idun_agent_schema" },
     { name = "idun-agent-standalone", editable = "libs/idun_agent_standalone" },
 ]
+provides-extras = ["guardrails"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1525,7 +1525,7 @@ wheels = [
 [[package]]
 name = "guardrails-ai"
 version = "0.9.2"
-source = { git = "https://github.com/guardrails-ai/guardrails?rev=ee6999d84d3becdb3dbf5862ae7b893130ddacb8#ee6999d84d3becdb3dbf5862ae7b893130ddacb8" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "diff-match-patch" },
@@ -1554,6 +1554,10 @@ dependencies = [
     { name = "tiktoken" },
     { name = "typer" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/62/2b28a8f7f9fbea06cdb76885a44ec0a5e0bad758b53d317c7039a5dfd164/guardrails_ai-0.9.2.tar.gz", hash = "sha256:4c136b7ef9ef1562098cbe91338f71fe91824cbf1393f3e5b3a0d8a393f55851", size = 170657, upload-time = "2026-03-16T18:22:00.903Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/67/b1db74bf7bd6cbbdd5e6f37880ece08e9d6a785cf955c8ba652ed43ec880/guardrails_ai-0.9.2-py3-none-any.whl", hash = "sha256:530758c544383c23f6a755670673988a5446c90596102d629cc89311a3616fb7", size = 237653, upload-time = "2026-03-16T18:22:02.116Z" },
 ]
 
 [[package]]
@@ -1813,7 +1817,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0,<=0.134.0" },
     { name = "google-adk", specifier = ">=1.19.0,<2.0.0" },
     { name = "google-cloud-logging", specifier = ">=3.10.0,<4.0.0" },
-    { name = "guardrails-ai", marker = "extra == 'guardrails'", git = "https://github.com/guardrails-ai/guardrails?rev=ee6999d84d3becdb3dbf5862ae7b893130ddacb8" },
+    { name = "guardrails-ai", marker = "extra == 'guardrails'", specifier = "==0.9.2" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "httpx-sse", specifier = ">=0.4.0,<1.0.0" },
     { name = "idun-agent-schema", editable = "libs/idun_agent_schema" },


### PR DESCRIPTION
Three stacked commits on top of `develop` (each was its own branch; this branch contains all of them):

## 1. Standalone telemetry sink (`2668d61f`)
Standalone ships traces to the manager over an HTTP sink, so enrolled agents report telemetry centrally.

## 2. Async config-from-API + hardening (`71f3b997`)
`with_config_from_api` is now async and hardened (proper await path, robust error handling), supporting the enrolled-mode boot flow.

## 3. Reload-concurrency fix (`ef7a32f2`)
Fixes two HIGH-severity bugs in `/reload` under concurrency:
- **Deadlock/wedge** when reloads overlap.
- **Mid-run `'NoneType' object is not a mapping` crash** when a run was in flight during a swap.

Approach: serialize reloads with an `asyncio.Lock`, **build the new agent before tearing down the old one** and swap atomically, and **drain in-flight runs** before closing the previous agent. Covered by 6 TDD tests in `tests/unit/server/test_reload_concurrency.py`; also exercised via a sandboxed engine + manager QA pass.

## Notes
- Linear stack: `telemetry-sink → enrolled async config → reload fix`. Merging this branch brings all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)