### PR TITLE
chore(release): 0.6.3 prep — version bumps + CHANGELOGs

### DIFF
--- a/libs/idun_agent_engine/CHANGELOG.md
+++ b/libs/idun_agent_engine/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to `idun-agent-engine` are documented here. This project fol
 
 _No unreleased changes yet._
 
+## 0.6.3 — 2026-06-08
+
+Patch release. Hardens the `/reload` pipeline under concurrency and makes config-from-API async (#698).
+
+### Fixed
+
+- **Reload concurrency.** Reloads now serialize on a per-app `asyncio.Lock`, build the new agent before tearing down the old one, and swap `app.state.agent` atomically — fixing a deadlock when reloads overlapped and a mid-run `'NoneType' object is not a mapping` crash when a run was in flight during a swap. In-flight streaming runs are drained before the old agent is closed, and the in-flight count is now taken at stream construction rather than the body generator's first iteration, so a concurrent reload can no longer close an agent out from under a run whose stream has not started yet (#698).
+
+### Changed
+
+- **`with_config_from_api` is now async** and built on `httpx`, with trailing-slash normalisation and consistent `ValueError` wrapping, to support the enrolled-mode boot flow (#698).
+
 ## 0.6.2 — 2026-05-21
 
 Patch release. No engine code changes. Ships the bundled `idun-agent-standalone` UI at 0.6.2, which fixes a cluster of SPA-navigation bugs in the admin surface under Next.js 15 `output: "export"` (AuthGuard `?next=` preservation, post-login hard-nav, trace detail soft-nav resolution, sidebar Traces + post-delete hard-nav). See `libs/idun_agent_standalone/CHANGELOG.md` for the full list (#682).

--- a/libs/idun_agent_engine/pyproject.toml
+++ b/libs/idun_agent_engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-agent-engine"
-version = "0.6.2"
+version = "0.6.3"
 description = "Python SDK and runtime to serve AI agents with FastAPI, LangGraph, and observability."
 authors = [{ name = "Idun Group", email = "h.geoffrey@idun-group.com" }]
 requires-python = ">=3.12,<3.13"

--- a/libs/idun_agent_engine/src/idun_agent_engine/_version.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/_version.py
@@ -1,3 +1,3 @@
 """Version information for Idun Agent Engine."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/libs/idun_agent_schema/pyproject.toml
+++ b/libs/idun_agent_schema/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-agent-schema"
-version = "0.6.2"
+version = "0.6.3"
 description = "Centralized Pydantic schema library for Idun Agent Engine"
 authors = [{ name = "Idun Group", email = "h.geoffrey@idun-group.com" }]
 license = "GPL-3.0-only"

--- a/libs/idun_agent_schema/src/idun_agent_schema/__init__.py
+++ b/libs/idun_agent_schema/src/idun_agent_schema/__init__.py
@@ -6,4 +6,4 @@ Public namespaces:
 - idun_agent_schema.shared: Shared cross-cutting schemas
 """
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/libs/idun_agent_standalone/CHANGELOG.md
+++ b/libs/idun_agent_standalone/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to `idun-agent-standalone` are documented here. This package
 
 _No unreleased changes yet._
 
+## 0.6.3 — 2026-06-08
+
+Patch release. Adds a central telemetry sink for enrolled-mode deployments (#698).
+
+### Added
+
+- **HTTP telemetry sink.** When `IDUN_MANAGER_HOST` and `IDUN_AGENT_API_KEY` are both set, the trace writer ships span/trace batches to the manager's `/collect` endpoint (Bearer auth) instead of the local DB, so enrolled agents report telemetry centrally. Bootstrap selects between local-DB and manager-HTTP modes from settings, and the retention scheduler is skipped in manager mode (#698).
+
 ## 0.6.2 — 2026-05-21
 
 Patch release. Fixes a cluster of SPA-navigation bugs in the standalone admin UI under Next.js 15 `output: "export"` + FastAPI SPA-rewrite, where soft client-side navigation and cookie handling do not behave as they would in a standard server-rendered Next.js app.

--- a/libs/idun_agent_standalone/pyproject.toml
+++ b/libs/idun_agent_standalone/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "idun-agent-standalone"
-version = "0.6.2"
+version = "0.6.3"
 description = "Single-process, single-tenant Idun agent with embedded UI, admin panel, and traces viewer."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/libs/idun_agent_standalone/src/idun_agent_standalone/__init__.py
+++ b/libs/idun_agent_standalone/src/idun_agent_standalone/__init__.py
@@ -1,3 +1,3 @@
 """idun-agent-standalone — single-process, single-tenant Idun agent."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "idun-engine"
-version = "0.6.2"
+version = "0.6.3"
 description = "Idun Engine"
 authors = [{ name = "Idun Group", email = "h.geoffrey@idun-group.com" }]
 requires-python = ">=3.12,<3.13"

--- a/services/idun_agent_standalone_ui/package.json
+++ b/services/idun_agent_standalone_ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idun-agent-standalone-ui",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3100",

--- a/uv.lock
+++ b/uv.lock
@@ -1713,7 +1713,7 @@ wheels = [
 
 [[package]]
 name = "idun-agent-engine"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "libs/idun_agent_engine" }
 dependencies = [
     { name = "ag-ui-adk" },
@@ -1877,7 +1877,7 @@ dev = [
 
 [[package]]
 name = "idun-agent-schema"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "libs/idun_agent_schema" }
 dependencies = [
     { name = "jinja2" },
@@ -1894,7 +1894,7 @@ requires-dist = [
 
 [[package]]
 name = "idun-agent-standalone"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "libs/idun_agent_standalone" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1945,7 +1945,7 @@ requires-dist = [
 
 [[package]]
 name = "idun-engine"
-version = "0.6.2"
+version = "0.6.3"
 source = { virtual = "." }
 dependencies = [
     { name = "idun-agent-engine" },


### PR DESCRIPTION
Prepare **0.6.3**. Bumps `idun-engine`, `idun-agent-engine`, `idun-agent-schema`, `idun-agent-standalone`, and `idun-agent-standalone-ui` from `0.6.2 → 0.6.3` (coordinated across all components), regenerates `uv.lock`, and adds CHANGELOG entries.

## What ships in 0.6.3 (#698)
- **Engine — reload-concurrency hardening:** serialized reloads, build-before-teardown atomic swap, drain in-flight runs before closing the old agent, and in-flight counting at stream construction to close the residual reload race.
- **Engine — `with_config_from_api` async** (httpx) for the enrolled-mode boot flow.
- **Standalone — HTTP telemetry sink:** enrolled-mode agents POST span/trace batches to the manager `/collect` endpoint; bootstrap selects local-DB vs manager-HTTP mode.

## Files
- Version strings: 4× `pyproject.toml` + `_version.py` / `__init__.py` for engine/schema/standalone + UI `package.json`.
- `uv.lock` regenerated.
- `CHANGELOG.md` for engine + standalone.

Once merged into develop, these changes flow into the v0.6.3 release PR (#700, develop → main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)