### PR TITLE
"fix(engine): agent loaders skip sys.path setup, breaking package-relative imports"

### DIFF
--- a/libs/idun_agent_engine/CLAUDE.md
+++ b/libs/idun_agent_engine/CLAUDE.md
@@ -19,6 +19,7 @@ idun_agent_engine/
 │   └── server_runner   # run_server() → uvicorn wrapper
 ├── agent/              # Framework adapters (all implement BaseAgent ABC)
 │   ├── base            # BaseAgent protocol: initialize(), invoke(), stream(), copilotkit_agent_instance
+│   ├── loader_utils    # ensure_import_root(): puts a file-path agent's package root on sys.path before exec (shared by both loaders)
 │   ├── langgraph/      # Primary adapter. Full streaming (AG-UI events). Expects uncompiled StateGraph.
 │   └── adk/            # Google ADK adapter. Mature. Session + memory services. AG-UI streaming via /agent/run (ADKAGUIAgent).
 ├── server/             # FastAPI layer
@@ -192,7 +193,7 @@ All adapters implement `discover_capabilities()` (returns `AgentCapabilities`) a
 
 ### LangGraph: Key Details
 
-- **`graph_definition`**: Format `path/to/file.py:variable_name`. Tries file path first, falls back to Python module import.
+- **`graph_definition`**: Format `path/to/file.py:variable_name`. Tries file path first, falls back to Python module import. When loaded by file path, the agent file's package/project root is placed on `sys.path` first (via `agent/loader_utils.py`), so absolute package-relative imports like `from app.config import config` resolve.
 - **Checkpointers**: `InMemorySaver`, `AsyncSqliteSaver`, `AsyncPostgresSaver` — configured via YAML.
 - **Streaming**: Maps LangGraph `astream_events(v2)` to AG-UI events (RunStarted, StepStarted, TextMessageStart/Content/End, ToolCallStart/Args/End, ThinkingStart/End, RunFinished).
 - **Capability discovery (input/output schemas)**: the adapter reads `graph.input_schema` and `graph.output_schema` from the compiled `StateGraph` to populate `AgentCapabilities.input.mode` / `output.mode`. Operators are encouraged to declare these explicitly:

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/adk/adk.py
@@ -444,7 +444,10 @@ class AdkAgent(agent_base.BaseAgent):
         try:
             from pathlib import Path
 
+            from idun_agent_engine.agent.loader_utils import ensure_import_root
+
             resolved_path = Path(module_path).resolve()
+            ensure_import_root(resolved_path)
             spec = importlib.util.spec_from_file_location(
                 agent_variable_name, str(resolved_path)
             )

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/langgraph/langgraph.py
@@ -470,11 +470,14 @@ class LanggraphAgent(agent_base.BaseAgent):
         try:
             from pathlib import Path
 
+            from idun_agent_engine.agent.loader_utils import ensure_import_root
+
             resolved_path = Path(module_path).resolve()
             # If the file doesn't exist, it might be a python module path
             if not resolved_path.exists():
                 raise FileNotFoundError
 
+            ensure_import_root(resolved_path)
             spec = importlib.util.spec_from_file_location(
                 graph_variable_name, str(resolved_path)
             )

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/loader_utils.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/loader_utils.py
@@ -19,6 +19,45 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 _INIT_FILE = "__init__.py"
+# Files that mark the root of a Python project. Used to locate the import root
+# for implicit namespace packages (PEP 420), which have no __init__.py chain.
+_ROOT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg")
+
+
+def _package_root(file_dir: Path) -> Path:
+    """Return the top of the ``__init__.py`` (regular-package) chain.
+
+    Walks up while each directory is a regular package. For a file at
+    ``.../myproject/app/agent.py`` where ``app`` is a regular package, returns
+    ``.../myproject``. When ``file_dir`` is not itself a regular package,
+    returns ``file_dir`` unchanged.
+    """
+    root = file_dir
+    while (root / _INIT_FILE).exists():
+        root = root.parent
+    return root
+
+
+def _marker_root(start: Path) -> Path | None:
+    """Return the nearest ancestor (inclusive) holding a project-root marker."""
+    for directory in (start, *start.parents):
+        if any((directory / marker).exists() for marker in _ROOT_MARKERS):
+            return directory
+    return None
+
+
+def _prepend_sys_path(path_str: str) -> None:
+    """Make ``path_str`` the first entry of ``sys.path``.
+
+    If the entry already exists elsewhere it is moved to the front, so the
+    agent's own project root wins over any earlier same-named package. Idempotent
+    when the entry is already at ``sys.path[0]``.
+    """
+    if sys.path and sys.path[0] == path_str:
+        return
+    if path_str in sys.path:
+        sys.path.remove(path_str)
+    sys.path.insert(0, path_str)
 
 
 def ensure_import_root(agent_file: Path) -> str:
@@ -27,36 +66,52 @@ def ensure_import_root(agent_file: Path) -> str:
     ``importlib.util.spec_from_file_location`` loads a single file without
     adding its project root to ``sys.path``, so absolute imports the file makes
     relative to its project root (``from app.config import config``) raise
-    ``ModuleNotFoundError``. This helper resolves that root and inserts it at
-    ``sys.path[0]`` so those imports resolve as they would when the project is
-    run normally.
+    ``ModuleNotFoundError``. This helper resolves that root and moves it to the
+    front of ``sys.path`` so those imports resolve as they would when the
+    project is run normally.
 
     Resolution:
-        * Walk up the ``__init__.py`` chain from the file's directory to find
-          the top of the enclosing package; the root is that package's parent.
-          For ``.../myproject/app/agent.py`` where ``app`` is a package, the
-          root is ``.../myproject`` — making ``from app.config import ...`` work.
-        * If the file is not inside a package (its directory has no
-          ``__init__.py``), the file's own directory is used, so flat-layout
-          sibling imports (``from config import ...``) resolve.
+        * **Regular package** — walk up the ``__init__.py`` chain from the
+          file's directory; the root is the top package's parent. For
+          ``.../myproject/app/agent.py`` the root is ``.../myproject``.
+        * **Namespace package / flat script** — when the file's directory has
+          no ``__init__.py``, its own directory is used (so flat-layout sibling
+          imports resolve), and, if a project-root marker
+          (``pyproject.toml`` / ``setup.py`` / ``setup.cfg``) is found in an
+          ancestor, that project root is added as well — this is what makes an
+          implicit namespace package's ``from app.config import config`` resolve.
 
-    The insert is idempotent: an entry already on ``sys.path`` is not added
-    again, so this is safe to call repeatedly under hot-reload.
+    Every root placed on ``sys.path`` is moved to the front if already present,
+    so it takes precedence over an earlier same-named package. The operation is
+    idempotent, so it is safe to call repeatedly under hot-reload.
 
     Args:
         agent_file: Filesystem path to the user's agent module. Callers should
             pass an already-resolved (absolute) path.
 
     Returns:
-        The directory added to (or already present on) ``sys.path``.
+        The primary root placed at ``sys.path[0]`` (the package/flat-script
+        root).
     """
-    root = agent_file.parent
-    while (root / _INIT_FILE).exists():
-        root = root.parent
+    file_dir = agent_file.parent
+    pkg_root = _package_root(file_dir)
 
-    root_str = str(root)
-    if root_str not in sys.path:
-        sys.path.insert(0, root_str)
-        logger.debug("Added agent project root to sys.path: %s", root_str)
+    if pkg_root != file_dir:
+        # Regular package: its parent is the one correct import root.
+        roots = [str(pkg_root)]
+    else:
+        # No __init__.py at the agent's directory: it is either a flat script
+        # (needs its own directory) or a namespace-package member (needs the
+        # project root). Add both so either import style resolves; keep the
+        # file's own directory at highest precedence.
+        roots = [str(file_dir)]
+        marker_root = _marker_root(file_dir)
+        if marker_root is not None and marker_root != file_dir:
+            roots.append(str(marker_root))
 
-    return root_str
+    # Prepend in reverse so roots[0] ends up at sys.path[0] (highest precedence).
+    for path_str in reversed(roots):
+        _prepend_sys_path(path_str)
+
+    logger.debug("Ensured agent import roots on sys.path: %s", roots)
+    return roots[0]

--- a/libs/idun_agent_engine/src/idun_agent_engine/agent/loader_utils.py
+++ b/libs/idun_agent_engine/src/idun_agent_engine/agent/loader_utils.py
@@ -1,0 +1,62 @@
+"""Shared helpers for dynamically loading user agent modules from a file path.
+
+Both the LangGraph and ADK adapters import the user's agent file directly via
+``importlib.util.spec_from_file_location``. That call bypasses Python's normal
+import machinery and never puts the agent's project root on ``sys.path`` — so an
+agent file that uses absolute, package-relative imports (e.g.
+``from app.config import config``) fails to boot with ``ModuleNotFoundError``.
+
+``ensure_import_root`` restores the missing behaviour by placing the agent
+file's package/project root on ``sys.path`` before the module is executed.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_INIT_FILE = "__init__.py"
+
+
+def ensure_import_root(agent_file: Path) -> str:
+    """Ensure the package/project root of ``agent_file`` is importable.
+
+    ``importlib.util.spec_from_file_location`` loads a single file without
+    adding its project root to ``sys.path``, so absolute imports the file makes
+    relative to its project root (``from app.config import config``) raise
+    ``ModuleNotFoundError``. This helper resolves that root and inserts it at
+    ``sys.path[0]`` so those imports resolve as they would when the project is
+    run normally.
+
+    Resolution:
+        * Walk up the ``__init__.py`` chain from the file's directory to find
+          the top of the enclosing package; the root is that package's parent.
+          For ``.../myproject/app/agent.py`` where ``app`` is a package, the
+          root is ``.../myproject`` — making ``from app.config import ...`` work.
+        * If the file is not inside a package (its directory has no
+          ``__init__.py``), the file's own directory is used, so flat-layout
+          sibling imports (``from config import ...``) resolve.
+
+    The insert is idempotent: an entry already on ``sys.path`` is not added
+    again, so this is safe to call repeatedly under hot-reload.
+
+    Args:
+        agent_file: Filesystem path to the user's agent module. Callers should
+            pass an already-resolved (absolute) path.
+
+    Returns:
+        The directory added to (or already present on) ``sys.path``.
+    """
+    root = agent_file.parent
+    while (root / _INIT_FILE).exists():
+        root = root.parent
+
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+        logger.debug("Added agent project root to sys.path: %s", root_str)
+
+    return root_str

--- a/libs/idun_agent_engine/tests/unit/agent/test_loader_sys_path.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_loader_sys_path.py
@@ -98,6 +98,56 @@ def test_ensure_import_root_is_idempotent(tmp_path, clean_import_state):
     assert sys.path.count(str(tmp_path.resolve())) == 1
 
 
+def test_ensure_import_root_moves_existing_root_to_front(tmp_path, clean_import_state):
+    """A root already on sys.path but behind another entry is moved to index 0.
+
+    Regression for the precedence gap: without moving it, an earlier same-named
+    package would shadow the agent's own project.
+    """
+    from idun_agent_engine.agent.loader_utils import ensure_import_root
+
+    pkg_dir = _write_package_project(tmp_path, "myapp")
+    agent_file = pkg_dir / "agent.py"
+    agent_file.write_text("x = 1\n")
+
+    # Simulate the root sitting behind a decoy entry at index 0.
+    root_str = str(tmp_path.resolve())
+    sys.path.insert(0, "/decoy/earlier/entry")
+    sys.path.append(root_str)
+
+    ensure_import_root(agent_file.resolve())
+
+    assert sys.path[0] == root_str
+    assert sys.path.count(root_str) == 1
+
+
+def test_ensure_import_root_namespace_package_uses_marker_root(
+    tmp_path, clean_import_state
+):
+    """An implicit namespace package (no __init__.py) resolves via a project marker.
+
+    Regression for the namespace-package gap: the package's parent (the project
+    root holding pyproject.toml) must land on sys.path so `from app.config
+    import ...` resolves.
+    """
+    import importlib
+
+    from idun_agent_engine.agent.loader_utils import ensure_import_root
+
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+    ns_pkg = tmp_path / "app"  # NOTE: no __init__.py -> namespace package
+    ns_pkg.mkdir()
+    (ns_pkg / "config.py").write_text("SETTING = 'namespace-ok'\n")
+    agent_file = ns_pkg / "agent.py"
+    agent_file.write_text("x = 1\n")
+
+    ensure_import_root(agent_file.resolve())
+
+    assert str(tmp_path.resolve()) in sys.path
+    # The parent-on-path is what makes the package-relative import resolve.
+    mod = importlib.import_module("app.config")
+    assert mod.SETTING == "namespace-ok"
+
 
 # LangGraph loader — the reported regression
 
@@ -145,9 +195,7 @@ def test_langgraph_loader_raises_clear_error_without_fix(tmp_path, clean_import_
         loader._load_graph_builder(f"{agent_file.resolve()}:graph")
 
 
-
 # ADK loader
-
 
 
 def test_adk_loader_resolves_package_relative_import(tmp_path, clean_import_state):
@@ -175,9 +223,7 @@ def test_adk_loader_resolves_package_relative_import(tmp_path, clean_import_stat
     assert agent_instance.name == "mock"
 
 
-
 # Full-boot reproduction of issue #686
-
 
 
 @pytest.mark.asyncio

--- a/libs/idun_agent_engine/tests/unit/agent/test_loader_sys_path.py
+++ b/libs/idun_agent_engine/tests/unit/agent/test_loader_sys_path.py
@@ -1,0 +1,228 @@
+"""Regression tests for agent-loader sys.path setup (issue #686).
+
+Both the LangGraph and ADK dynamic loaders import the user's agent file via
+``importlib.util.spec_from_file_location``, which never adds the agent's
+project root to ``sys.path``. Agent files using absolute, package-relative
+imports (e.g. ``from myapp.config import config``) therefore failed to boot
+with ``ModuleNotFoundError``. These tests pin the fixed behaviour.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def clean_import_state():
+    """Snapshot and restore sys.path / sys.modules around a test.
+
+    Loading an agent file inserts its project root onto sys.path and imports
+    the user's package into sys.modules. Restore both so tests don't leak.
+    """
+    saved_path = list(sys.path)
+    saved_modules = set(sys.modules)
+    try:
+        yield
+    finally:
+        sys.path[:] = saved_path
+        for name in set(sys.modules) - saved_modules:
+            del sys.modules[name]
+
+
+def _write_package_project(root: Path, package: str) -> Path:
+    """Create ``root/<package>/{__init__,config}.py`` and return the package dir."""
+    pkg_dir = root / package
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "config.py").write_text("SETTING = 'from-package-relative-import'\n")
+    return pkg_dir
+
+
+# ensure_import_root unit behaviour
+
+
+def test_ensure_import_root_uses_package_parent(tmp_path, clean_import_state):
+    """A file inside a package resolves to the package's parent directory."""
+    from idun_agent_engine.agent.loader_utils import ensure_import_root
+
+    pkg_dir = _write_package_project(tmp_path, "myapp")
+    agent_file = pkg_dir / "agent.py"
+    agent_file.write_text("x = 1\n")
+
+    root = ensure_import_root(agent_file.resolve())
+
+    assert Path(root) == tmp_path.resolve()
+    assert str(tmp_path.resolve()) == sys.path[0]
+
+
+def test_ensure_import_root_walks_nested_packages(tmp_path, clean_import_state):
+    """The walk climbs the full __init__.py chain, not just one level."""
+    from idun_agent_engine.agent.loader_utils import ensure_import_root
+
+    outer = tmp_path / "pkg"
+    inner = outer / "sub"
+    inner.mkdir(parents=True)
+    (outer / "__init__.py").write_text("")
+    (inner / "__init__.py").write_text("")
+    agent_file = inner / "agent.py"
+    agent_file.write_text("x = 1\n")
+
+    root = ensure_import_root(agent_file.resolve())
+
+    assert Path(root) == tmp_path.resolve()
+
+
+def test_ensure_import_root_flat_layout_uses_file_dir(tmp_path, clean_import_state):
+    """A file not inside a package resolves to its own directory."""
+    from idun_agent_engine.agent.loader_utils import ensure_import_root
+
+    agent_file = tmp_path / "agent.py"
+    agent_file.write_text("x = 1\n")
+
+    root = ensure_import_root(agent_file.resolve())
+
+    assert Path(root) == tmp_path.resolve()
+
+
+def test_ensure_import_root_is_idempotent(tmp_path, clean_import_state):
+    """Repeated calls (hot-reload) never add duplicate sys.path entries."""
+    from idun_agent_engine.agent.loader_utils import ensure_import_root
+
+    agent_file = tmp_path / "agent.py"
+    agent_file.write_text("x = 1\n")
+
+    ensure_import_root(agent_file.resolve())
+    ensure_import_root(agent_file.resolve())
+
+    assert sys.path.count(str(tmp_path.resolve())) == 1
+
+
+
+# LangGraph loader — the reported regression
+
+
+def test_langgraph_loader_resolves_package_relative_import(
+    tmp_path, clean_import_state
+):
+    from idun_agent_engine.agent.langgraph.langgraph import LanggraphAgent
+
+    pkg_dir = _write_package_project(tmp_path, "lg_app")
+    agent_file = pkg_dir / "agent.py"
+    agent_file.write_text(
+        "from lg_app.config import SETTING\n"
+        "from langgraph.graph import END, StateGraph\n"
+        "from typing import TypedDict\n"
+        "\n"
+        "class State(TypedDict):\n"
+        "    value: str\n"
+        "\n"
+        "def node(state: State):\n"
+        "    return {'value': SETTING}\n"
+        "\n"
+        "builder = StateGraph(State)\n"
+        "builder.add_node('n', node)\n"
+        "builder.set_entry_point('n')\n"
+        "builder.add_edge('n', END)\n"
+        "graph = builder\n"
+    )
+
+    loader = LanggraphAgent()
+    graph_builder = loader._load_graph_builder(f"{agent_file.resolve()}:graph")
+
+    assert graph_builder is not None
+
+
+def test_langgraph_loader_raises_clear_error_without_fix(tmp_path, clean_import_state):
+    """Sanity check: a genuinely missing import still surfaces as an error."""
+    from idun_agent_engine.agent.langgraph.langgraph import LanggraphAgent
+
+    agent_file = tmp_path / "agent.py"
+    agent_file.write_text("import a_module_that_does_not_exist_anywhere\n")
+
+    loader = LanggraphAgent()
+    with pytest.raises(ValueError):
+        loader._load_graph_builder(f"{agent_file.resolve()}:graph")
+
+
+
+# ADK loader
+
+
+
+def test_adk_loader_resolves_package_relative_import(tmp_path, clean_import_state):
+    from idun_agent_engine.agent.adk.adk import AdkAgent
+
+    pkg_dir = _write_package_project(tmp_path, "adk_app")
+    agent_file = pkg_dir / "agent.py"
+    agent_file.write_text(
+        "from adk_app.config import SETTING\n"
+        "from google.adk.agents import BaseAgent\n"
+        "from google.adk.events import Event\n"
+        "from google.genai.types import Content, Part\n"
+        "\n"
+        "class Mock(BaseAgent):\n"
+        "    async def _run_async_impl(self, ctx):\n"
+        "        yield Event(author='mock', content=Content(parts=[Part(text=SETTING)]))\n"
+        "\n"
+        "root_agent = Mock(name='mock', description='pkg-relative import test')\n"
+    )
+
+    loader = AdkAgent()
+    agent_instance = loader._load_agent(f"{agent_file.resolve()}:root_agent")
+
+    assert agent_instance is not None
+    assert agent_instance.name == "mock"
+
+
+
+# Full-boot reproduction of issue #686
+
+
+
+@pytest.mark.asyncio
+async def test_issue_686_full_boot_relative_path_from_cwd(
+    tmp_path, monkeypatch, clean_import_state
+):
+    """Faithful repro of #686: a RELATIVE graph_definition pointing into an
+    ``app`` package, booted through the real ConfigBuilder path from the
+    project cwd (as ``idun init`` would). Before the fix this raised
+    ``No module named 'app'``."""
+    from idun_agent_engine.core.config_builder import ConfigBuilder
+
+    pkg_dir = _write_package_project(tmp_path, "app")
+    (pkg_dir / "agent.py").write_text(
+        "from app.config import SETTING  # the exact failing import from #686\n"
+        "from langgraph.graph import END, StateGraph\n"
+        "from typing import TypedDict\n"
+        "\n"
+        "class State(TypedDict):\n"
+        "    value: str\n"
+        "\n"
+        "def node(state):\n"
+        "    return {'value': SETTING}\n"
+        "\n"
+        "builder = StateGraph(State)\n"
+        "builder.add_node('n', node)\n"
+        "builder.set_entry_point('n')\n"
+        "builder.add_edge('n', END)\n"
+        "root_agent = builder\n"
+    )
+
+    # Run from the project root, exactly like the reproduction.
+    monkeypatch.chdir(tmp_path)
+
+    config = {
+        "agent": {
+            "type": "LANGGRAPH",
+            "config": {
+                "name": "issue686",
+                "graph_definition": "app/agent.py:root_agent",  # relative
+            },
+        },
+    }
+    engine_config = ConfigBuilder.from_dict(config).build()
+    agent = await ConfigBuilder.initialize_agent_from_config(engine_config)
+
+    assert agent is not None
+    assert agent.name == "issue686"


### PR DESCRIPTION
Fixes #686.

Both dynamic agent loaders import the user's agent file with importlib.util.spec_from_file_location:

- agent/adk/adk.py → _load_agent
- agent/langgraph/langgraph.py → _load_graph_builder

That call executes the file but never puts its project root on sys.path. An agent file that uses an absolute, package-relative import — the common from app.config import config pattern — therefore fails to boot with ModuleNotFoundError: No module named 'app'. Running from the project cwd doesn't help, because idun is an installed console script and Python puts the script's own directory (the venv bin/) on sys.path[0], not the shell cwd.

Fix

New shared helper agent/loader_utils.py::ensure_import_root(agent_file):

- Walks up the __init__.py chain from the agent file to the top of its enclosing package and inserts that package's parent on sys.path[0] (so from app.config import ... resolves for a file at app/agent.py).
- If the file isn't in a package, uses its own directory, so flat-layout sibling imports still work.
- The insert is idempotent — safe to call repeatedly under hot-reload.

Both loaders call it right before building the spec. Deriving the root from the agent file (rather than from config.yaml's directory) means it works identically for YAML boot and programmatic ConfigBuilder.from_dict(...) callers, with no new config plumbing.

Why this strategy

Of the directions listed in the issue:

- config.yaml-dir would need a new parameter threaded through ConfigBuilder → initialize_agent_from_config → initialize → _load_*, and still wouldn't help from_dict callers who never supply a path.
- explicit project_root config field pushes the burden onto every user.
- The package-root walk is self-contained and matches how Python resolves the project when run normally.

Scope / limitation

This fixes absolute package-relative imports (from app.config import config), which is what #686 reports. It does not enable explicit-relative imports inside the agent file (from .config import config) — spec_from_file_location gives the module an empty __package__. That's a separate case the issue doesn't cover; happy to follow up if maintainers want it.

Tests

New tests/unit/agent/test_loader_sys_path.py (8 tests):

- ensure_import_root unit behaviour: package-parent, nested-package walk, flat-layout fallback, idempotency.
- LangGraph and ADK loaders each resolve a real package-relative import.
- A sanity test that a genuinely missing import still raises.
- Full-boot repro of #686: a relative graph_definition into an app package, booted through the real ConfigBuilder path from the project cwd.

Verified the tests catch the bug: reverting only the two loaders makes the loader/full-boot tests fail with the issue's No module named 'app', while the helper unit tests stay green.

Docs

Per the CLAUDE.md PR-scope rule (new module added): updated libs/idun_agent_engine/CLAUDE.md — added loader_utils to the module map and a note on the graph_definition behaviour.

Checks

- uv run pytest libs/idun_agent_engine/tests/unit/agent -q — passing
- ruff check / ruff format --check — clean
- mypy on the new helper — Success: no issues found
